### PR TITLE
Removes the exclusion of the 'download' CPT from RCP

### DIFF
--- a/includes/plugin-compatibility.php
+++ b/includes/plugin-compatibility.php
@@ -15,20 +15,6 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 /**
- * Removes the "Restrict This Content" meta box from Restrict Content Pro.
- *
- * @since 1.0
- * @param array $post_types Post Types
- * @return array $post_types Array with 'download' post type added
- */
-function edd_remove_restrict_meta_box( $post_types ) {
-	$post_types[] = 'download';
-
-	return $post_types;
-}
-add_filter( 'rcp_metabox_excluded_post_types', 'edd_remove_restrict_meta_box', 999 );
-
-/**
  * Disables admin sorting of Post Types Order
  *
  * When sorting downloads by price, earnings, sales, date, or name,


### PR DESCRIPTION
Based on -> https://twitter.com/pippinsplugins/status/330786609618358272

The custom post type of 'download' was being excluded from having the
Restrict Content Pro "Restrict This Content" meta box. This removes
that exclusion filter.
