### PR TITLE
Button colors <select> element space

### DIFF
--- a/includes/metabox.php
+++ b/includes/metabox.php
@@ -116,7 +116,7 @@ function edd_render_button_color($post_id) {
 				foreach($colors as $key => $color) {
 					echo '<option value="' . $key . '" ' . checked($key, $button_color, false) . '>' . $color . '</option>';
 				}
-			echo '</select> ';
+			echo '</select>&nbsp;';
 			echo __('Choose the color of the purchase link, if button was selected above.', 'edd');
 		echo '</td>';
 	echo '</tr>';


### PR DESCRIPTION
Adds a little space after the button colors <select> element to separate it from it's description.
