### PR TITLE
implementing #546 parse email template tags in subject

### DIFF
--- a/includes/email-functions.php
+++ b/includes/email-functions.php
@@ -46,7 +46,7 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true ) {
 	$from_name = isset( $edd_options['from_name'] ) ? $edd_options['from_name'] : get_bloginfo('name');
 	$from_email = isset( $edd_options['from_email'] ) ? $edd_options['from_email'] : get_option('admin_email');
 	
-	$subject = isset( $edd_options['purchase_subject'] ) && strlen( trim( $edd_options['purchase_subject'] ) ) > 0 ? edd_email_template_tags( $edd_options['purchase_subject'], $payment_data, $payment_id ) : __('Purchase Receipt', 'edd');
+	$subject = isset( $edd_options['purchase_subject'] ) && strlen( trim( $edd_options['purchase_subject'] ) ) > 0 ? edd_email_templage_tags( $edd_options['purchase_subject'], $payment_data, $payment_id ) : __('Purchase Receipt', 'edd');
 
 	$headers = "From: " . stripslashes_deep( html_entity_decode( $from_name, ENT_COMPAT, 'UTF-8' ) ) . " <$from_email>\r\n";
 	$headers .= "Reply-To: ". $from_email . "\r\n";


### PR DESCRIPTION
So, I've just taken the call to edd_email_templage_tags() which is ran on the message body and in line 49 of email-functions.php applied the same function to the subject line of outgoing email receipts.

This worked perfectly for me!
