### PR TITLE
Fixing Travis testSetup_Constants for version 1.5.2

### DIFF
--- a/travis/tests/easy-digital-downloadsTest.php
+++ b/travis/tests/easy-digital-downloadsTest.php
@@ -96,7 +96,7 @@ class Easy_Digital_DownloadsTest extends WP_UnitTestCase {
 	public function testSetup_Constants() {
 		// At this point, since plugin is loaded these should be defined
 		// Plugin version
-		$this->assertSame( EDD_VERSION, '1.5.1' );
+		$this->assertSame( EDD_VERSION, '1.5.2' );
 
 		// Plugin Folder URL
 		$path = str_replace( 'travis/tests/', '', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
This should resolve the following Travis CI build failure:

``` text
Time: 0 seconds, Memory: 37.25Mb
There was 1 failure:
1) Easy_Digital_DownloadsTest::testSetup_Constants
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-1.5.2
+1.5.1
/home/travis/build/pippinsplugins/Easy-Digital-Downloads/travis/tests/easy-digital-downloadsTest.php:99
```
