### PR TITLE
Fix double item separator on downloads cart widget

### DIFF
--- a/includes/cart/template.php
+++ b/includes/cart/template.php
@@ -82,7 +82,7 @@ function edd_get_cart_item_template( $cart_key, $item, $ajax = false ) {
 	$price      = edd_get_cart_item_price( $id, $options );
 
 	if ( ! empty( $options ) ) {
-		$title .= ' <span class="edd-cart-item-separator">-</span> ' . edd_get_price_name( $id, $item['options'] );
+		$title .= ( edd_has_variable_prices( $item['id'] ) ) ? ' <span class="edd-cart-item-separator">-</span> ' . edd_get_price_name( $id, $item['options'] ) : edd_get_price_name( $id, $item['options'] );
 	}
 
 	ob_start();


### PR DESCRIPTION
This fixes the double separator for normal priced downloads shown on the downloads cart widget, and only adds the separator for variable priced downloads.

Before:

`Download Name - - $5.00 - remove`

After:

`Download Name - $5.00 - remove`

Variable priced downloads look the same as before:

`Download Name - Price Option Name - $5.00 - remove`
