### PR TITLE
Fix user can seemingly apply discount. Issue #141 

### DIFF
--- a/includes/js/edd-ajax.js
+++ b/includes/js/edd-ajax.js
@@ -95,14 +95,25 @@ jQuery(document).ready(function ($) {
         return false;
     });
 
-    // validate and apply a discount
-    $('#edd_checkout_form_wrap').on('click', '.edd-apply-discount', function (event) {
-        var $this = $(this),
-            discount_code = $('#edd-discount').val(),
-            edd_email = $('#edd-email').val();
+    // For tricksters
+	var before_discount = $('.edd_cart_amount').text();	
+	$('#edd_checkout_form_wrap').on('change', '#edd-email', function (event) {
+		$('.edd_cart_amount').html(before_discount);
+		$('#edd-discount').val('');
+	});
 
+	// validate and apply a discount
+    $('#edd_checkout_form_wrap').on('click', '.edd-apply-discount', function (event) {
+        
+		var $this = $(this),
+            discount_code = $('#edd-discount').val(),
+			edd_email = $('#edd-email').val();
         if (discount_code == '') {
             alert(edd_scripts.no_discount);
+            return false;
+        }
+		if (edd_email == '') {
+            alert(edd_scripts.no_email);
             return false;
         }
 


### PR DESCRIPTION
You can seemingly apply the discount by changing
the email to one that hasn't been used then changing it back to the correct
one. You won't be able to make the purchase but you can make the payment
amount change.

JavaScript fix to check when user changes email and revert discount.
