### PR TITLE
Added Sorting Options to [downloads] Short Code 

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -427,7 +427,7 @@ function edd_downloads_query($atts, $content = null) {
 							<div class="edd_download_image">
 								<?php echo get_the_post_thumbnail($download->ID, $thumbsize); ?>
 							</div>
-						<?php elseif (false !== $fallback): ?>
+						<?php elseif ( false !== $fallback ): ?>
 							<div class="edd_download_image">
 								<img src="<?php echo $fallback; ?>" alt="<?php the_title(); ?>"/>
 							</div>


### PR DESCRIPTION
# [downloads] Short Code Sorting
#### The downloads short code now has the following sorting options:
- Order by download title
- Order by download ID
- Order by download publish date
- Order by random
- Order by **non-variable priced** downloads only
- Order by ASC/DESC
#### To Do
- Need to add price sorting for variable priced downloads
