### PR TITLE
Improvements to the register form

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -162,7 +162,7 @@ function edd_user_info_fields() {
 	<?php
 }
 add_action( 'edd_purchase_form_after_user_info', 'edd_user_info_fields' );
-add_action( 'edd_register_user_info_info_fields', 'edd_user_info_fields' );
+add_action( 'edd_register_user_info_fields', 'edd_user_info_fields' );
 /**
  * Renders the credit card info form.
  *
@@ -382,7 +382,7 @@ function edd_get_register_fields() {
 	<fieldset id="edd_register_fields">
 		<p id="edd-login-account-wrap"><?php _e( 'Already have an account?', 'edd' ); ?> <a href="<?php echo add_query_arg('login', 1); ?>" class="edd_checkout_register_login" data-action="checkout_login"><?php _e( 'Login', 'edd' ); ?></a></p>
 		<?php do_action('edd_register_fields_before'); ?>
-		<?php do_action( 'edd_register_user_info_info_fields' ); ?>
+		<?php do_action( 'edd_register_user_info_fields' ); ?>
 		<?php do_action('edd_register_fields_after'); ?>
 		<fieldset id="edd_register_account_fields">
 			<span><legend><?php _e( 'Create an account', 'edd' ); if( !edd_no_guest_checkout() ) { echo ' ' . __( '(optional)', 'edd' ); } ?></legend></span>


### PR DESCRIPTION
Right now there's no way of removing the first/last name or email fields from the checkout form when a user is not logged in. Those fields are hardcoded and unlike the version of checkout for logged in users, does not call the function to generate those fields. This PR fixes that.
