### PR TITLE
Add filter to item before template

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -80,6 +80,8 @@ function edd_ajax_add_to_cart() {
 					'id'      => $_POST['download_id'],
 					'options' => $options
 				);
+				
+				$item = apply_filters( 'edd_ajax_pre_cart_item_template', $item );
 
 				$cart_item    = edd_get_cart_item_template( $key, $item, true );
 


### PR DESCRIPTION
It isn't currently possible (as far as I'm aware) to filter an item before it gets sent to the template (using Ajax).

It can be filtered using "edd_cart_item" but only _after_ the template has been set, an item cannot be modified before this. Would be useful is custom options have been set in the item.
