### PR TITLE
Allow $user_data to be filtered before edd_log_user_in()

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -568,6 +568,9 @@ function edd_register_and_login_new_user( $user_data = array() ) {
 	if ( is_wp_error( $user_id ) )
 		return -1;
 
+	// Allow themes and plugins to filter the user data
+	$user_data = apply_filters( 'edd_insert_user_data', $user_data, $user_args );
+
 	// Allow themes and plugins to hook
 	do_action( 'edd_insert_user', $user_id, $user_data );
 


### PR DESCRIPTION
This would allow the user_data to be filtered just before sending it to edd_log_user_in(), perfect in the case of EDD Auto Register. 

I looked at your suggestion in #1750, but from what I can see, the `edd_insert_user_args` filter in the same function only allows manipulation of the user_args, not user_data. Tested and works beautifully :)
