### PR TITLE
password settings callback & failing gracefully

### DIFF
--- a/includes/register-settings.php
+++ b/includes/register-settings.php
@@ -678,7 +678,7 @@ function edd_password_callback($args) {
 */
 
 function edd_missing_callback($args) {
-	echo "The <strong>" . $args['id'] . "</strong> setting's callback function is missing."; 
+	printf( __( 'The callback function used for the <strong>%s</strong> setting is missing.', 'edd' ), $args['id'] );
 }
 
 /**


### PR DESCRIPTION
if the callback function does not exist, fail gracefully by falling back to the text field
