### PR TITLE
Fixed issue with edd_format_amount()

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -62,7 +62,7 @@ function edd_format_amount( $amount ) {
 	if( $decimal_sep == ',' && false !== ( $found = strpos( $amount, $decimal_sep ) ) ) {
 		$whole = substr( $amount, 0, $sep_found );
 		$part = substr( $amount, $sep_found + 1, ( strlen( $amount ) - 1 ) );
-		$amount = $whole . '.' . $part;
+		$amount = $whole . ',' . $part;
 	}
 
 	return number_format( $amount, 2, $decimal_sep, $thousands_sep );


### PR DESCRIPTION
Fixed an issue with the `edd_format_amount()` function in the [`formatting.php`](https://github.com/pippinsplugins/Easy-Digital-Downloads/blob/master/includes/formatting.php) file.

A check was being run if the decimal separator was a comma and if it was, it was returning a period instead of the comma causing the Purchase Receipt to display a period instead of a comma.

This has been tested and is working correctly on the Downloads page, Checkout page, Purchase History page and the Purchase Receipt.
