### PR TITLE
Update includes/template-functions.php

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -174,7 +174,7 @@ function edd_after_download_content( $content ) {
 	
 	global $post;
 	
-	if ( $post->post_type == 'download' && is_singular() && is_main_query() ) {
+	if ( $post && $post->post_type == 'download' && is_singular() && is_main_query() ) {
 		ob_start();
 		do_action( 'edd_after_download_content', $post->ID );
 		$content .= ob_get_clean();


### PR DESCRIPTION
Fix to stop: Notice: Trying to get property of non-object in C:\apache\htdocs\wp34\wp-content\plugins\easy-digital-downloads\includes\template-functions.php on line 196
This notice appears multiple times when: WP_DEBUG = true, the oik base plugin is activated and the oik options > options page is displayed.

The fix checks that the global $post variable is set.
