### PR TITLE
#1079 - EDD_API: Pending Sales are retrieved

### DIFF
--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -923,7 +923,7 @@ class EDD_API {
 	public function get_recent_sales() {
 		$sales = array();
 
-		$query = edd_get_payments( array( 'number' => $this->per_page(), 'page' => $this->get_paged() ) );
+		$query = edd_get_payments( array( 'number' => $this->per_page(), 'page' => $this->get_paged(), 'status' => 'publish' ) );
 
 		if ( $query ) {
 			$i = 0;


### PR DESCRIPTION
This should fix to only pull in items that are 'complete' by getting only post status "publish".
