### PR TITLE
Fix double empty p tag

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -445,7 +445,6 @@ function edd_terms_agreement() {
 	if ( isset( $edd_options['show_agree_to_terms'] ) ) {
 ?>
 		<fieldset id="edd_terms_agreement">
-			<p id="edd-terms-wrap">
 				<div id="edd_terms" style="display:none;">
 					<?php
 						do_action( 'edd_before_terms' );
@@ -459,7 +458,6 @@ function edd_terms_agreement() {
 				</div>
 				<label for="edd_agree_to_terms"><?php echo isset( $edd_options['agree_label'] ) ? $edd_options['agree_label'] : __( 'Agree to Terms?', 'edd' ); ?></label>
 				<input name="edd_agree_to_terms" class="required" type="checkbox" id="edd_agree_to_terms" value="1"/>
-			</p>
 		</fieldset>
 <?php
 	}


### PR DESCRIPTION
![screen shot 2013-05-30 at 10 55 31 pm](https://f.cloud.github.com/assets/52581/584445/95e67b16-c917-11e2-82bb-9f6a8faafa99.png)

I don't think we need this wrapper p tag. All it seems to do is cause an empty `<p>` tag at the top and bottom of the fieldset. There are plenty of other divs for wrapping.
