### PR TITLE
Added settings link in the 'no checkout page configured' error message

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -50,8 +50,8 @@ function edd_get_purchase_link( $download_id = null, $link_text = null, $style =
 
 	global $edd_options, $post, $user_ID;
 	
-	if ( ! isset( $edd_options['purchase_page'] ) ){
-		edd_set_error( 'set_checkout', __( 'No checkout page has been configured. Visit your ', 'edd' ) . '<a href="' . site_url() . '/wp-admin/edit.php?post_type=download&page=edd-settings">' . __( 'Settings', 'edd' ) . '</a> ' . __( 'to set one.', 'edd' ) );
+	if ( ! isset( $edd_options['purchase_page'] ) && $edd_options['purchase_page'] != 0 ) {
+		edd_set_error( 'set_checkout', sprintf( __( 'No checkout page has been configured. Visit <a href="%s">Settings</a> to set one.', 'edd' ), admin_url( 'edit.php?post_type=download&page=edd-settings' ) ) );
 		edd_print_errors(); // Not really how edd_print_errors was intended to be used but didn't want to add hook 
 		// Potentially this error could be hidden from customers as a html comment just to give the developer a hint
 		// It will confuse customers that can't find the purchase link but we don't want to give too much info about the backend to them either. 


### PR DESCRIPTION
I figured to improve UIX it would make sense to link to the settings
page where users can configure the checkout page when needed. Also just
fixed a small typo that I noticed. Tested and it works. I did notice while testing that after setting a checkout page, if you set it to the blank item in the select menu, it still believes that a checkout page has been configured and won't show the error message. Not a big deal, but thought worth mentioning in the case that a user deletes their checkout page, the add to cart button will still work although won't link through to a checkout page.
