### PR TITLE
fixes fallthrough in switch statement

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -381,16 +381,14 @@ function edd_let_to_num( $v ) {
 	$ret = substr( $v, 0, -1 );
 
 	switch ( strtoupper( $l ) ) {
-		case 'P':
+		case 'P': // fall-through
+		case 'T': // fall-through
+		case 'G': // fall-through
+		case 'M': // fall-through
+		case 'K': // fall-through
 			$ret *= 1024;
-		case 'T':
-			$ret *= 1024;
-		case 'G':
-			$ret *= 1024;
-		case 'M':
-			$ret *= 1024;
-		case 'K':
-			$ret *= 1024;
+			break;
+		default:
 			break;
 	}
 


### PR DESCRIPTION
If all cases do the same thing, no need to repeat the statement
