### PR TITLE
Move edd_display_tax_rate below purchase_submit_button_wrapper

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -99,10 +99,6 @@ function edd_get_purchase_link( $args = array() ) {
 
 		<?php do_action( 'edd_purchase_link_top', $args['download_id'] ); ?>
 
-		<?php if( edd_display_tax_rate() ) {
-			echo '<div class="edd_purchase_tax_rate">' . sprintf( __( 'Includes %1$s&#37; tax', 'edd' ), $edd_options['tax_rate'] ) . '</div>';
-		} ?>
-
 		<div class="edd_purchase_submit_wrapper">
 			<?php
 			 if ( edd_is_ajax_enabled() ) {
@@ -149,7 +145,11 @@ function edd_get_purchase_link( $args = array() ) {
 				</span>
 			<?php endif; ?>
 		</div><!--end .edd_purchase_submit_wrapper-->
-
+		
+		<?php if( edd_display_tax_rate() ) {
+			echo '<div class="edd_purchase_tax_rate">' . sprintf( __( 'Includes %1$s&#37; tax', 'edd' ), $edd_options['tax_rate'] ) . '</div>';
+		} ?>
+		
 		<input type="hidden" name="download_id" value="<?php echo esc_attr( $args['download_id'] ); ?>">
 		<?php if( ! empty( $args['direct'] ) ) { ?>
 			<input type="hidden" name="edd_action" class="edd_action_input" value="straight_to_gateway">


### PR DESCRIPTION
Changing the tax rate below the purchase button looks much better than above and it's not as confusing for the customers.
Thanks
