### PR TITLE
Add product details widget

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -247,9 +247,9 @@ class EDD_Product_Details_Widget extends WP_Widget {
 	public function __construct() {
 		parent::__construct(
 			'edd_product_details',
-			sprintf( __( 'EDD %s Details', 'edd' ), edd_get_label_singular() ),
+			sprintf( __( '%s Details', 'edd' ), edd_get_label_singular() ),
 			array( 
-				'description' => sprintf( __( '%s details widget', 'edd' ), edd_get_label_singular() ),
+				'description' => sprintf( __( 'Display the details of a specific %s', 'edd' ), edd_get_label_singular() ),
 			)
 		);
 	}


### PR DESCRIPTION
Need to flesh out the default HTML, make it easier to filter etc.

Because this widget can show the "current" download, what's the best way to prevent it from NOT showing the widget when the page is a normal WP page, ie an about page. Because there's no $download_id it will use the current page's ID and not function correctly. If I simply use `!is_singular('download)` then the other widget instances (when having multiple copies) fail to load.

![screen shot 2013-11-02 at 12 55 12 pm](https://f.cloud.github.com/assets/52581/1458110/fb16cbfa-4354-11e3-9871-383d3854bcf5.png)
![screen shot 2013-11-02 at 12 54 56 pm](https://f.cloud.github.com/assets/52581/1458111/fb380e96-4354-11e3-9fc7-089d07b96c8b.png)
