### PR TITLE
Disables price input field for variable pricing

### DIFF
--- a/includes/dashboard-columns.php
+++ b/includes/dashboard-columns.php
@@ -225,7 +225,7 @@ function edd_price_field_quick_edit( $column_name, $post_type ) {
 			<label>
 				<span class="title"><?php _e( 'Price', 'edd' ); ?></span>
 				<span class="input-text-wrap">
-					<input type="text" name="_edd_regprice" class="text regprice" value="" placeholder="<?php _e( 'Price', 'edd' ); ?>" />
+					<input type="text" name="_edd_regprice" class="text regprice" />
 				</span>
 			</label>
 			<br class="clear" />

--- a/includes/js/admin-scripts.js
+++ b/includes/js/admin-scripts.js
@@ -182,12 +182,16 @@ jQuery(document).ready(function ($) {
 
         var $edd_inline_data = $('#post-' + post_id);
 
-        var regprice = $edd_inline_data.find('.downloadprice-' + post_id).val();
+        var regprice = $edd_inline_data.find('.column-price .downloadprice-' + post_id).val();
 
-        //Trying to see if hidden input field in price column exists, if not...hide the #edd-download-data div
-        //if ( $('.downloadprice-' + post_id ).length ) { alert( regprice ); $('#edd-download-data').remove(); }
+        var var_product_input_message = 'Sorry, not available for variable priced products.';
 
-        $('input[name="_edd_regprice"]', '#edd-download-data').val(regprice);
+        // If variable priced product disable editing, otherwise allow price changes
+        if ( regprice != $('#post-' + post_id + '.column-price .downloadprice-' + post_id).val() ) {
+            $('.regprice', '#edd-download-data').val(regprice).attr('disabled', false);
+        } else {
+            $('.regprice', '#edd-download-data').val(var_product_input_message).attr('disabled', 'disabled');
+        }
     });
 	
 });


### PR DESCRIPTION
I stuck the input field message in a JS variable and I know that translation is available through JS but I'm not quite sure how to do it exactly. So that being able to be translated would be a good idea until we figure out how to handle variable pricing updates.
