### PR TITLE
Add $required_fields array for edd_purchase_form_validate_logged_in_user function

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -264,6 +264,23 @@ function edd_purchase_form_validate_agree_to_terms() {
 
 
 /**
+ * Purchase Form Required Fields
+ *
+ * @access      private
+ * @since       1.5
+ * @return      array
+*/
+function edd_purchase_form_required_fields() {
+	$required_fields = array(
+		'edd_first' => array(
+			'error_id' => 'invalid_first_name',
+			'error_message' => __( 'Please enter your first name.', 'edd' )
+		)
+	);
+	return apply_filters( 'edd_purchase_form_required_fields', $required_fields );
+}
+
+/**
  * Purchase Form Validate Logged In User
  *
  * @access      private
@@ -285,23 +302,15 @@ function edd_purchase_form_validate_logged_in_user() {
 		// Get the logged in user data
 		$user_data = get_userdata( $user_ID );
 
-		// required form fields
-		$required_fields = array(
-			'user_first'
-		);
-
-		$required_fields = apply_filters( 'edd_purchase_form_required_fields', $required_fields );
-		
 		if( ! is_email( $_POST['edd_email'] ) ) {
 			edd_set_error( 'invalid_email', __( 'Please enter a valid email address.', 'edd' ) );
 		}
 
-		if( in_array( 'user_first', $required_fields ) && empty( $_POST['edd_first'] ) ) {
-			edd_set_error( 'invalid_first_name', __( 'Please enter your first name.', 'edd' ) );
-		}
-
-		if ( in_array( 'user_last', $required_fields ) && empty( $_POST['edd_last'] ) ) {
-			edd_set_error( 'invalid_last_name', __( 'Please enter your last name.', 'edd' ) );
+		// Loop through required fields and show error messages
+		foreach( edd_purchase_form_required_fields() as $field_name => $value ) {		
+			if( in_array( $value, edd_purchase_form_required_fields() ) && empty( $_POST[ $field_name ] ) ) {
+				edd_set_error( $value['error_id'], $value['error_message'] );
+			}
 		}
 
 		// Verify data
@@ -511,8 +520,11 @@ function edd_purchase_form_validate_guest_user() {
 		edd_set_error( 'email_empty', __( 'Enter an email', 'edd' ) );
 	}
 
-	if ( empty( $_POST['edd_first'] ) ) {
-		edd_set_error( 'invalid_name', __( 'Please enter your first name.', 'edd' ) );
+	// Loop through required fields and show error messages
+	foreach( edd_purchase_form_required_fields() as $field_name => $value ) {		
+		if( in_array( $value, edd_purchase_form_required_fields() ) && empty( $_POST[ $field_name ] ) ) {
+			edd_set_error( $value['error_id'], $value['error_message'] );
+		}
 	}
 
 	return $valid_user_data;


### PR DESCRIPTION
Allows filtering of required fields on purchase form. 

I've left the first name field as required, but making the last name required is possible through the new `edd_purchase_form_required_fields` filter. Also possible is removing both the first name and last name from the validation by returning an empty array.

https://easydigitaldownloads.com/support/topic/hook-added-to-edd_purchase_form_validate_logged_in_user-function/#post-29781
