### PR TITLE
Added support for WP 3.5 Button 

### DIFF
--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -23,13 +23,19 @@ if ( !defined( 'ABSPATH' ) ) exit;
 */
 
 function edd_media_button( $context ) {
-	global $pagenow, $typenow;
+	global $pagenow, $typenow, $wp_version;
 	$output = '';
-
-	// Only run in post/page creation and edit screens
+	
+	/** Only run in post/page creation and edit screens */
 	if( in_array( $pagenow, array( 'post.php', 'page.php', 'post-new.php', 'post-edit.php' ) ) && $typenow != 'download' ) {
-		$img = '<img src="' . EDD_PLUGIN_URL . 'includes/images/edd-media.png" alt="' . sprintf( __( 'Insert %s', 'edd' ), edd_get_label_singular() ) . '"/>';
-		$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox" title="' . __( 'Insert Download', 'edd' ) . '">' . $img . '</a>';
+		/* check current WP version */
+		if ( version_compare( $wp_version, '3.5', '<' ) ) {
+			$img = '<img src="' . EDD_PLUGIN_URL . 'includes/images/edd-media.png" alt="' . sprintf( __( 'Insert %s', 'edd' ), edd_get_label_singular() ) . '"/>';
+			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox" title="' . __( 'Insert Download', 'edd' ) . '">' . $img . '</a>';
+		} else {
+			$img = '<span class="wp-media-buttons-icon" style="background-image: url(' . EDD_PLUGIN_URL . 'includes/images/edd-media.png' . '); margin-top: -1px;"></span>';
+			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox button" title="' . __( 'Insert Download', 'edd' ) . '" style="padding-left: .4em;">' . $img . 'Insert Download'. '</a>';
+		}
 	}
 	return $context . $output;
 }


### PR DESCRIPTION
Added support for using WP 3.5 button styling for "Insert Download" button in Post/Page editor. 
First it will check if the current WP version is less than 3.5. 
If the condition is true, it will display the button in old format i.e. only download icon.
If the current version is 3.5 then the "Insert Download" button will appear in new format with icon and text. 
Here is a screenshot for WP 3.5 http://icustomizethesis.com/wp-content/uploads/2012/12/edd-button.jpg
