### PR TITLE
Don't run before/after download content hooks if password required (and not provided)

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -243,7 +243,7 @@ add_action( 'edd_purchase_link_top', 'edd_purchase_variable_pricing', 10 );
 function edd_before_download_content( $content ) {
 	global $post;
 
-	if ( $post && $post->post_type == 'download' && is_singular( 'download' ) && is_main_query() ) {
+	if ( $post && $post->post_type == 'download' && is_singular( 'download' ) && is_main_query() && !post_password_required() ) {
 		ob_start();
 		$content .= ob_get_clean();
 		do_action( 'edd_before_download_content', $post->ID );
@@ -268,7 +268,7 @@ add_filter( 'the_content', 'edd_before_download_content' );
 function edd_after_download_content( $content ) {
 	global $post;
 
-	if ( $post && $post->post_type == 'download' && is_singular( 'download' ) && is_main_query() ) {
+	if ( $post && $post->post_type == 'download' && is_singular( 'download' ) && is_main_query() && !post_password_required() ) {
 		ob_start();
 		do_action( 'edd_after_download_content', $post->ID );
 		$content .= ob_get_clean();


### PR DESCRIPTION
If you have a post / page / cpt with a password set on it, then you probably don't want someone to purchase it until the correct password has been provided.

`post_password_required()` checks to see if there is a password set on the post, and then if it's required.
- It returns `false` if no password is set
- It returns `false` if the password has already been provided
- It returns `true` if the password is set and has not been provided or was incorrect
