### PR TITLE
(Re-)adds display: none; to Thickbox content to insert a download.

### DIFF
--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -87,7 +87,7 @@ function edd_admin_footer_for_thickbox() {
             });
 		</script>
 
-		<div id="choose-download">
+		<div id="choose-download" style="display: none;">
 			<div class="wrap" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
 				<p><?php echo sprintf( __( 'Use the form below to insert the short code for purchasing a %s', 'edd' ), edd_get_label_singular() ); ?></p>
 				<div>


### PR DESCRIPTION
The Thickbox content to help you insert a downloads shortcode was shown because the `display: none` was removed from the style attribute in the `release/1.9` branch

![add_new_form__wp_latest__wordpress_20131223_221708](https://f.cloud.github.com/assets/885856/1803272/9c7e16ac-6c17-11e3-942f-5cde213df9c4.jpg)

The contents of the Thickbox is still somewhat messed up by the way.

![add_new_form__wp_latest__wordpress_20131223_221917](https://f.cloud.github.com/assets/885856/1803285/e870f836-6c17-11e3-919e-48a7a9172354.jpg)
