### PR TITLE
$after_widget printed event when $before_widget isn't

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -209,8 +209,8 @@ class edd_purchase_history_widget extends WP_Widget {
 					}
 
 				}
+				echo $after_widget;
 			}
-			echo $after_widget;
 		}
 	}
 


### PR DESCRIPTION
Just noticed this while browsing the source. The `$after_widget` and `$before_widget` are printed in different nested `if` statements - so if a user is logged in, but has no purchases to display the former isn't printed, but the latter is.
