### PR TITLE
Decode all HTML characters using UTF-8

### DIFF
--- a/includes/email-functions.php
+++ b/includes/email-functions.php
@@ -56,7 +56,7 @@ function edd_email_purchase_receipt($payment_id, $admin_notice = true) {
 		$gateway = edd_get_gateway_admin_label( get_post_meta($payment_id, '_edd_payment_gateway', true) );
 		
 		$admin_message .= $download_list . "\n";
-		$admin_message .= __('Amount: ', 'edd') . " " . html_entity_decode(edd_currency_filter($payment_data['amount'])) . "\n\n";
+		$admin_message .= __('Amount: ', 'edd') . " " . html_entity_decode(edd_currency_filter($payment_data['amount']), ENT_COMPAT, 'UTF-8') . "\n\n";
 		$admin_message .= __('Payment Method: ', 'edd') . " " . $gateway . "\n\n";
 		$admin_message .= __('Thank you', 'edd');
 		$admin_message = apply_filters('edd_admin_purchase_notification', $admin_message, $payment_id, $payment_data);


### PR DESCRIPTION
Decode all HTML characters using UTF-8. Issue with £ not being displayed correctly. UTF-8 is default on PHP 5.4.0 onwards, therefore adding support for older versions.
