### PR TITLE
Fix: new user email notification

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -569,7 +569,7 @@ function edd_register_and_login_new_user( $user_data = array() ) {
 		return -1;
 
 	// Allow themes and plugins to hook
-	do_action( 'edd_insert_user', $user_id );
+	do_action( 'edd_insert_user', $user_id, $user_data );
 
 	// Login new user
 	edd_log_user_in( $user_id, $user_data['user_login'], $user_data['user_pass'] );


### PR DESCRIPTION
`wp_new_user_notification()` in `edd_new_user_notification()` sends an email both to the admin and the new user at signup. 

Currently, only the admin notification is being received. The user isn't receiving a notification because the 2nd parameter of wp_new_user_notification() is blank (should be plain text password).
#1692
