### PR TITLE
Remove $wp_version check, now that 3.7 is the min.

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -185,7 +185,7 @@ final class Easy_Digital_Downloads {
 	 * @return void
 	 */
 	private function includes() {
-		global $edd_options, $wp_version;
+		global $edd_options;
 
 		require_once EDD_PLUGIN_DIR . 'includes/admin/settings/register-settings.php';
 		$edd_options = edd_get_settings();
@@ -236,7 +236,7 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/process-purchase.php';
 		require_once EDD_PLUGIN_DIR . 'includes/login-register.php';
 
-		if( is_admin() ) {
+		if ( is_admin() ) {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/add-ons.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/admin-actions.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/admin-notices.php';
@@ -265,9 +265,7 @@ final class Easy_Digital_Downloads {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrades.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/welcome.php';
-			if( version_compare( $wp_version, '3.6', '>=' ) ) {
-				require_once EDD_PLUGIN_DIR . 'includes/admin/class-edd-heartbeat.php';
-			}
+			require_once EDD_PLUGIN_DIR . 'includes/admin/class-edd-heartbeat.php';
 		} else {
 			require_once EDD_PLUGIN_DIR . 'includes/process-download.php';
 			require_once EDD_PLUGIN_DIR . 'includes/shortcodes.php';


### PR DESCRIPTION
Shouldn't be necessary to check for this for the Heartbeat API, now that 3.7 is the minimum.
