### PR TITLE
Filter to disable purchase receipts

### DIFF
--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * @param bool $admin_notice Whether to send the admin email notification or not (default: true)
  * @return void
  */
-function edd_email_purchase_receipt( $payment_id, $admin_notice = true, $purchase_receipt = true ) {
+function edd_email_purchase_receipt( $payment_id, $admin_notice = true ) {
 	global $edd_options;
 
 	$payment_data = edd_get_payment_meta( $payment_id );
@@ -60,7 +60,7 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true, $purchas
 	// Allow add-ons to add file attachments
 	$attachments = apply_filters( 'edd_receipt_attachments', array(), $payment_id, $payment_data );
 
-	if ( apply_filters( 'edd_email_purchase_receipt', $purchase_receipt ) ) {
+	if ( apply_filters( 'edd_email_purchase_receipt', true ) ) {
 		wp_mail( $email, $subject, $message, $headers, $attachments );
 	}
 


### PR DESCRIPTION
EDD Per Product Emails add-on needs an option to disable the standard purchase receipts sent to the customer. This is the cleanest way I can think of doing it. Any suggestions?
