### PR TITLE
Restructure of edd_register_and_login_new_user()

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -551,7 +551,7 @@ function edd_register_and_login_new_user( $user_data = array() ) {
 	if( edd_get_errors() )
 		return -1;
 
-	$user_args = array(
+	$user_args = apply_filters( 'edd_insert_user_args', array(
 		'user_login'      => isset( $user_data['user_login'] ) ? $user_data['user_login'] : null,
 		'user_pass'       => isset( $user_data['user_pass'] ) ? $user_data['user_pass'] : null,
 		'user_email'      => $user_data['user_email'],
@@ -559,10 +559,10 @@ function edd_register_and_login_new_user( $user_data = array() ) {
 		'last_name'       => $user_data['user_last'],
 		'user_registered' => date('Y-m-d H:i:s'),
 		'role'            => get_option( 'default_role' )
-	);
+	), $user_data );
 
 	// Insert new user
-	$user_id = wp_insert_user( apply_filters( 'edd_insert_user_args', $user_args ) );
+	$user_id = wp_insert_user( $user_args );
 
 	// Validate inserted user
 	if ( is_wp_error( $user_id ) )


### PR DESCRIPTION
This slight restructure keeps the code functioning how it did before, but allows $user_args to now be available for use later on in the `edd_register_and_login_new_user()` function.

I'm rebuilding the way EDD Auto Register works and keeping it as close to EDD as possible, whereby it registers the user before sending to payment gateway, regardless of whether the payment is marked as completed etc. Currently the plugin cannot register users if using an off-site gateway. 

Essentially, I'm using the `edd_insert_user_args` filter to create a random password and setting the user_login to the users email, and then sending it back to the function. I need to be able to pass the new login and password to the `edd_log_user_in()` function.

This is how it is currently
`edd_log_user_in( $user_id, $user_data['user_login'], $user_data['user_pass'] );`

I need this to use the new login and password that I have filtered in $user_args

`edd_log_user_in( $user_id, $user_args['user_login'], $user_args['user_pass'] );`

What is the cleanest way you can think of to accomplish this?
