### PR TITLE
Serialize form for AJAX request

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -72,7 +72,7 @@ jQuery(document).ready(function ($) {
             item_price_ids[0] = download;
         }
 
-        var action = $this.data('action'),
+        var action = $this.data('action');
         var data = $(form).serialize() + '&action=' + action + '&price_ids=' + item_price_ids + '&nonce=' + edd_scripts.ajax_nonce;
 
         $.post(edd_scripts.ajaxurl, data, function (cart_item_response) {


### PR DESCRIPTION
Serialize the form instead of posting only EDD inputs. Allows for posting of custom fields via AJAX.
