### PR TITLE
Split Metabox Tweaks

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -67,6 +67,7 @@ textarea#edd_product_notes { width: 100%; height: 4em; margin: 0; }
 #edd-purchased-files .inside { margin: 0; padding: 0; }
 
 .edd-price-field { width: 80px; }
+.edd_repeatable_upload_wrapper .pricing select, .edd_repeatable_product_wrapper .edd-select { min-width: 100%; }
 
 /** Stats */
 #edd_product_stats .label { width: 70px; display: inline-block; }

--- a/includes/admin/downloads/contextual-help.php
+++ b/includes/admin/downloads/contextual-help.php
@@ -38,12 +38,8 @@ function edd_downloads_contextual_help() {
 
 	$screen->add_help_tab( array(
 		'id'	    => 'edd-download-configuration',
-		'title'	    => __( 'Download Configuration', 'edd' ),
+		'title'	    => sprintf( __( '%s Settings', 'edd' ), edd_get_label_singular() ),
 		'content'	=>
-			'<p>' . __( '<strong>Pricing Options</strong> - Either define a single fixed price, or enable variable pricing. By enabling variable pricing, multiple download options and prices can be configured.', 'edd' ) . '</p>' .
-
-			'<p>' . __( '<strong>File Downloads</strong> - Define download file names and their respsective file URL. Multiple files can be assigned to a single price, or variable prices.', 'edd' ) . '</p>' .
-
 			'<p>' . __( '<strong>File Download Limit</strong> - Define how many times customers are allowed to download their purchased files. Leave at 0 for unlimited. Resending the purchase receipt will permit the customer one additional download if their limit has already been reached.', 'edd' ) . '</p>' .
 
 			'<p>' . __( '<strong>Accounting Options</strong> - If enabled, define an individual SKU or product number for this download.', 'edd' ) . '</p>' .
@@ -52,8 +48,27 @@ function edd_downloads_contextual_help() {
 	) );
 
 	$screen->add_help_tab( array(
+		'id'	    => 'edd-download-prices',
+		'title'	    => sprintf( __( '%s Prices', 'edd' ), edd_get_label_singular() ),
+		'content'	=>
+			'<p>' . __( '<strong>Enable variable pricing</strong> - By enabling variable pricing, multiple download options and prices can be configured.', 'edd' ) . '</p>' .
+
+			'<p>' . __( '<strong>Enable multi-option purchases</strong> - By enabling multi-option purchases customers can add multiple variable price items to their cart at once.', 'edd' ) . '</p>'
+	) );
+
+	$screen->add_help_tab( array(
+		'id'	    => 'edd-download-files',
+		'title'	    => sprintf( __( '%s Files', 'edd' ), edd_get_label_singular() ),
+		'content'	=>
+			'<p>' . __( '<strong>Product Type Options</strong> - Choose a default product type or a bundle. Bundled products automatically include access other download&#39;s files when purchased.', 'edd' ) . '</p>' . 
+
+			'<p>' . __( '<strong>File Downloads</strong> - Define download file names and their respsective file URL. Multiple files can be assigned to a single price, or variable prices.', 'edd' ) . '</p>'
+	) );
+
+
+	$screen->add_help_tab( array(
 		'id'	    => 'edd-product-notes',
-		'title'	    => __( 'Product Notes', 'edd' ),
+		'title'	    => sprintf( __( '%s Notes', 'edd' ), edd_get_label_singular() ),
 		'content'	=> '<p>' . __( 'Special notes or instructions for the product. These notes will be added to the purchase receipt, and additionaly may be used by some extensions or themes on the frontend.', 'edd' ) . '</p>'
 	) );
 

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -333,7 +333,7 @@ function edd_render_price_field( $post_id ) {
 		<input type="hidden" id="edd_variable_prices" class="edd_variable_prices_name_field" value=""/>
 		<p>
 			<?php echo EDD()->html->checkbox( array( 'name' => '_edd_price_options_mode', 'current' => $single_option_mode ) ); ?>
-			<label for="_edd_price_options_mode"><?php apply_filters( 'edd_multi_option_purchase_text', _e( 'Enable multi option purchase mode. Leave unchecked to only permit a single price option to be purchased', 'edd' ) ); ?></label>
+			<label for="_edd_price_options_mode"><?php apply_filters( 'edd_multi_option_purchase_text', _e( 'Enable multi-option purchase mode. Allows multiple price options to be added to your cart at once', 'edd' ) ); ?></label>
 		</p>
 		<div id="edd_price_fields" class="edd_meta_table_wrap">
 			<table class="widefat edd_repeatable_table" width="100%" cellpadding="0" cellspacing="0">
@@ -498,7 +498,7 @@ function edd_render_products_field( $post_id ) {
 			<table class="widefat" width="100%" cellpadding="0" cellspacing="0">
 				<thead>
 					<tr>
-						<th style="width: 20%"><?php printf( __( 'Select the %s to bundle with this %s', 'edd' ), edd_get_label_plural(), edd_get_label_singular() ); ?></th>
+						<th style="width: 97%"><?php printf( __( '%s Name', 'edd' ), edd_get_label_singular() ); ?></th>
 						<?php do_action( 'edd_download_products_table_head', $post_id ); ?>
 						<th style="width: 2%"></th>
 					</tr>
@@ -521,7 +521,7 @@ function edd_render_products_field( $post_id ) {
 				<?php endif; ?>
 					<tr>
 						<td class="submit" colspan="4" style="float: none; clear:both; background: #fff;">
-							<a class="button-secondary edd_add_repeatable" style="margin: 6px 0;"><?php _e( 'Add New', 'edd' ); ?></a>
+							<a class="button-secondary edd_add_repeatable" style="margin: 6px 0 10px;"><?php printf( __( 'Add %s', 'edd' ), edd_get_label_singular() ); ?></a>
 						</td>
 					</tr>
 				</tbody>
@@ -619,7 +619,7 @@ function edd_render_files_field( $post_id = 0 ) {
 				<?php endif; ?>
 					<tr>
 						<td class="submit" colspan="4" style="float: none; clear:both; background: #fff;">
-							<a class="button-secondary edd_add_repeatable" style="margin: 6px 0;"><?php _e( 'Add New File', 'edd' ); ?></a>
+							<a class="button-secondary edd_add_repeatable" style="margin: 6px 0 10px;"><?php _e( 'Add New File', 'edd' ); ?></a>
 						</td>
 					</tr>
 				</tbody>
@@ -743,7 +743,7 @@ function edd_render_download_limit_row( $post_id ) {
 			'value' => $edd_download_limit,
 			'class' => 'small-text'
 		) ); ?>
-		<?php _e( 'The maximum number of times a buyer can download each file. Leave blank or set to 0 for unlimited', 'edd' ); ?>
+		<?php _e( 'Blank or 0 for unlimited', 'edd' ); ?>
 	</label>
 <?php
 }


### PR DESCRIPTION
See #1502 
- Updated Contextual Help (and always use dynamic nouns for labels)
- Make sure select boxes are always full-width
- Add extra spacing to submit buttons for MP6 (3.8)
- Adjust labels to be clearer (and shorter) in some instances
