### PR TITLE
Radio button not always clickable + make payment option entirely clickable

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -385,13 +385,13 @@ function edd_payment_mode_select() {
 		<fieldset id="edd_payment_mode_select">
 			<?php do_action('edd_payment_mode_before_gateways'); ?>
 			<p id="edd-payment-mode-wrap">
-				<label for="edd-gateway"><?php _e( 'Select Payment Method', 'edd' ); ?><label><br/>
+				<?php _e( 'Select Payment Method', 'edd' ); ?><br/>
 				<?php
 				foreach($gateways as $gateway_id => $gateway) :
 					$checked = checked( $gateway_id, edd_get_default_gateway(), false );
-					echo '<span class="edd-gateway-option" id="edd-gateway-option-' . esc_attr( $gateway_id ) . '">';
+					echo '<label for="edd-gateway-' . esc_attr( $gateway_id ) . '" class="edd-gateway-option" id="edd-gateway-option-' . esc_attr( $gateway_id ) . '">';
 						echo '<input type="radio" name="payment-mode" class="edd-gateway" id="edd-gateway-' . esc_attr( $gateway_id ) . '" value="' . esc_attr( $gateway_id ) . '"' . $checked . '>' . esc_html( $gateway['checkout_label'] ) . '</option>';
-					echo '</span>';
+					echo '</label>';
 				endforeach;
 				?>
 			</p>


### PR DESCRIPTION
- Fixes radio input not being clickable all the time. Sometimes it takes 3-5 clicks to register the option
- Swapped `<span>`'s for `<label>`'s and added "for" attribute so each payment option is entirely clickable.

Do we need the id and class attributes for the label elements? I don't think it needs either
