### PR TITLE
make 'preapproved' payments get same access rights as 'complete' payments (issue #1232)

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -31,7 +31,7 @@ function edd_get_users_purchases( $user = 0, $number = 20, $pagination = false, 
 		$user = get_current_user_id();
 	}
 
-	$status = $status === 'complete' ? 'publish' : $status;
+	$status = $status === 'complete' || 'preapproved' ? 'publish' : $status;
 
 	$mode = edd_is_test_mode() ? 'test' : 'live';
 


### PR DESCRIPTION
I wrote up a small issue I came across with EDD and EDD Content Restriction in [issue #1232 on the main EDD repo](https://github.com/easydigitaldownloads/Easy-Digital-Downloads/issues/1232).

The little tweak here I've made seems to address this issue and works so far in testing, for me on a local installation at least.
