### PR TITLE
Payment History - date filter

### DIFF
--- a/includes/admin-pages/payments-history.php
+++ b/includes/admin-pages/payments-history.php
@@ -266,7 +266,7 @@ function edd_payment_history_page() {
 										</div>
 									</td>
 									<td style="text-transform:uppercase;"><?php echo edd_currency_filter( $payment_meta['amount']); ?></td>
-									<td><?php echo date(get_option('date_format'), strtotime($payment->post_date)); ?></td>
+									<td><?php echo edd_format_payment_date( $payment->post_date );  ?></td>
 									<td>
 										<?php $user_id = isset($user_info['id']) && $user_info['id'] != -1 ? $user_info['id'] : $user_info['email']?>
 										<a href="<?php echo remove_query_arg('p', add_query_arg('user', $user_id) ); ?>">

--- a/includes/payment-functions.php
+++ b/includes/payment-functions.php
@@ -436,3 +436,23 @@ function edd_get_payment_meta( $payment_id ) {
 	return get_post_meta($payment_id, '_edd_payment_meta', true);
 }
 
+/**
+ * Format the date in the Payment History page
+ * 
+ * Add a hook for further filtering
+ * 
+ * @param 	payment_date the $payment->post_date variable from the payments-history page
+ * @access 	public
+ * @since 	1.1.9
+ * @return 	string filtered date
+ */
+function edd_format_payment_date( $payment_date ) {
+	 $payment_filtered_date = apply_filters( 'edd_payment_date_filter', $payment_date );
+	
+	 if( $payment_filtered_date === $payment_date ) {
+	 	return date( get_option('date_format'), strtotime($payment_date) ); 
+	 }
+	 
+	 return $payment_filtered_date;
+}
+


### PR DESCRIPTION
With regards to this issue - https://github.com/pippinsplugins/Easy-Digital-Downloads/issues/312 - added a hook that allows date filtering on the payment history page.

Sample usage:

```
add_filter('edd_payment_date_filter', 'date_payment_filter');

function date_payment_filter( $date ) {
    return date( 'Y-m-d', strtotime($date) );
}
```
