### PR TITLE
Adding filters to admin script loader

### DIFF
--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -181,10 +181,10 @@ function edd_load_admin_scripts( $hook ) {
 	if ( is_object( $post ) && ! in_array( $post->post_type, $edd_cpt ) )
 		return;
 
-	if ( in_array( $hook, apply_filters( 'edd_load_scripts_for_reports', array( 'download_page_edd-reports', ) ) ) ) {
+	if ( in_array( $hook, apply_filters( 'edd_load_scripts_for_reports', array( 'download_page_edd-reports' ) ) ) ) {
 		wp_enqueue_script( 'jquery-flot', $js_dir . 'jquery.flot' . $suffix . '.js' );
 	}
-	if ( in_array( $hook, apply_filters( 'edd_load_scripts_for_discounts', array( 'download_page_edd-discounts', ) ) ) ) {
+	if ( in_array( $hook, apply_filters( 'edd_load_scripts_for_discounts', array( 'download_page_edd-discounts' ) ) ) ) {
 		wp_enqueue_script( 'jquery-ui-datepicker' );
 		$ui_style = ( 'classic' == get_user_option( 'admin_color' ) ) ? 'classic' : 'fresh';
 		wp_enqueue_style( 'jquery-ui-css', $css_dir . 'jquery-ui-' . $ui_style . $suffix . '.css' );


### PR DESCRIPTION
Adds three more filters to the edd_load_admin_scripts() function to
allow extension pages to use the same scripts.
