### PR TITLE
Fix bug with email preview only showing once

### DIFF
--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -651,9 +651,10 @@ jQuery(document).ready(function ($) {
 
 			// Show the email template previews
 			if( $('#email-preview-wrap').length ) {
+				var emailPreview = $('#email-preview');
 				$('#open-email-preview').colorbox({
 					inline: true,
-					href: '#email-preview',
+					href: emailPreview,
 					width: '80%',
 					height: 'auto'
 				});


### PR DESCRIPTION
Once the color box has been shown once it will be empty if the preview button is clicked again. This fixes that.
