### PR TITLE
Adds header filters on test & receipt mail functions

### DIFF
--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -54,6 +54,7 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true ) {
 	$headers .= "Reply-To: ". $from_email . "\r\n";
 	$headers .= "MIME-Version: 1.0\r\n";
 	$headers .= "Content-Type: text/html; charset=utf-8\r\n";
+	$headers = apply_filters( 'edd_receipt_headers', $headers );
 
 	// Allow add-ons to add file attachments
 	$attachments = apply_filters( 'edd_receipt_attachments', array(), $payment_id, $payment_data );
@@ -97,6 +98,7 @@ function edd_email_test_purchase_receipt() {
 	$headers .= "Reply-To: ". $from_email . "\r\n";
 	$headers .= "MIME-Version: 1.0\r\n";
 	$headers .= "Content-Type: text/html; charset=utf-8\r\n";
+	$headers = apply_filters( 'edd_test_purchase_headers', $headers );
 
 	wp_mail( edd_get_admin_notice_emails(), $subject, $message, $headers );
 }


### PR DESCRIPTION
Adds filters on the mail headers variable on payment receipt & admin test functions.
This is so other plugins can hook in and edit the headers to pass additional data along.

First use of these filters are from [this plugin](https://github.com/studioromeo/edd-bcc).
