### PR TITLE
Add filter for decimals in edd_format_amount() function

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -69,8 +69,10 @@ function edd_format_amount( $amount ) {
 		$part = substr( $amount, $sep_found + 1, ( strlen( $amount ) - 1 ) );
 		$amount = $whole . '.' . $part;
 	}
+	
+	$decimals = apply_filters( 'edd_format_amount_decimals', 2 );
 
-	return number_format( $amount, 2, $decimal_sep, $thousands_sep );
+	return number_format( $amount, $decimals, $decimal_sep, $thousands_sep );
 }
 
 


### PR DESCRIPTION
The function edd_format_amount was very restricted the amount of decimal values​​.

I'm developing a plugin for Easy Digital Downloads that will accept Bitcoins.
Certainly many users will like to change the currency format.

With this filter you can work with currencies like Bitcoin.
