### PR TITLE
Remove <p> tag from edd_checkout_submit() that is causing 2 empty <p> tags in markup

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -517,7 +517,7 @@ add_action( 'edd_purchase_form_before_submit', 'edd_checkout_final_total', 999 )
 function edd_checkout_submit() {
 ?>
 	<fieldset id="edd_purchase_submit">
-		<p id="edd-purchase-submit-wrap">
+		
 			<?php do_action( 'edd_purchase_form_before_submit' ); ?>
 
 			<?php edd_checkout_hidden_fields(); ?>
@@ -525,7 +525,6 @@ function edd_checkout_submit() {
 			<?php echo edd_checkout_button_purchase(); ?>
 
 			<?php do_action( 'edd_purchase_form_after_submit' ); ?>
-		</p>
 
 		<?php if ( ! edd_is_ajax_enabled() ) { ?>
 			<p class="edd-cancel"><a href="javascript:history.go(-1)"><?php _e( 'Go back', 'edd' ); ?></a></p>


### PR DESCRIPTION
- Causes 2 empty `<p>` tag's in markup, one at top and one at bottom, resulting in unnecessary space in themes when the `<p>` has margin bottom or line height applied to it.
- The submit button appears inside `<p>` tag in the code, but outside in html markup

Can't see any other reason to keep it there. When firing any functions on the hook, a developer could add their own wrapper if necessary.

![Screen Shot 2013-03-07 at 12 50 00 PM](https://f.cloud.github.com/assets/52581/230233/94bdb200-86b8-11e2-9194-1b2c188bdbf7.png)
