### PR TITLE
Sanitize Settings Data on Save

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1280,7 +1280,7 @@ function edd_hook_callback( $args ) {
  */
 function edd_settings_sanitize( $input ) {
 	add_settings_error( 'edd-notices', '', __( 'Settings Updated', 'edd' ), 'updated' );
-	return $input;
+	return apply_filters( 'edd_save_settings_before', $input );
 }
 
 /**


### PR DESCRIPTION
Allow add-on developer to call any functions like trim, strip tag etc
before saving settings data to database.
