### PR TITLE
Missing cart template CSS separator class

### DIFF
--- a/includes/cart-template.php
+++ b/includes/cart-template.php
@@ -78,7 +78,7 @@ function edd_get_cart_item_template($cart_key, $item, $ajax = false) {
 	$remove_url = edd_remove_item_url($cart_key, $post, $ajax);
 	$title = get_the_title($id); 
 	if(!empty($item['options'])) {
-		$title .= ' - ' . edd_get_price_name($id, $item['options']);							
+		$title .= ' <span class="edd-cart-item-separator">-</span> ' . edd_get_price_name($id, $item['options']);							
 	}
 	$remove = '<a href="' . $remove_url . '" data-cart-item="' . $cart_key . '" data-action="edd_remove_from_cart" class="edd-remove-from-cart">' . __('remove', 'edd') . '</a>';	
 	$item = '<li class="edd-cart-item"><span class="edd-cart-item-title">' . $title . '</span> <span class="edd-cart-item-separator">-</span> ' . $remove . '</li>';


### PR DESCRIPTION
adds a missing CSS class to the separator when no options are present
