### PR TITLE
Added option to preselect variable option

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -174,7 +174,7 @@ function edd_purchase_variable_pricing( $download_id ) {
 						esc_attr( 'edd_price_option_' . $download_id ),
 						esc_attr( $key ),
 						esc_html( $price['name'] . ' - ' . edd_currency_filter( edd_format_amount( $amount ) ) ),
-						checked( isset( $_GET['price_option'] ) ? $_GET['price_option'] : null, esc_attr( $key ), 0 )
+						checked( isset( $_GET['price_option'] ), $key, false )
 					);
 				endforeach;
 			endif;


### PR DESCRIPTION
I've added this functionality for people to create URLs which automatically select the variable pricing option.

It looks for `price_option` added to the URL using `$_GET` and then matches the value from the GET variable to the variable price option and automatically selects that radio button.

See here: https://easydigitaldownloads.com/support/topic/link-to-product-with-price-option-preselected/.
