### PR TITLE
Dashboard widget breaks dashboard

### DIFF
--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -216,6 +216,6 @@ function edd_dashboard_sales_widget() {
 				</tbody>
 			</table>
 		</div>
+		<?php } // End if ?>
 	</div>
-	<?php } // End if
-}
+<?php }


### PR DESCRIPTION
Per [this support request](https://easydigitaldownloads.com/support/topic/admin-dashboard/#post-28805), I took a look at the EDD dashboard widgets and there is, in fact, an issue. The final </div> should be outside the endif, not inside. This results in an incorrectly closed div, throwing off the rest of the page.
