### PR TITLE
Product notes.

### DIFF
--- a/includes/css/edd-admin.css
+++ b/includes/css/edd-admin.css
@@ -29,3 +29,5 @@ tr.status-refunded td { background: #cecece; border-top-color: #ccc; }
 
 .edd_remove_repeatable { margin: 3px 0 0 5px; cursor: pointer; width: 10px; height: 10px; display: inline-block; text-indent: -9999px; overflow: hidden; }
 .edd_remove_repeatable:active, .edd_remove_repeatable:hover { background-position: -10px 0!important }
+
+textarea#edd_product_notes { width: 100%; height: 4em; margin: 0; }

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -610,9 +610,8 @@ function edd_verify_download_link($download_id, $key, $email, $expire, $file_key
  * @return      boolean
  */
 function edd_get_product_notes( $download_id ) {
-	$post  = get_post( $download_id );
-	$notes = $post->post_excerpt;
-
+	$notes = get_post_meta( $download_id, 'edd_product_notes', true );
+	
 	if ( $notes )
 		return apply_filters( 'edd_product_notes', $notes, $download_id );
 

--- a/includes/email-template.php
+++ b/includes/email-template.php
@@ -53,7 +53,6 @@ function edd_email_templage_tags($message, $payment_data, $payment_id) {
 	if( $downloads ) {
 		foreach(maybe_unserialize($payment_data['downloads']) as $download) {
 			$id = isset($payment_data['cart_details']) ? $download['id'] : $download;
-			$download_data = get_post( $id );
 			$download_list .= '<li>' . get_the_title($id) . '<br/>';
 			$download_list .= '<ul>';	
 
@@ -67,8 +66,8 @@ function edd_email_templage_tags($message, $payment_data, $payment_id) {
 							$file_url = edd_get_download_file_url($payment_data['key'], $payment_data['email'], $filekey, $id);
 							$download_list .= '<a href="' . $file_url . '">' . $file['name'] . '</a>';
 
-							if ( '' != $download_data->post_excerpt )
-								$download_list .= ' - <small>' . $download_data->post_excerpt . '</small>';
+							if ( '' != edd_get_product_notes( $id ) )
+								$download_list .= ' - <small>' . edd_get_product_notes( $id ) . '</small>';
 
 						$download_list .= '</li>';
 					}

--- a/includes/metabox.php
+++ b/includes/metabox.php
@@ -79,7 +79,7 @@ function edd_render_product_notes_field( $post_id ) {
 
 	$product_notes = edd_get_product_notes( $post_id );
 ?>
-	<textarea rows="1" cols="40" name="excerpt" id="excerpt"><?php echo $product_notes; ?></textarea>
+	<textarea rows="1" cols="40" name="edd_product_notes" id="edd_product_notes"><?php echo $product_notes; ?></textarea>
 	<p><?php _e( 'Notes and instructions about this product will automatically be attached to purchase receipts.', 'edd' ); ?></p>
 <?php
 }
@@ -425,7 +425,8 @@ function edd_download_meta_box_save($post_id) {
 			'_edd_purchase_text',
 			'_edd_purchase_style',
 			'_edd_purchase_color',
-			'_edd_hide_purchase_link'
+			'_edd_hide_purchase_link',
+			'edd_product_notes'
 		)
 	);
 	foreach($fields as $field) {


### PR DESCRIPTION
Add optional product notes to download. Uses post excerpts, so no special stuff really needed to be added. Not sure if I chose the best way to present the notes in the email, but it seems to work.
