### PR TITLE
Add the removed item ID to post remove cart

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -106,12 +106,13 @@ function edd_remove_from_cart( $cart_key ) {
 	if ( ! is_array( $cart ) ) {
 		return true; // Empty cart
 	} else {
+		$item_id = isset( $cart[ $cart_key ][ 'id' ] ) ? $cart[ $cart_key ][ 'id' ] : null;
 		unset( $cart[ $cart_key ] );
 	}
 
 	EDD()->session->set( 'edd_cart', $cart );
 
-	do_action( 'edd_post_remove_from_cart', $cart_key );
+	do_action( 'edd_post_remove_from_cart', $cart_key, $item_id );
 
 	// Clear all the checkout errors, if any
 	edd_clear_errors();


### PR DESCRIPTION
A plugin may require to know what item was removed from the cart, once it's already been removed. This can't be done with the action as it's too late.
