### PR TITLE
Add edd_downloadable_files filter

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -748,3 +748,13 @@ function edd_checkout_hidden_fields() {
 	<input type="hidden" name="edd-gateway" value="<?php echo edd_get_chosen_gateway(); ?>" />
 <?php
 }
+
+/**
+ * Show a download's files in the purchase receipt
+ *
+ * @since 1.8.6
+ * @return boolean
+*/
+function edd_receipt_show_download_files( $item_id ) {
+	return apply_filters( 'edd_receipt_show_download_files', true, $item_id );
+}

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -565,14 +565,3 @@ if ( ! function_exists( 'cal_days_in_month' ) ) {
 		return date( 't', mktime( 0, 0, 0, $month, 1, $year ) );
 	}
 }
-
-
-/**
- * Show a download's files in the purchase receipt
- *
- * @since 1.8.6
- * @return boolean
-*/
-function edd_receipt_show_download_files( $item_id ) {
-	return apply_filters( 'edd_receipt_show_download_files', true, $item_id );
-}


### PR DESCRIPTION
This new filter would allow sites that sell "services" (rather than downloads), the ability to remove the "No downloadable files found." text on the purchase confirmation page.
