### PR TITLE
'settings-updated' query fix

### DIFF
--- a/includes/admin-pages/settings.php
+++ b/includes/admin-pages/settings.php
@@ -30,11 +30,11 @@ function edd_options_page() {
 	<div class="wrap">
 		
 		<h2 class="nav-tab-wrapper">
-			<a href="<?php echo add_query_arg('tab', 'general'); ?>" class="nav-tab <?php echo $active_tab == 'general' ? 'nav-tab-active' : ''; ?>"><?php _e('General', 'edd'); ?></a>
-			<a href="<?php echo add_query_arg('tab', 'gateways'); ?>" class="nav-tab <?php echo $active_tab == 'gateways' ? 'nav-tab-active' : ''; ?>"><?php _e('Payment Gateways', 'edd'); ?></a>
-			<a href="<?php echo add_query_arg('tab', 'emails'); ?>" class="nav-tab <?php echo $active_tab == 'emails' ? 'nav-tab-active' : ''; ?>"><?php _e('Emails', 'edd'); ?></a>
-			<a href="<?php echo add_query_arg('tab', 'styles'); ?>" class="nav-tab <?php echo $active_tab == 'styles' ? 'nav-tab-active' : ''; ?>"><?php _e('Styles', 'edd'); ?></a>
-			<a href="<?php echo add_query_arg('tab', 'misc'); ?>" class="nav-tab <?php echo $active_tab == 'misc' ? 'nav-tab-active' : ''; ?>"><?php _e('Misc', 'edd'); ?></a>
+			<a href="<?php echo remove_query_arg('settings-updated',add_query_arg('tab', 'general')); ?>" class="nav-tab <?php echo $active_tab == 'general' ? 'nav-tab-active' : ''; ?>"><?php _e('General', 'edd'); ?></a>
+			<a href="<?php echo remove_query_arg('settings-updated',add_query_arg('tab', 'gateways')); ?>" class="nav-tab <?php echo $active_tab == 'gateways' ? 'nav-tab-active' : ''; ?>"><?php _e('Payment Gateways', 'edd'); ?></a>
+			<a href="<?php echo remove_query_arg('settings-updated',add_query_arg('tab', 'emails')); ?>" class="nav-tab <?php echo $active_tab == 'emails' ? 'nav-tab-active' : ''; ?>"><?php _e('Emails', 'edd'); ?></a>
+			<a href="<?php echo remove_query_arg('settings-updated',add_query_arg('tab', 'styles')); ?>" class="nav-tab <?php echo $active_tab == 'styles' ? 'nav-tab-active' : ''; ?>"><?php _e('Styles', 'edd'); ?></a>
+			<a href="<?php echo remove_query_arg('settings-updated',add_query_arg('tab', 'misc')); ?>" class="nav-tab <?php echo $active_tab == 'misc' ? 'nav-tab-active' : ''; ?>"><?php _e('Misc', 'edd'); ?></a>
 		</h2>
 			
 		<div id="tab_container">


### PR DESCRIPTION
Current tab navigation does not take into account the `settings-updated` query attached to the URL after saving the settings. This removes that portion of the URL for the other tab links. This will become especially useful to make sure the `Settings Updated` message is not shown on the other plugin setting tabs (when that update message is added into the core).
