### PR TITLE
Fix [download_discounts] invalid argument warning.

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -153,21 +153,21 @@ function edd_discounts_shortcode( $atts, $content = null ) {
 
 	$discounts_list = '<ul id="edd_discounts_list">';
 
-	/**
-	 * Move this outside of the foreach() construct, otherwise an invalid
-	 * argument supplied warning is thrown when there are no discounts.
-	 */
 	if ( edd_has_active_discounts( $discount->ID ) ) {
 
 		foreach ( $discounts as $discount ) {
 
-			$discounts_list .= '<li class="edd_discount">';
+			if ( edd_is_discount_active( $discount->ID ) ) {
 
-				$discounts_list .= '<span class="edd_discount_name">' . edd_get_discount_code( $discount->ID ) . '</span>';
-				$discounts_list .= '<span class="edd_discount_separator"> - </span>';
-				$discounts_list .= '<span class="edd_discount_amount">' . edd_format_discount_rate( edd_get_discount_type( $discount->ID ), edd_get_discount_amount( $discount->ID ) ) . '</span>';
+				$discounts_list .= '<li class="edd_discount">';
 
-			$discounts_list .= '</li>';
+					$discounts_list .= '<span class="edd_discount_name">' . edd_get_discount_code( $discount->ID ) . '</span>';
+					$discounts_list .= '<span class="edd_discount_separator"> - </span>';
+					$discounts_list .= '<span class="edd_discount_amount">' . edd_format_discount_rate( edd_get_discount_type( $discount->ID ), edd_get_discount_amount( $discount->ID ) ) . '</span>';
+
+				$discounts_list .= '</li>';
+
+			}
 
 		}
 


### PR DESCRIPTION
An invalid argument supplied warning is thrown when there are no
discounts.
