### PR TITLE
Option for unified customer name field

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -65,10 +65,10 @@ function edd_register_settings() {
 					'type' => 'select',
 					'options' => $pages_options
 				),
-				'currency_settings' => array(
-					'id' => 'currency_settings',
-					'name' => '<strong>' . __( 'Currency Settings', 'edd' ) . '</strong>',
-					'desc' => __( 'Configure the currency options', 'edd' ),
+				'internationalization_settings' => array(
+					'id' => 'internationalization_settings',
+					'name' => '<strong>' . __( 'Internationalization Settings', 'edd' ) . '</strong>',
+					'desc' => __( 'Configure options for different locales', 'edd' ),
 					'type' => 'header'
 				),
 				'currency' => array(
@@ -103,6 +103,16 @@ function edd_register_settings() {
 					'type' => 'text',
 					'size' => 'small',
 					'std' => '.'
+				),
+				'customer_name_style' => array(
+					'id' => 'customer_name_style',
+					'name' => __( 'Customer Name Style', 'edd' ),
+					'desc' => __( 'Configure how customer names are stored in the database.', 'edd' ),
+					'type' => 'select',
+					'options' => array(
+						'simple' => __( 'Simple Name Field', 'edd' ),
+						'firstlast' => __( 'First Name / Last Name', 'edd' )
+					)
 				),
 				'api_settings' => array(
 					'id' => 'api_settings',

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -119,6 +119,8 @@ add_action( 'edd_purchase_form', 'edd_show_purchase_form' );
  * @return void
  */
 function edd_user_info_fields() {
+	global $edd_options;
+
 	if ( is_user_logged_in() ) :
 		$user_data = get_userdata( get_current_user_id() );
 	endif;
@@ -137,6 +139,7 @@ function edd_user_info_fields() {
 			<input class="edd-input required" type="email" name="edd_email" placeholder="<?php _e( 'Email address', 'edd' ); ?>" id="edd-email" value="<?php echo is_user_logged_in() ? $user_data->user_email : ''; ?>"/>
 		</p>
 		<?php do_action( 'edd_purchase_form_after_email' ); ?>
+		<?php if( $edd_options[ 'customer_name_style' ] == 'firstlast' ) : ?>
 		<p id="edd-first-name-wrap">
 			<label class="edd-label" for="edd-first">
 				<?php _e( 'First Name', 'edd' ); ?>
@@ -157,6 +160,18 @@ function edd_user_info_fields() {
 			<span class="edd-description"><?php _e( 'We will use this as well to personalize your account experience.', 'edd' ); ?></span>
 			<input class="edd-input" type="text" name="edd_last" id="edd-last" placeholder="<?php _e( 'Last name', 'edd' ); ?>" value="<?php echo is_user_logged_in() ? $user_data->last_name : ''; ?>"/>
 		</p>
+		<?php else : ?>
+		<p id="edd-first-name-wrap">
+			<label class="edd-label" for="edd-first">
+				<?php _e( 'Name', 'edd' ); ?>
+				<?php if( edd_field_is_required( 'edd_first' ) ) { ?>
+					<span class="edd-required-indicator">*</span>
+				<?php } ?>
+			</label>
+			<span class="edd-description"><?php _e( 'We will use this to personalize your account experience.', 'edd' ); ?></span>
+			<input class="edd-input required" type="text" name="edd_first" placeholder="<?php _e( 'Name', 'edd' ); ?>" id="edd-first" value="<?php echo is_user_logged_in() ? $user_data->display_name : ''; ?>"/>
+		</p>
+		<?php endif; ?>
 		<?php do_action( 'edd_purchase_form_user_info' ); ?>
 	</fieldset>
 	<?php


### PR DESCRIPTION
Separating names into "first name" and "last name", and then referring to people by their first name, is a pretty anglo-centric approach.  Other cultures have other conventions.  For my case, in China it's _way_ too familiar for a business to refer to a customer by their given name.

The best culturally-neutral approach is just to have a simple free text field for the name and let people tell you how they want you to refer to them.  This is especially true when the name is only needed "to personalize your account experience."

This change provides an option to switch between first name / last name and simple name field.
