### PR TITLE
Only add hyphen for variable priced downloads on checkout

### DIFF
--- a/templates/checkout_cart.php
+++ b/templates/checkout_cart.php
@@ -25,8 +25,9 @@
 								}
 							}
 							$item_title = get_the_title( $item['id'] );
+							$variable_pricing = edd_has_variable_prices( $item['id'] );
 							if ( !empty( $item['options'] ) ) {
-								$item_title .= ' - ' . edd_get_price_name( $item['id'], $item['options'] );
+								$item_title .= $variable_pricing ? ' - ' . edd_get_price_name( $item['id'], $item['options'] ) : edd_get_price_name( $item['id'], $item['options'] );
 							}
 							echo '<span class="edd_checkout_cart_item_title">' . esc_html( $item_title ) . '</span>';
 						?>


### PR DESCRIPTION
On the checkout page, all downloads have a hyphen at the end of the download name, regardless of being a variable priced download or not. This will only add the hyphen if it's a variable priced download.
