### PR TITLE
Fixed CSS Bug with Purchase Button

### DIFF
--- a/templates/edd.css
+++ b/templates/edd.css
@@ -107,6 +107,7 @@ input.edd_submit_plain { background: none !important; border: none !important; p
 .edd_download_purchase_form .edd_price_options li { display: block; padding: 0; margin: 0; }
 
 .edd-submit { text-shadow: 1px 1px #FAFAFA; line-height: normal; cursor: pointer; }
+.edd-submit.button { font-size: inherit; }
 .edd-submit.plain { text-shadow: none; margin: 0; padding: 0; background: none; border: 0; }
 .edd-submit.plain:hover { text-decoration: underline; }
 


### PR DESCRIPTION
Fixed a CSS bug that occurred when clicking the `Buy Now` purchase button automatically appended to all downloads and the font size would increase when the `<input>` was hidden and the `<a>` was displayed.
