### PR TITLE
Receipt Shortcode

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -441,9 +441,9 @@ add_shortcode( 'edd_price', 'edd_download_price_shortcode' );
  * @return      string
  */
 function edd_receipt_shortcode( $atts, $content = null ) {
-	global $args;
+	global $edd_receipt_args;
 
-	$args = shortcode_atts( array(
+	$edd_receipt_args = shortcode_atts( array(
 		'error'           => __( 'Sorry, trouble retrieving payment receipt.', 'edd' ),
 		'key'             => null,
 		'price'           => true,
@@ -460,22 +460,22 @@ function edd_receipt_shortcode( $atts, $content = null ) {
 	if ( isset( $_GET[ 'purchase_key' ] ) ) {
 		$purchase_key = $_GET[ 'purchase_key' ];
 	
-		if ( ! $args[ 'key' ] )
-			return $args[ 'error' ];
+		if ( ! $edd_receipt_args[ 'key' ] )
+			return $edd_receipt_args[ 'error' ];
 	} else if ( $session ) {
 		$purchase_key = $session[ 'purchase_key' ];
 	}
 
 	// No key found
 	if ( ! $purchase_key )
-		return $args[ 'error' ];
+		return $edd_receipt_args[ 'error' ];
 
-	$args[ 'id' ] = edd_get_purchase_id_by_key( $purchase_key );
-	$user = edd_get_payment_meta_user_info( $args[ 'id' ] );
+	$edd_receipt_args[ 'id' ] = edd_get_purchase_id_by_key( $purchase_key );
+	$user = edd_get_payment_meta_user_info( $edd_receipt_args[ 'id' ] );
 
 	// Not the proper user
 	if ( $user[ 'id' ] != get_current_user_id() ) {
-		return $args[ 'error' ];
+		return $edd_receipt_args[ 'error' ];
 	}
 
 	ob_start();

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -3,9 +3,9 @@
  *
  */
 
-global $args;
+global $edd_receipt_args;
 
-$payment   = get_post( $args[ 'id' ] );
+$payment   = get_post( $edd_receipt_args[ 'id' ] );
 $meta      = edd_get_payment_meta( $payment->ID );
 $cart      = edd_get_payment_meta_cart_details( $payment->ID );
 $user      = edd_get_payment_meta_user_info( $payment->ID );
@@ -14,55 +14,55 @@ $downloads = edd_get_payment_meta_downloads( $payment->ID );
 
 <table id="edd_purchase_receipt">
 	<tbody>
-		<?php do_action( 'edd_payment_receipt_before', $payment, $args ); ?>
+		<?php do_action( 'edd_payment_receipt_before', $payment, $edd_receipt_args ); ?>
 
-		<?php if ( $args[ 'payment_id' ] ) : ?>
+		<?php if ( $edd_receipt_args[ 'payment_id' ] ) : ?>
 		<tr>
 			<td><strong><?php _e( 'Payment', 'edd' ); ?>:</strong></td>
 			<td>#<?php echo $payment->ID; ?></td>
 		</tr>
 		<?php endif; ?>
 
-		<?php if ( $args[ 'date' ] ) : ?>
+		<?php if ( $edd_receipt_args[ 'date' ] ) : ?>
 		<tr>
 			<td><strong><?php _e( 'Date', 'edd' ); ?>:</strong></td>
 			<td><?php echo date( get_option( 'date_format' ), strtotime( $meta[ 'date' ] ) ); ?></td>
 		</tr>
 		<?php endif; ?>
 
-		<?php if ( $args[ 'price' ] ) : ?>
+		<?php if ( $edd_receipt_args[ 'price' ] ) : ?>
 		<tr>
 			<td><strong><?php _e( 'Total Price', 'edd' ); ?>:</strong></td>
 			<td><?php echo edd_price( edd_get_payment_amount( $payment->ID ) ); ?></td>
 		</tr>
 		<?php endif; ?>
 
-		<?php if ( $args[ 'discount' ] ) : ?>
+		<?php if ( $edd_receipt_args[ 'discount' ] ) : ?>
 		<tr>
 			<td><strong><?php _e( 'Discount', 'edd' ); ?>:</strong></td>
 			<td><?php echo $user[ 'discount' ]; ?></td>
 		</tr>
 		<?php endif; ?>
 
-		<?php if ( $args[ 'payment_method' ] ) : ?>
+		<?php if ( $edd_receipt_args[ 'payment_method' ] ) : ?>
 		<tr>
 			<td><strong><?php _e( 'Payment Method', 'edd' ); ?>:</strong></td>
 			<td><?php echo edd_get_payment_gateway( $payment->ID ); ?></td>
 		</tr>
 		<?php endif; ?>
 
-		<?php if ( $args[ 'payment_key' ] ) : ?>
+		<?php if ( $edd_receipt_args[ 'payment_key' ] ) : ?>
 		<tr>
 			<td><strong><?php _e( 'Payment Key', 'edd' ); ?>:</strong></td>
 			<td><?php echo get_post_meta( $payment->ID, '_edd_payment_purchase_key', true ); ?></td>
 		</tr>
 		<?php endif; ?>
 
-		<?php do_action( 'edd_payment_receipt_after', $payment, $args ); ?>
+		<?php do_action( 'edd_payment_receipt_after', $payment, $edd_receipt_args ); ?>
 	</tbody>
 </table>
 
-<?php if ( $args[ 'products' ] ) : ?>
+<?php if ( $edd_receipt_args[ 'products' ] ) : ?>
 	<h3><?php echo apply_filters( 'edd_payment_receipt_products_title', __( 'Products', 'edd' ) ); ?></h3>
 
 	<table>


### PR DESCRIPTION
See #495

Usage:

`[edd_receipt]`

Certain things can be turned off:

`[edd_receipt price="0" discount="0" products="0" date="0" payment_key="0" payment_method="0" payment_id="0" key="123123123"]`

If a purchase key isn't explicitly set, there are two options:
- Load from the current session (most recent payment)
- Load for the `?purchase_key` in the URL

**Todo**
- Create a helper function to generate a "Receipt" link (`add_query_arg()` to success page)
- Something else I can't think of

Everything seems to work, but testing as usual, is needed!
