### PR TITLE
Pass $atts with edd_downloads_query

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -343,7 +343,7 @@ function edd_downloads_query( $atts, $content = null ) {
 	endswitch;
 
 	// Allow the query to be manipulated by other plugins
-	$query = apply_filters( 'edd_downloads_query', $query );
+	$query = apply_filters( 'edd_downloads_query', $query, $atts );
 
 	$downloads = new WP_Query( $query );
 	if ( $downloads->have_posts() ) :


### PR DESCRIPTION
One more thing, just need to pass $atts along with the filter

Then I can do this in EDD featured downloads plugin:

Add new "featured" parameter to [downloads] shortcode:
Example usage: [downloads featured="yes"]

```
function edd_fd_filter_downloads_shortcode( $out, $pairs, $atts ) {
    $out['featured'] = '';
    return $out;
}
add_filter( 'shortcode_atts_downloads', 'edd_fd_filter_downloads_shortcode', 10, 3 );
```

Filter the $query to only show the featured downloads

```
function edd_fd_filter_downloads_query( $query, $atts ) {
    if( 'yes' == $atts['featured'] )
        $query['meta_key'] = 'edd_feature_download';

    return $query;
}
add_filter( 'edd_downloads_query', 'edd_fd_filter_downloads_query', 10, 2 );
```

How awesome is that :)
