### PR TITLE
Escape HTML and some code formatting for template-functions.php

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -359,7 +359,7 @@ function edd_get_purchase_download_links( $purchase_data ) {
 	foreach( $purchase_data['downloads'] as $download ) {
 
 		$links .= '<li>';
-			$links .= '<h3 class="edd_download_link_title">' . get_the_title( $download['id'] ) . '</h3>';
+			$links .= '<h3 class="edd_download_link_title">' . esc_html( get_the_title( $download['id'] ) ) . '</h3>';
 			$price_id = isset( $download['options'] ) && isset( $download['options']['price_id'] ) ? $download['options']['price_id'] : null;
 			$files = edd_get_download_files( $download['id'], $price_id );
 			if ( is_array( $files ) ) {


### PR DESCRIPTION
I was looking around in this file for some purchase link functionality. In the meantime, I noticed many of the form element attributes and html were not being escaped.

I also applied some basic code formatting to adhear closer to the WordPress coding standards (http://codex.wordpress.org/WordPress_Coding_Standards). Not sure if you are into that type of thing. If so, I thought I would go through periodically and do the same to other files.

These changes are small and maybe useful. If anything, the escaping may be of more importance. Keep up the good work!
