### PR TITLE
Fix for missing check and missing directory creation of 'edd' uploads directory.

### DIFF
--- a/includes/upload-functions.php
+++ b/includes/upload-functions.php
@@ -87,6 +87,8 @@ function edd_create_protection_files() {
     if( false === get_transient( 'edd_check_protection_files' ) ) {
         $wp_upload_dir = wp_upload_dir();
         $upload_path = $wp_upload_dir['basedir'] . '/edd';
+
+        wp_mkdir_p( $upload_path );
         
         // top level blank index.php
         if( !file_exists( $upload_path . '/index.php' ) ) {
@@ -95,9 +97,11 @@ function edd_create_protection_files() {
 
         // top level .htaccess file
         $rules = 'Options -Indexes';
-        $contents = @file_get_contents( $upload_path . '/.htaccess' );
-        if( false === strpos( $contents, 'Options -Indexes' ) || ! $contents ) {
-            @file_put_contents( $upload_path . '/.htaccess', $rules );
+        if ( file_exists( $upload_path . '/.htaccess' ) ) {
+            $contents = @file_get_contents( $upload_path . '/.htaccess' );
+            if( false === strpos( $contents, 'Options -Indexes' ) || ! $contents ) {
+                @file_put_contents( $upload_path . '/.htaccess', $rules );
+            }
         }
 
         // now place index.php files in all sub folders


### PR DESCRIPTION
I noticed on first activation of the plugin, file_put_contents throws errors (delete the transient "_transient_edd_check_protection_files" to see it on an existing install).

It seems the 'edd' directory isn't created at the right point in the code, and a check isn't run on the existence of an '.htaccess' file inside either. I've put the directory creation line in, and added a check.
