### PR TITLE
-- Add export csv option to payment history

### DIFF
--- a/includes/admin-pages/payments-history.php
+++ b/includes/admin-pages/payments-history.php
@@ -96,6 +96,9 @@ function edd_payment_history_page() {
 					<a href="<?php echo add_query_arg('status', 'trash'); ?>" <?php echo isset( $_GET['status'] ) && $_GET['status'] == 'trash' ? 'class="current"' : ''; ?>><?php _e('Deleted', 'edd'); ?> <span class="count">(<?php echo $payment_count->trash; ?>)</span></a>
 				</li>
 			</ul>
+			<ul class="subsubsub edd-export-payments">
+				<li> | Export: <a href="<?php echo add_query_arg('export', 'csv'); ?>">csv</a></li>
+			</ul>	
 			<form id="payments-filter" action="<?php echo admin_url('edit.php'); ?>" method="get" style="float: right; margin-bottom: 5px;">
 				<label for="edd-mode"><?php _e('Payment mode', 'edd'); ?></label>
 				<select name="mode" id="edd-mode">
@@ -307,3 +310,125 @@ function edd_payment_history_page() {
 		<?php
 	}
 }
+add_action('admin_init', 'edd_export_payment_history'); //Sorry about this, need to serve header :)
+function edd_export_payment_history() {
+	global $edd_options;
+	if(!(isset( $_GET['export'] ))){
+		return; // get out quick if not required.
+	}
+	$mode = isset($_GET['mode']) ? $_GET['mode'] : 'live';
+	if(edd_is_test_mode() && !isset($_GET['mode'])) $mode = 'test';
+	
+	$orderby = isset( $_GET['orderby'] ) ? $_GET['orderby'] : 'ID';
+	$order = isset( $_GET['order'] ) ? $_GET['order'] : 'DESC';
+	$order_inverse = $order == 'DESC' ? 'ASC' : 'DESC';
+	$order_class = strtolower($order_inverse);
+	$user = isset( $_GET['user'] ) ? $_GET['user'] : null;
+	$status = isset( $_GET['status'] ) ? $_GET['status'] : null;
+	
+	$export = isset( $_GET['export'] ) ? $_GET['export'] : null;
+	
+	if($export == 'csv'){ // extensible for other formats in future
+		
+		header('Content-Type: text/csv; charset=utf-8');
+		header('Content-Disposition: attachment; filename=data.csv');
+		header("Pragma: no-cache");
+		header("Expires: 0");
+
+		$payments = edd_get_payments(0, -1, $mode, $orderby, $order, $user, $status);
+		if($payments){
+			$i = 0;
+			echo '"' . __('ID', 'edd') .  '",';
+			echo '"' . __('Email', 'edd') .  '",';
+			echo '"' . __('Name', 'edd') .  '",';
+			echo '"' . __('Products', 'edd') .  '",';
+			echo '"' . __('Discounts,', 'edd') .  '",';
+			echo '"' . __('Amount paid', 'edd') .  '",';
+			echo '"' . __('Payment method', 'edd') .  '",';
+			echo '"' . __('Key', 'edd') .  '",';
+			echo '"' . __('Date', 'edd') .  '",';
+			echo '"' . __('User', 'edd') .  '",';
+			echo '"' . __('Status', 'edd') .  '"';
+			echo "\r\n";
+			foreach($payments as $payment){
+
+				$payment_meta = get_post_meta($payment->ID, '_edd_payment_meta', true);
+				$user_info = maybe_unserialize($payment_meta['user_info']);
+				
+				echo '"' . $payment->ID . '",';
+				echo '"' . $payment_meta['email'] . '",';
+				echo '"' . $user_info['first_name'] . ' ' . $user_info['last_name']. '",';
+				$downloads = isset($payment_meta['cart_details']) ? maybe_unserialize($payment_meta['cart_details']) : false;
+				if (empty($downloads ) || !$downloads ) {
+					$downloads = maybe_unserialize($payment_meta['downloads']);
+				}
+
+				if ($downloads) {
+					
+					foreach($downloads as $key => $download) {
+						
+						// retrieve the ID of the download
+						$id = isset($payment_meta['cart_details']) ? $download['id'] : $download;
+						
+						// if download has variable prices, override the default price
+						$price_override = isset($payment_meta['cart_details']) ? $download['price'] : null;
+						
+						$user_info = unserialize($payment_meta['user_info']);
+						
+						// calculate the final price
+						$price = edd_get_download_final_price($id, $user_info, $price_override);
+						
+						// show name of download
+						echo '"' . get_the_title($id);
+						
+						echo  ' - ';
+						
+						if (isset($downloads[$key]['item_number'])) {
+							
+							$price_options = $downloads[$key]['item_number']['options'];
+							
+							if (isset($price_options['price_id']) ) {
+								echo edd_get_price_option_name($id, $price_options['price_id']);
+								echo ' - ';
+							}
+						}
+						echo edd_currency_filter($price) . '",';
+						
+					}
+				}
+
+				if (isset($user_info['discount']) && $user_info['discount'] != 'none') {
+					echo '"' . $user_info['discount'] . '",';
+				} else {
+					
+					echo '"' . __('none', 'edd') . '",';
+				}
+				echo '"' . edd_currency_filter($payment_meta['amount']) . '",';
+	
+				$gateway = get_post_meta($payment->ID, '_edd_payment_gateway', true);
+				if ($gateway) {
+					echo '"' .  edd_get_gateway_admin_label($gateway) . '",';
+				} else {
+					echo '"none",'; 
+				}
+				echo '"' . $payment_meta['key'] . '",';
+				echo '"' . date(get_option('date_format'), strtotime($payment->post_date)) . '",';
+				
+				$user_id = isset($user_info['id']) && $user_info['id'] != -1 ? $user_info['id'] : $user_info['email'];
+
+				echo '"';
+				echo is_numeric($user_id) ? get_user_by('id', $user_id)->display_name : __('guest', 'edd');
+				echo '",';
+				echo '"' . edd_get_payment_status($payment, true) . '"';
+				echo "\r\n";
+
+				$i++;
+			}			
+		}else{
+			echo 'No payments recorded yet';
+		}
+	}
+	die();	
+}
+
+?>


### PR DESCRIPTION
Not as tested as I'd like but I thought you might take it from here. Should be extensible to add other export options.

I also tried to keep the code separate from the rest of the payment history page..
