### PR TITLE
fix tax calculation for prices entered inclusive tax 

### DIFF
--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -142,14 +142,19 @@ function edd_calculate_tax( $amount, $sum = true, $country = false, $state = fal
 	$tax = 0.00;
 	$prices_include_tax = edd_prices_include_tax();
 
-	$tax = $amount * $rate;
-
 	if ( $sum ) {
 
 		if ( $prices_include_tax ) {
-			$tax = $amount - $tax;
+			$tax = $amount - (($amount / (1+$rate)) * $rate);
 		} else {
-			$tax = $amount + $tax;
+			$tax = $amount + ($amount * $rate);
+				}
+		} else {
+
+		if ( $prices_include_tax ) {
+			$tax = ($amount / (1+$rate)) * $rate;
+		} else {
+			$tax = $amount * rate;
 		}
 
 	}


### PR DESCRIPTION
see
http://easydigitaldownloads.com/support/topic/tax-issue-still-exists-if-prices-are-entered-including-taxes/
and
http://easydigitaldownloads.com/support/topic/tax-calculation-wrong-for-inclusive-taxes-patch-included/

Fixes #1450
