### PR TITLE
"Settings Saved" Message Missing

### DIFF
--- a/includes/admin-notices.php
+++ b/includes/admin-notices.php
@@ -38,7 +38,10 @@ function edd_admin_messages() {
 		$upgrade_notice = sprintf( __( 'The payment history needs updated. %s'), '<a href="' . wp_nonce_url( $url, 'edd_upgrade_payments_nonce' ) . '">' . __('Click to Upgrade', 'edd') . '</a>' );
 		add_settings_error( 'edd-notices', 'edd-payments-upgrade', $upgrade_notice, 'error' );
 	}
-	settings_errors( 'edd-notices' );
+	global $pagenow;
+	if ( $pagenow == 'edit.php' ) {
+		settings_errors( 'edd-notices' );
+	}
 }
 add_action( 'admin_notices', 'edd_admin_messages' );
 


### PR DESCRIPTION
I'll be the first to admit that I don't fully understand what's going on here, but I've played around with it a while and here's what I've come up with. It seems that the `settings_errors( 'edd-notices' );` call was overriding the settings errors that exist already on other settings pages. I restricted the `settings_errors( 'edd-notices' );` to only run if the current page is edit.php. This seemed to solve the problem, although I couldn't test payment "Payment deleted" and "Purchase receipt resent" messages because I don't have any purchases or payments in my test environment.
