### PR TITLE
Proposed change to CPTs to better define plural names.

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -190,7 +190,7 @@ function edd_setup_download_taxonomies() {
 
 	/** Categories */
 	$category_labels = array(
-		'name' 				=> _x( 'Categories', 'taxonomy general name', 'edd' ),
+		'name' 				=> _x( 'Download Categories', 'taxonomy general name', 'edd' ),
 		'singular_name' 	=> _x( 'Category', 'taxonomy singular name', 'edd' ),
 		'search_items' 		=> __( 'Search Categories', 'edd'  ),
 		'all_items' 		=> __( 'All Categories', 'edd'  ),
@@ -216,7 +216,7 @@ function edd_setup_download_taxonomies() {
 
 	/** Tags */
 	$tag_labels = array(
-		'name' 				=> _x( 'Tags', 'taxonomy general name', 'edd' ),
+		'name' 				=> _x( 'Download Tags', 'taxonomy general name', 'edd' ),
 		'singular_name' 	=> _x( 'Tag', 'taxonomy singular name', 'edd' ),
 		'search_items' 		=> __( 'Search Tags', 'edd'  ),
 		'all_items' 		=> __( 'All Tags', 'edd'  ),


### PR DESCRIPTION
In certain places, notably the Appearance->Menus page, it is difficult for a user to differentiate between the built-in Tags and Categories widget and the EDD equivalents. This tweak changes the plural names to include 'Downloads', which simplifies this process without negatively impacting other areas of the platform.
