### PR TITLE
Added filter for languages directory (translations loading), plus one missing textdomain

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -56,7 +56,13 @@ global $edd_options;
 */
 
 function edd_textdomain() {
-	load_plugin_textdomain( 'edd', false, dirname( plugin_basename( EDD_PLUGIN_FILE ) ) . '/languages/' );
+
+	// Set filter for plugin's languages directory
+	$edd_lang_dir = dirname( plugin_basename( EDD_PLUGIN_FILE ) ) . '/languages/';
+	$edd_lang_dir = apply_filters( 'edd_languages_directory', $edd_lang_dir );
+
+	// Load the translations
+	load_plugin_textdomain( 'edd', false, $edd_lang_dir );
 }
 add_action('init', 'edd_textdomain');
 

--- a/includes/admin-pages/payments-history.php
+++ b/includes/admin-pages/payments-history.php
@@ -78,7 +78,7 @@ function edd_payment_history_page() {
 			<ul class="subsubsub">
 				<li class="all">
 					<a href="<?php echo remove_query_arg('status'); ?>" <?php echo !isset( $_GET['status'] ) ? 'class="current"' : ''; ?>>
-						<?php _e('All'); ?> 
+						<?php _e('All', 'edd'); ?> 
 						<span class="count">(<?php echo $total_count; ?>)</span>
 					</a> |
 				</li>


### PR DESCRIPTION
Added a filter for the translations loading:

``` php
    // Set filter for plugin's languages directory
    $edd_lang_dir = dirname( plugin_basename( EDD_PLUGIN_FILE ) ) . '/languages/';
    $edd_lang_dir = apply_filters( 'edd_languages_directory', $edd_lang_dir );

    // Load the translations
    load_plugin_textdomain( 'edd', false, $edd_lang_dir );
```

This way, users can setup other folders so when updating the plugin custom language files won't be lost. This also allows for developers to create language-pack-plugins so non-techie users get more alternatives for up-to-date translation files.
