### PR TITLE
Customize [downloads] shortcode columns of 0

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -329,6 +329,8 @@ function edd_downloads_query( $atts, $content = null ) {
 		$query['paged'] = 1;
 
 	switch( intval( $columns ) ) :
+	    case 0:
+	        $column_width = 'inherit'; break;
 		case 1:
 			$column_width = '100%'; break;
 		case 2:
@@ -381,7 +383,7 @@ function edd_downloads_query( $atts, $content = null ) {
 						?>
 					</div>
 				</div>
-				<?php if ( $i % $columns == 0 ) { ?><div style="clear:both;"></div><?php } ?>
+				<?php if ( $i % $columns == 0 && $columns != 0 ) { ?><div style="clear:both;"></div><?php } ?>
 			<?php $i++; endwhile; ?>
 
 			<div style="clear:both;"></div>


### PR DESCRIPTION
The downloads shortcode spits out div's with clear:both in order to force columns, but if one could make a column of 0 (zero) without them, it would permit CSS styling for a far easier responsive display.
