### PR TITLE
add_query_arg() and AJAX

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -183,3 +183,23 @@ function edd_ajax_get_download_title() {
 }
 add_action('wp_ajax_edd_get_download_title', 'edd_ajax_get_download_title');
 add_action('wp_ajax_nopriv_edd_get_download_title', 'edd_ajax_get_download_title');
+
+/**
+ * Get Download Title
+ *
+ * Used only in the admin
+ *
+ * @access      private
+ * @since       1.1.5.2
+ * @return      string
+*/
+
+function edd_ajax_get_payment_gateway() {
+	$payment_mode = esc_attr( $_POST[ 'gateway' ] );
+	
+	echo edd_get_checkout_form( $payment_mode );
+
+	die();
+}
+add_action('wp_ajax_edd_ajax_get_payment_gateway', 'edd_ajax_get_payment_gateway');
+add_action('wp_ajax_nopriv_edd_ajax_get_payment_gateway', 'edd_ajax_get_payment_gateway');

--- a/includes/checkout-template.php
+++ b/includes/checkout-template.php
@@ -47,196 +47,203 @@ function edd_checkout_form() {
 			do_action('edd_after_checkout_cart');
 			?>
 			
-			<div id="edd_checkout_form_wrap" class="edd_clearfix">
-			
-				<?php 				
-				do_action('edd_checkout_form_top');
-			
-				$gateways = edd_get_enabled_payment_gateways();
-				$show_gateways = false;
-				if(count($gateways) > 1 && !isset($_GET['payment-mode'])) {
-					$show_gateways = true;
-					if(edd_get_cart_amount() <= 0) {
-						$show_gateways = false;
-					}
-				}
-				if($show_gateways) { ?>
-					<?php do_action('edd_payment_mode_top'); ?>
-					<form id="edd_payment_mode" action="<?php echo $page_URL; ?>" method="GET">
-						<fieldset id="edd_payment_mode_select">
-							<?php do_action('edd_payment_mode_before_gateways'); ?>
-							<p id="edd-payment-mode-wrap">
-								<?php								
-									echo '<select class="edd-select" name="payment-mode" id="edd-gateway">';
-										foreach($gateways as $gateway_id => $gateway) :
-											echo '<option value="' . $gateway_id . '">' . $gateway['checkout_label'] . '</option>';
-										endforeach;
-									echo '</select>';
-									echo '<label for="edd-gateway">' . __('Choose Your Payment Method', 'edd') . '</label>';
-								?>
-							</p>
-							<?php do_action('edd_payment_mode_after_gateways'); ?>
-						</fieldset>
-						<fieldset id="edd_payment_mode_submit">
-							<p id="edd-next-submit-wrap">
-								<?php $color = isset($edd_options['checkout_color']) ? $edd_options['checkout_color'] : 'gray'; ?> 
-								<span class="edd_button edd_<?php echo $color; ?>">
-									<span class="edd_button_outer">
-										<span class="edd_button_inner">
-											<input type="submit" id="edd_next_button" class="edd_button_text edd-submit" value="<?php _e('Next', 'edd'); ?>"/>
-										</span>
-									</span>
-								</span>
-							</p>
-						</fieldset>
-					</form>
-					<?php do_action('edd_payment_mode_bottom'); ?>
-			
-				<?php } else { ?>
-		
-					<?php
-						if(count($gateways) >= 1 && !isset($_GET['payment-mode'])) {					
-							foreach($gateways as $gateway_id => $gateway) :
-								$enabled_gateway = $gateway_id;
-								if(edd_get_cart_amount() <= 0) {
-									$enabled_gateway = 'manual'; // this allows a free download by filling in the info
-								}
-							endforeach;
-						} else if(edd_get_cart_amount() <= 0) {
-							$enabled_gateway = 'manual';
-						}
-						$payment_mode = isset($_GET['payment-mode']) ? urldecode($_GET['payment-mode']) : $enabled_gateway;	
-					?>
-					
-					<?php do_action('edd_before_purchase_form'); ?>
-					<form id="edd_purchase_form" action="<?php echo $page_URL; ?>" method="POST">					
-					
-						<?php do_action('edd_purchase_form_top'); ?>
-					
-						<?php 
-						if(isset($edd_options['logged_in_only']) && !isset($edd_options['show_register_form'])) {
-							if(is_user_logged_in()) {
-								$can_checkout = true;
-							} else {
-								$can_checkout = false;
-							}
-						} elseif(isset($edd_options['show_register_form']) && isset($edd_options['logged_in_only'])) {
-							$can_checkout = true;
-						} elseif(!isset($edd_options['logged_in_only'])) {
-							$can_checkout = true;
-						}
-						$can_checkout = true;
-						if($can_checkout) { ?>
-							
-							<?php if(isset($edd_options['show_register_form']) && !is_user_logged_in() && !isset($_GET['login'])) { ?>
-								<div id="edd_checkout_login_register"><?php echo edd_get_register_fields(); ?></div>
-							<?php } elseif(isset($edd_options['show_register_form']) && !is_user_logged_in() && isset($_GET['login'])) { ?>
-								<div id="edd_checkout_login_register"><?php echo edd_get_login_fields(); ?></div>
-							<?php } ?>
-
-							<?php if( (!isset($_GET['login']) && is_user_logged_in()) || !isset($edd_options['show_register_form'])) { ?>											
-							<fieldset id="edd_checkout_user_info">
-								<legend><?php _e('Personal Info', 'edd'); ?></legend>
-								<?php do_action('edd_purchase_form_before_email'); ?>
-								<p id="edd-email-wrap">
-									<input class="edd-input required" type="email" name="edd_email" placeholder="<?php _e('Email address', 'edd'); ?>" id="edd-email" value="<?php echo is_user_logged_in() ? $user_data->user_email : ''; ?>"/>
-									<label class="edd-label" for="edd-email"><?php _e('Email Address', 'edd'); ?></label>
-								</p>
-								<?php do_action('edd_purchase_form_after_email'); ?>
-								<p id="edd-first-name-wrap">
-									<input class="edd-input required" type="text" name="edd_first" placeholder="<?php _e('First Name', 'edd'); ?>" id="edd-first" value="<?php echo is_user_logged_in() ? $user_data->first_name : ''; ?>"/>
-									<label class="edd-label" for="edd-first"><?php _e('First Name', 'edd'); ?></label>
-								</p>
-								<p id="edd-last-name-wrap">
-									<input class="edd-input" type="text" name="edd_last" id="edd-last" placeholder="<?php _e('Last name', 'edd'); ?>" value="<?php echo is_user_logged_in() ? $user_data->last_name : ''; ?>"/>
-									<label class="edd-label" for="edd-last"><?php _e('Last Name', 'edd'); ?></label>
-								</p>	
-								<?php do_action('edd_purchase_form_user_info'); ?>
-							</fieldset>	
-							
-							<?php do_action('edd_purchase_form_after_user_info'); ?>
-
-							<?php } ?>
-							
-							<?php if(edd_has_active_discounts()) { // only show if we have at least one active discount ?>
-								<fieldset id="edd_discount_code">
-									<p id="edd-discount-code-wrap">
-										<input class="edd-input" type="text" id="edd-discount" name="edd-discount" placeholder="<?php _e('Enter discount', 'edd'); ?>"/>
-										<label class="edd-label" for="edd-discount">
-											<?php _e('Discount', 'edd'); ?>
-											<?php if(edd_is_ajax_enabled()) { ?>
-												- <a href="#" class="edd-apply-discount"><?php _e('Apply Discount', 'edd'); ?></a>
-											<?php } ?>
-										</label>
-									</p>
-								</fieldset>	
-							<?php } ?>
-
-							<?php 
-								// load the credit card form and allow gateways to load their own if they wish
-								if(has_action('edd_' . $payment_mode . '_cc_form')) {
-									do_action('edd_' . $payment_mode . '_cc_form'); 
-								} else {
-									do_action('edd_cc_form');
-								}
-							?>			
-							
-							<?php if(isset($edd_options['show_agree_to_terms'])) { ?>
-								<fieldset id="edd_terms_agreement">
-									<p>
-										<div id="edd_terms" style="display:none;">
-											<?php 
-												do_action('edd_before_terms');
-												echo wpautop($edd_options['agree_text']); 
-												do_action('edd_after_terms');
-											?>
-										</div>
-										<div id="edd_show_terms">
-											<a href="#" class="edd_terms_links"><?php _e('Show Terms', 'edd'); ?></a>
-											<a href="#" class="edd_terms_links" style="display:none;"><?php _e('Hide Terms', 'edd'); ?></a>
-										</div>
-										<input name="edd_agree_to_terms" class="required" type="checkbox" id="edd_agree_to_terms" value="1"/>
-										<label for="edd_agree_to_terms"><?php echo isset($edd_options['agree_label']) ? $edd_options['agree_label'] : __('Agree to Terms?', 'edd'); ?></label>
-									</p>
-								</fieldset>
-							<?php } ?>	
-							<fieldset id="edd_purchase_submit">
-								<p>
-									<?php do_action('edd_purchase_form_before_submit'); ?>
-									<?php if(is_user_logged_in()) { ?>
-									<input type="hidden" name="edd-user-id" value="<?php echo $user_data->ID; ?>"/>
-									<?php } ?>
-									<input type="hidden" name="edd_action" value="purchase"/>
-									<input type="hidden" name="edd-gateway" value="<?php echo $payment_mode; ?>" />
-									<input type="hidden" name="edd-nonce" value="<?php echo wp_create_nonce('edd-purchase-nonce'); ?>"/>
-									<?php $color = isset($edd_options['checkout_color']) ? $edd_options['checkout_color'] : 'gray'; ?>
-									<span class="edd_button edd_<?php echo $color; ?>">
-										<span class="edd_button_outer">
-											<span class="edd_button_inner">
-												<input type="submit" class="edd_button_text edd-submit" id="edd-purchase-button" name="edd-purchase" value="<?php _e('Purchase', 'edd'); ?>"/>
-											</span>
-										</span>
-									</span>
-									<?php do_action('edd_purchase_form_after_submit'); ?>
-								</p>
-								<?php if(!edd_is_ajax_enabled()) { ?>
-									<p class="edd-cancel"><a href="javascript:history.go(-1)"><?php _e('Go back', 'edd'); ?></a></p>
-								<?php } ?>				
-							</fieldset>
-						<?php } else { ?>
-							<p><?php _e('You must be logged in to complete your purchase', 'edd'); ?></p>
-						<?php } ?>
-						<?php do_action('edd_purchase_form_bottom'); ?>
-					</form>
-					<?php do_action('edd_after_purchase_form'); ?>
-			<?php } ?>
-		</div><!--end #edd_checkout_form_wrap-->
+			<?php do_action( 'edd_checkout_form' ); ?>
 		<?php
 		else:
 			do_action('edd_empty_cart');
 		endif;
 	return ob_get_clean();
 }
+
+function edd_get_checkout_form( $force_gateway = null ) {
+	global $edd_options;
+
+	$gateways = edd_get_enabled_payment_gateways();
+	$show_gateways = false;
+	if(count($gateways) > 1 && !isset($_GET['payment-mode'])) {
+		$show_gateways = true;
+		if(edd_get_cart_amount() <= 0) {
+			$show_gateways = false;
+		}
+	} 
+
+	if ( $force_gateway )
+		$show_gateways = false;
+?>
+
+<div id="edd_checkout_form_wrap" class="edd_clearfix">
+	<?php 				
+	do_action('edd_checkout_form_top');
+	if($show_gateways) { ?>
+		<?php do_action('edd_payment_mode_top'); ?>
+		<form id="edd_payment_mode" action="<?php echo $page_URL; ?>" method="GET">
+			<fieldset id="edd_payment_mode_select">
+				<?php do_action('edd_payment_mode_before_gateways'); ?>
+				<p id="edd-payment-mode-wrap">
+					<?php								
+						echo '<select class="edd-select" name="payment-mode" id="edd-gateway">';
+							foreach($gateways as $gateway_id => $gateway) :
+								echo '<option value="' . $gateway_id . '">' . $gateway['checkout_label'] . '</option>';
+							endforeach;
+						echo '</select>';
+						echo '<label for="edd-gateway">' . __('Choose Your Payment Method', 'edd') . '</label>';
+					?>
+				</p>
+				<?php do_action('edd_payment_mode_after_gateways'); ?>
+			</fieldset>
+			<fieldset id="edd_payment_mode_submit">
+				<p id="edd-next-submit-wrap">
+					<?php $color = isset($edd_options['checkout_color']) ? $edd_options['checkout_color'] : 'gray'; ?> 
+					<span class="edd_button edd_<?php echo $color; ?>">
+						<span class="edd_button_outer">
+							<span class="edd_button_inner">
+								<input type="submit" id="edd_next_button" class="edd_button_text edd-submit" value="<?php _e('Next', 'edd'); ?>"/>
+							</span>
+						</span>
+					</span>
+				</p>
+			</fieldset>
+		</form>
+		<?php do_action('edd_payment_mode_bottom'); ?>
+
+	<?php } else { ?>
+
+		<?php
+			if(count($gateways) >= 1 && !isset($_GET['payment-mode'])) {					
+				foreach($gateways as $gateway_id => $gateway) :
+					$enabled_gateway = $gateway_id;
+					if(edd_get_cart_amount() <= 0) {
+						$enabled_gateway = 'manual'; // this allows a free download by filling in the info
+					}
+				endforeach;
+			} else if(edd_get_cart_amount() <= 0) {
+				$enabled_gateway = 'manual';
+			}
+			$payment_mode = isset($_GET['payment-mode']) ? urldecode($_GET['payment-mode']) : $enabled_gateway;
+
+			if ( $force_gateway )
+				$payment_mode = $force_gateway;	
+		?>
+		
+		<?php do_action('edd_before_purchase_form'); ?>
+		<form id="edd_purchase_form" action="<?php echo $page_URL; ?>" method="POST">					
+		
+			<?php do_action('edd_purchase_form_top'); ?>
+		
+			<?php 
+			if(isset($edd_options['logged_in_only']) && !isset($edd_options['show_register_form'])) {
+				if(is_user_logged_in()) {
+					$can_checkout = true;
+				} else {
+					$can_checkout = false;
+				}
+			} elseif(isset($edd_options['show_register_form']) && isset($edd_options['logged_in_only'])) {
+				$can_checkout = true;
+			} elseif(!isset($edd_options['logged_in_only'])) {
+				$can_checkout = true;
+			}
+			$can_checkout = true;
+			if($can_checkout) { ?>
+				
+				<?php if(isset($edd_options['show_register_form']) && !is_user_logged_in() && !isset($_GET['login'])) { ?>
+					<div id="edd_checkout_login_register"><?php echo edd_get_register_fields(); ?></div>
+				<?php } elseif(isset($edd_options['show_register_form']) && !is_user_logged_in() && isset($_GET['login'])) { ?>
+					<div id="edd_checkout_login_register"><?php echo edd_get_login_fields(); ?></div>
+				<?php } ?>
+
+				<?php if( (!isset($_GET['login']) && is_user_logged_in()) || !isset($edd_options['show_register_form'])) { ?>											
+				<fieldset id="edd_checkout_user_info">
+					<legend><?php _e('Personal Info', 'edd'); ?></legend>
+					<?php do_action('edd_purchase_form_before_email'); ?>
+					<p id="edd-email-wrap">
+						<input class="edd-input required" type="email" name="edd_email" placeholder="<?php _e('Email address', 'edd'); ?>" id="edd-email" value="<?php echo is_user_logged_in() ? $user_data->user_email : ''; ?>"/>
+						<label class="edd-label" for="edd-email"><?php _e('Email Address', 'edd'); ?></label>
+					</p>
+					<?php do_action('edd_purchase_form_after_email'); ?>
+					<p id="edd-first-name-wrap">
+						<input class="edd-input required" type="text" name="edd_first" placeholder="<?php _e('First Name', 'edd'); ?>" id="edd-first" value="<?php echo is_user_logged_in() ? $user_data->first_name : ''; ?>"/>
+						<label class="edd-label" for="edd-first"><?php _e('First Name', 'edd'); ?></label>
+					</p>
+					<p id="edd-last-name-wrap">
+						<input class="edd-input" type="text" name="edd_last" id="edd-last" placeholder="<?php _e('Last name', 'edd'); ?>" value="<?php echo is_user_logged_in() ? $user_data->last_name : ''; ?>"/>
+						<label class="edd-label" for="edd-last"><?php _e('Last Name', 'edd'); ?></label>
+					</p>	
+					<?php do_action('edd_purchase_form_user_info'); ?>
+				</fieldset>	
+				
+				<?php do_action('edd_purchase_form_after_user_info'); ?>
+
+				<?php } ?>
+				
+				<?php if(edd_has_active_discounts()) { // only show if we have at least one active discount ?>
+					<fieldset id="edd_discount_code">
+						<p id="edd-discount-code-wrap">
+							<input class="edd-input" type="text" id="edd-discount" name="edd-discount" placeholder="<?php _e('Enter discount', 'edd'); ?>"/>
+							<label class="edd-label" for="edd-discount">
+								<?php _e('Discount', 'edd'); ?>
+								<?php if(edd_is_ajax_enabled()) { ?>
+									- <a href="#" class="edd-apply-discount"><?php _e('Apply Discount', 'edd'); ?></a>
+								<?php } ?>
+							</label>
+						</p>
+					</fieldset>	
+				<?php } ?>
+
+				<?php do_action('edd_' . $payment_mode . '_cc_form'); ?>			
+				
+				<?php if(isset($edd_options['show_agree_to_terms'])) { ?>
+					<fieldset id="edd_terms_agreement">
+						<p>
+							<div id="edd_terms" style="display:none;">
+								<?php 
+									do_action('edd_before_terms');
+									echo wpautop($edd_options['agree_text']); 
+									do_action('edd_after_terms');
+								?>
+							</div>
+							<div id="edd_show_terms">
+								<a href="#" class="edd_terms_links"><?php _e('Show Terms', 'edd'); ?></a>
+								<a href="#" class="edd_terms_links" style="display:none;"><?php _e('Hide Terms', 'edd'); ?></a>
+							</div>
+							<input name="edd_agree_to_terms" class="required" type="checkbox" id="edd_agree_to_terms" value="1"/>
+							<label for="edd_agree_to_terms"><?php echo isset($edd_options['agree_label']) ? $edd_options['agree_label'] : __('Agree to Terms?', 'edd'); ?></label>
+						</p>
+					</fieldset>
+				<?php } ?>	
+				<fieldset id="edd_purchase_submit">
+					<p>
+						<?php do_action('edd_purchase_form_before_submit'); ?>
+						<?php if(is_user_logged_in()) { ?>
+						<input type="hidden" name="edd-user-id" value="<?php echo $user_data->ID; ?>"/>
+						<?php } ?>
+						<input type="hidden" name="edd_action" value="purchase"/>
+						<input type="hidden" name="edd-gateway" value="<?php echo $payment_mode; ?>" />
+						<input type="hidden" name="edd-nonce" value="<?php echo wp_create_nonce('edd-purchase-nonce'); ?>"/>
+						<?php $color = isset($edd_options['checkout_color']) ? $edd_options['checkout_color'] : 'gray'; ?>
+						<span class="edd_button edd_<?php echo $color; ?>">
+							<span class="edd_button_outer">
+								<span class="edd_button_inner">
+									<input type="submit" class="edd_button_text edd-submit" id="edd-purchase-button" name="edd-purchase" value="<?php _e('Purchase', 'edd'); ?>"/>
+								</span>
+							</span>
+						</span>
+						<?php do_action('edd_purchase_form_after_submit'); ?>
+					</p>
+					<?php if(!edd_is_ajax_enabled()) { ?>
+						<p class="edd-cancel"><a href="javascript:history.go(-1)"><?php _e('Go back', 'edd'); ?></a></p>
+					<?php } ?>				
+				</fieldset>
+			<?php } else { ?>
+				<p><?php _e('You must be logged in to complete your purchase', 'edd'); ?></p>
+			<?php } ?>
+			<?php do_action('edd_purchase_form_bottom'); ?>
+		</form>
+		<?php do_action('edd_after_purchase_form'); ?>
+	<?php } ?>
+</div><!--end #edd_checkout_form_wrap-->
+<?php
+}
+add_action( 'edd_checkout_form', 'edd_get_checkout_form' );
 
 
 /**

--- a/includes/gateways/manual.php
+++ b/includes/gateways/manual.php
@@ -75,7 +75,7 @@ function edd_manual_payment($purchase_data) {
 		edd_send_to_success_page();
 	} else {
 		// if errors are present, send the user back to the purchase page so they can be corrected
-		edd_send_back_to_checkout('?payment-mode=' . $purchase_data['post_data']['edd-gateway']);
+		edd_send_back_to_checkout( array( 'payment-mode' => $purchase_data['post_data']['edd-gateway'] ) );
 	}
 }
 add_action('edd_gateway_manual', 'edd_manual_payment');

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -77,7 +77,7 @@ function edd_process_paypal_purchase( $purchase_data ) {
     // check payment
     if ( ! $payment ) {
         // problems? send back
-        edd_send_back_to_checkout( '?payment-mode=' . $purchase_data['post_data']['edd-gateway'] );
+        edd_send_back_to_checkout( array( 'payment-mode' => $purchase_data['post_data']['edd-gateway'] ) );
     } else {
         // only send to PayPal if the pending payment is created successfully
         $listener_url = trailingslashit( home_url() ).'?edd-listener=IPN';

--- a/includes/gateways/paypal.php
+++ b/includes/gateways/paypal.php
@@ -117,7 +117,7 @@ function edd_process_paypal_purchase($purchase_data) {
 		
 	} else {
 		// if errors are present, send the user back to the purchase page so they can be corrected
-		edd_send_back_to_checkout('?payment-mode=' . $purchase_data['post_data']['edd-gateway']);
+		edd_send_back_to_checkout( array( 'payment-mode' => $purchase_data['post_data']['edd-gateway'] ) );
 	}
 }
 add_action('edd_gateway_paypal', 'edd_process_paypal_purchase');

--- a/includes/js/edd-ajax.js
+++ b/includes/js/edd-ajax.js
@@ -170,13 +170,21 @@ jQuery(document).ready(function ($) {
         } else {
             var payment_mode = $('#edd-gateway').val();
         }
-        var form = $(this),
-            action = form.attr("action") + '?payment-mode=' + payment_mode;
+
         // show the ajax loader
         $('.edd-cart-ajax').show();
         $('#edd_checkout_form_wrap').html('<img src="' + edd_scripts.ajax_loader + '"/>');
-        $('#edd_checkout_form_wrap').load(action + ' #edd_checkout_form_wrap');
-        return false;
+
+        data = {
+        	action  : 'edd_ajax_get_payment_gateway',
+        	gateway :  payment_mode
+        }
+       
+        $.post( edd_scripts.ajaxurl, data, function(response) {
+        	$( '#edd_checkout_form_wrap' ).html( response );
+        });
+
+        e.preventDefault();
     });
 
 });

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -34,21 +34,21 @@ function edd_process_purchase_form() {
 
 	// validate the form $_POST data
 	$valid_data = edd_purchase_form_validate_fields(); 
-
+	
 	// allow themes and plugins to hoook to errors
 	do_action('edd_checkout_error_checks', $_POST);
 
 	// check errors
 	if ( false !== $errors = edd_get_errors() ) {
 		// we have errors, send back to checkout
-		edd_send_back_to_checkout('?payment-mode=' . $valid_data['gateway']);
+		edd_send_back_to_checkout( array( 'payment-mode' => $valid_data['gateway'] ) );
 		exit;
 	}
 
 	// check user
 	if ( false === $user = edd_get_purchase_form_user( $valid_data ) ) {
 		// something went wrong when collecting data, send back to checkout
-		edd_send_back_to_checkout('?payment-mode=' . $valid_data['gateway']);
+		edd_send_back_to_checkout( array( 'payment-mode' => $valid_data['gateway'] ) );
 		exit;
 	}
 
@@ -114,7 +114,7 @@ add_action('edd_purchase', 'edd_process_purchase_form');
 
 function edd_purchase_form_validate_fields() {
 	global $edd_options;
-		
+	
 	// check if there is $_POST
 	if ( empty( $_POST ) ) return;
 	
@@ -658,12 +658,16 @@ function edd_send_to_success_page($query_string = null) {
  * @return      void
 */
 
-function edd_send_back_to_checkout($query_string = null) {
+function edd_send_back_to_checkout( $query_args = null ) {
 	global $edd_options;
-	$redirect = get_permalink($edd_options['purchase_page']);
-	if($query_string)
-		$redirect .= $query_string;
-	wp_redirect($redirect); exit;
+	
+	$redirect = get_permalink( $edd_options[ 'purchase_page' ] );
+	
+	if( $query_args )
+		$redirect = add_query_arg( $query_args, $redirect );
+
+	wp_redirect( $redirect );
+	exit;
 }
 
 


### PR DESCRIPTION
A stab at fixing #271. Ran into one problem with `has_action()` not working correctly with AJAX, so I just chopped that out (removing the default `edd_cc_form` action.) I didn't see it being called in the plugin directly, but it might be used in extensions that I don't know about. Not sure why `has_action()` wasn't working though.

If that `edd_cc_form` action needs to be there, we can figure something else out. 

Split the checkout form into its own function so it could be called by itself via AJAX, instead of loading the whole page and picking it out of the DOM.
