### PR TITLE
Remove Reports Log Default post_parent. 

### DIFF
--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -281,10 +281,9 @@ class EDD_Logging {
 	function get_connected_logs( $args = array() ) {
 
 		$defaults = array(
-			'post_parent' 	=> 0,
 			'post_type'		=> 'edd_log',
-			'posts_per_page'=> 30,
-			'post_status'	=> 'publish',
+			'posts_per_page'	=> 30,
+			'post_status'		=> 'publish',
 			'paged'			=> get_query_var( 'paged' ),
 			'log_type'		=> false
 		);


### PR DESCRIPTION
The post_parent = 0, would shows only top level posts, which in Payment Errors\Logs would mean that it will not return any payment errors attached(children) to a Payment.
If omitted, all payment errors/logs will be shown and will not affect other requests since they have parent post filter or are top level posts in the first place.

Please test and consider.
