### PR TITLE
Set user ID to -1 (guest) if does not exist

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -433,9 +433,11 @@ function edd_record_download_in_log( $download_id, $file_id, $user_info, $ip, $p
 		'log_type'		=> 'file_download'
 	);
 
+	$user_id = isset( $user_info['id'] ) ? $user_info['id'] : (int) -1;
+	
 	$log_meta = array(
 		'user_info'	=> $user_info,
-		'user_id'	=> (int) $user_info['id'],
+		'user_id'	=> $user_id,
 		'file_id'	=> (int) $file_id,
 		'ip'		=> $ip,
 		'payment_id'=> $payment_id,
@@ -890,12 +892,13 @@ function edd_verify_download_link( $download_id = 0, $key = '', $email = '', $ex
 					if ( $cart_item['id'] != $download_id )
 						continue;
 
-					$price_options = isset( $cart_item['item_number']['options'] ) ? $cart_item['item_number']['options'] : false;
+					$price_options 	= isset( $cart_item['item_number']['options'] ) ? $cart_item['item_number']['options'] : false;
+					$price_id 		= isset( $price_options['price_id'] ) ? $price_options['price_id'] : false;
 
 					$file_condition = edd_get_file_price_condition( $cart_item['id'], $file_key );
 
 					// Check to see if the file download limit has been reached
-					if ( edd_is_file_at_download_limit( $cart_item['id'], $payment->ID, $file_key, $price_options['price_id'] ) )
+					if ( edd_is_file_at_download_limit( $cart_item['id'], $payment->ID, $file_key, $price_id ) )
 						wp_die( apply_filters( 'edd_download_limit_reached_text', __( 'Sorry but you have hit your download limit for this file.', 'edd' ) ), __( 'Error', 'edd' ) );
 
 					// If this download has variable prices, we have to confirm that this file was included in their purchase


### PR DESCRIPTION
I believe this is related to the download limit bug.
https://easydigitaldownloads.com/support/topic/file-download-limit-and-download-link-expiration-not-working/page/3/

WP 3.7.1
Tested with: EDD github master, 1.8.3.1 stable and 1.8.2

Making a purchase as a guest (ie not creating an account at checkout) and then clicking the link of the download on the purchase confirmation page, results in the errors below, which repeat on different line numbers.

A var_dump of $user_info inside the edd_record_download_in_log() function reveals that the ID does not exist as per the first error below. Patch sets guest to -1 if it does not exist. 

`Notice: Undefined index: id in /wp-content/plugins/easy-digital-downloads/includes/download-functions.php on line 434`

`Warning: Cannot modify header information - headers already sent by (output started at /wp-content/plugins/easy-digital-downloads/includes/download-functions.php:434) in /wp-content/plugins/easy-digital-downloads/includes/process-download.php on line 84`

`Warning: Cannot modify header information - headers already sent by (output started at /wp-content/plugins/easy-digital-downloads/includes/download-functions.php:434) in /wp-content/plugins/easy-digital-downloads/includes/process-download.php on line 146`
