### PR TITLE
Fix undefined offset if there are no variable prices

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -362,7 +362,7 @@ function edd_get_cart_item_price_id( $item = array() ) {
 function edd_get_cart_item_price_name( $item = array() ) {
 	$price_id = (int) edd_get_cart_item_price_id( $item );
 	$prices   = edd_get_variable_prices( $item['id'] );
-	$name     = $prices[ $price_id ]['name'];
+	$name     = !empty( $prices ) ? $prices[ $price_id ]['name'] : '';
 	return apply_filters( 'edd_get_cart_item_price_name', $name, $item['id'], $price_id, $item );
 }
 


### PR DESCRIPTION
If there are no variable prices for an item the array is empty which results in a undefined offset
