### PR TITLE
add wpml language configuration file to root of easy digital downloads plugin

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,22 @@
+<wpml-config>
+    <admin-texts>
+        <key name="edd_settings_general">
+	        <key name="purchase_page" />
+	        <key name="success_page" />
+        </key>
+        
+        <key name="edd_settings_emails">
+            <key name="from_name" />
+            <key name="from_email" />
+            <key name="purchase_subject" />
+            <key name="purchase_receipt" />
+        </key>
+        <key name="edd_settings_misc">
+            <key name="agree_label" />
+            <key name="agree_text" />
+            <key name="checkout_label" />
+        </key>
+    </admin-texts>
+</wpml-config>
+
+


### PR DESCRIPTION
the WPML Language Configuration file enables WPML users to translate the options in the settings of the Easy Digital Downloads plugin. More information can be found at
http://wpml.org/documentation/support/language-configuration-files/
