### PR TITLE
Only show button colour dropdown if colors exist in array

### DIFF
--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -109,16 +109,19 @@ function edd_admin_footer_for_thickbox() {
 						?>
 					</select>
 				</div>
+				<?php 
+				$colors = edd_get_button_colors();
+				if( $colors ) { ?>
 				<div id="edd-color-choice" style="display: none;">
 					<select id="select-edd-color" style="clear: both; display: block; margin-bottom: 1em;">
 						<option value=""><?php _e('Choose a button color', 'edd'); ?></option>
 						<?php
-							$colors = edd_get_button_colors();
 							foreach ( $colors as $key => $color )
 								echo '<option value="' . str_replace( ' ', '_', $key ) . '">' . $color . '</option>';
 						?>
 					</select>
 				</div>
+				<?php } ?>
 				<div>
 					<input type="text" class="regular-text" id="edd-text" value="" placeholder="<?php _e( 'Link text . . .', 'edd' ); ?>"/>
 				</div>


### PR DESCRIPTION
Prevents button colour dropdown from being shown if no colours exist in the array. I've removed the colours using the `edd_button_colors` filter as I want my button colours to be consistant and controlled from the theme's overall styling.
