### PR TITLE
Add error message for a guest user at checkout

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -504,7 +504,7 @@ function edd_purchase_form_validate_guest_user() {
 
 	// Show error message if user must be logged in
 	if( edd_logged_in_only() ) {
-		edd_set_error( 'logged_in_only', __( 'Only logged in users can purchase files', 'edd' ) );
+		edd_set_error( 'logged_in_only', __( 'You must be logged into an account to purchase.', 'edd' ) );
 	}
 
 	// Get the guest email


### PR DESCRIPTION
If `Require that users be logged-in to purchase files.` is enabled, and `Display the registration and login forms on the checkout page for non-logged-in users.` is disabled, there is no visual indication of what is happening (page just refreshes after clicking purchase). 

This will set an error message on form submission to let the user know that only logged in users can purchase files.
