### PR TITLE
Remove <br> from subtotal excluding tax text

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -383,7 +383,7 @@ function edd_cart_subtotal() {
 
 	if ( edd_is_cart_taxed() ) {
 		if ( edd_prices_show_tax_on_checkout() ) {
-			$price .= '<br/><span style="font-weight:normal;text-transform:none;">' . __( '(excl. tax)', 'edd' ) . '</span>';
+			$price .= '<span class="edd_cart_subtotal_tax_text" style="font-weight:normal;text-transform:none;">' . __( '(excl. tax)', 'edd' ) . '</span>';
 		}
 	}
 


### PR DESCRIPTION
Having that <br> tag over there means less ways to customize. Removing and adding a new class to that span element means same options can be preserved as well. 
TODO: include inline style into the new class created.
