### PR TITLE
Fix: PHP Notice: Trying to get property of non-object

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 function edd_get_download( $download ) {
 	if ( is_numeric( $download ) ) {
 		$download = get_post( $download );
-		if ( $download->post_type != 'download' )
+		if ( !$download || $download->post_type != 'download' )
 			return null;
 		return $download;
 	}


### PR DESCRIPTION
When purchase_link shortcode is used on a page where the download ID does not exist it throws a the following PHP notice:

`PHP Notice:  Trying to get property of non-object in /wp-content/plugins/easy-digital-downloads/includes/download-functions.php on line 25`
