### PR TITLE
#1026 - Enhancement to stats API response

### DIFF
--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -911,7 +911,7 @@ class EDD_API {
 			$stats['customers']['total_customers'] = $count[0];
 
 			return $stats;
-		} elseif ( $args['type'] === null ) {
+		} elseif ( empty( $args['type'] ) ) {
 			$stats = array();
 			$stats = array_merge( $stats, $this->get_default_sales_stats() );
 			$stats = array_merge ( $stats, $this->get_default_earnings_stats() );


### PR DESCRIPTION
This should do the trick. Sets up a possible 'null' type, and if so returns the default data sets for sales and earnings. Also moves the 'default' for both sales and earnings into a private method so as to only need 1 edit to update these displays for both null, sales (default), and earnings (default)
