### PR TITLE
Update edd_get_payments to use an array of arguments.

### DIFF
--- a/includes/admin-pages/payments-history.php
+++ b/includes/admin-pages/payments-history.php
@@ -50,7 +50,16 @@ function edd_payment_history_page() {
 			$status 		= isset( $_GET['status'] ) ? $_GET['status'] : 'any';
 			$meta_key		= isset( $_GET['meta_key'] ) ? $_GET['meta_key'] : null;
 
-			$payments 		= edd_get_payments($offset, $per_page, $mode, $orderby, $order, $user, $status, $meta_key );
+			$payments 		= edd_get_payments( array(
+					'offset'   => $offset,
+					'number'   => $per_page, 
+					'mode'     => $mode, 
+					'orderby'  => $orderby, 
+					'order'    => $order, 
+					'user'     => $user, 
+					'status'   => $status, 
+					'meta_key' => $meta_key 
+			) );
 			$payment_count 	= wp_count_posts('edd_payment');
 
 			$total_count 	= $payment_count->publish + $payment_count->pending + $payment_count->refunded + $payment_count->trash;

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -23,7 +23,14 @@
 */
 
 function edd_count_payments($mode, $user = null) {
-	$payments = edd_get_payments(0, -1, $mode, 'ID', 'DESC', $user );
+	$payments = edd_get_payments( array(
+		'offset'  => 0, 
+		'number'  => -1, 
+		'mode'    => $mode, 
+		'orderby' => 'ID', 
+		'order'   => 'DESC', 
+		'user'    => $user 
+	) );
 	$count = 0;
 	if($payments) {
 		$count = count($payments);

--- a/includes/export-functions.php
+++ b/includes/export-functions.php
@@ -25,7 +25,15 @@ function edd_export_payment_history() {
 		header("Pragma: no-cache");
 		header("Expires: 0");
 
-		$payments = edd_get_payments(0, -1, $mode, $orderby, $order, $user, $status);
+		$payments = edd_get_payments( array(
+			'offset'  => 0, 
+			'number'  => -1, 
+			'mode'    => $mode, 
+			'orderby' => $orderby, 
+			'order'   => $order, 
+			'user'    => $user, 
+			'status'  => $status
+		) );
 		if($payments){
 			$i = 0;
 			echo '"' . __('ID', 'edd') .  '",';

--- a/includes/payment-actions.php
+++ b/includes/payment-actions.php
@@ -230,7 +230,11 @@ function edd_update_old_payments_with_totals( $data ) {
 	if( get_option( 'edd_payment_totals_upgraded' ) )
 		return;
 
-	$payments = edd_get_payments( 0, -1, 'all' );
+	$payments = edd_get_payments( array(
+		'offset' => 0, 
+		'number' => -1, 
+		'mode'   => 'all' 
+	) );
 	if( $payments ) {
 		foreach( $payments as $payment ) {
 			$meta = edd_get_payment_meta( $payment->ID );

--- a/includes/payment-functions.php
+++ b/includes/payment-functions.php
@@ -15,12 +15,30 @@
  *
  * Retrieve payments from the database.
  *
+ * Since 1.1.9, this function takes an array of arguments, instead of individual parameters.
+ * All of the original paremeters remain, but can be passed in any order via the array.
+ *
+ * $offset = 0, $number = 20, $mode = 'live', $orderby = 'ID', $order = 'DESC', $user = null, $status = 'any', $meta_key = null
+ *
  * @access      public
  * @since       1.0 
  * @return      object
-*/
+ */
+function edd_get_payments( $args = array() ) {
+	$defaults = array(
+		'offset'   => 0,
+		'number'   => 20,
+		'mode'     => 'live',
+		'orderby'  => 'ID',
+		'order'    => 'DESC',
+		'user'     => null,
+		'status'   => 'any',
+		'meta_key' => 'null'
+	);
 
-function edd_get_payments( $offset = 0, $number = 20, $mode = 'live', $orderby = 'ID', $order = 'DESC', $user = null, $status = 'any', $meta_key = null ) {
+	$args = wp_parse_args( $args, $defaults );
+	extract( $args );
+
 	$payment_args = array(
 		'post_type' => 'edd_payment', 
 		'posts_per_page' => $number, 
@@ -413,7 +431,15 @@ function edd_get_total_earnings() {
 	$total = (float) 0;
 	$payments = get_transient( 'edd_total_earnings' );
 	if( false === $payments ) {
-		$payments = edd_get_payments( 0, -1, 'live', 'ID', 'DESC', null, 'publish' );
+		$payments = edd_get_payments( array(
+			'offset' => 0, 
+			'number' => -1, 
+			'mode'   => 'live', 
+			'orderby' => 'ID', 
+			'order'   => 'DESC', 
+			'user'    => null, 
+			'status'  => 'publish' 
+		) );
 		set_transient( 'edd_total_earnings', $payments, 3600 );
 	}
 	if( $payments ) {


### PR DESCRIPTION
See #307. Some of the calls could now ommit some of the parameters, but I didn't want to mess with those yet. This solution is a straight forward match, and doesn't mess with any internals of the actual function. 
