### PR TITLE
Fixed Formatting Issue

### DIFF
--- a/includes/payment-functions.php
+++ b/includes/payment-functions.php
@@ -573,7 +573,7 @@ function edd_get_payment_gateway( $payment_id ) {
  */
 function edd_get_payment_amount( $payment_id ) {
 	$payment_meta = edd_get_payment_meta( $payment_id );
-	$amount = $payment_meta['amount'];
+	$amount = edd_currency_filter( edd_format_amount( $payment_meta['amount'] ) );
 
 	return apply_filters( 'edd_payment_amount', $amount );
 }


### PR DESCRIPTION
The incorrect formatting was displayed on the Purchase History page and wasn't taking into account different decimal/thousand separators if they'd been set from the Settings.

Tested and works.
