### PR TITLE
Update template.php to use site_url instead of network_site_url for added compat with SSL and mapped/sub domains.

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -514,7 +514,7 @@ function edd_show_payment_icons() {
 				echo '<img class="payment-icon" src="' . $key . '"/>';
 			} else {
                 $image = edd_locate_template( 'images/icons/' . strtolower( str_replace( ' ', '', $card ) ) . '.gif', false );
-				$image = str_replace( ABSPATH, network_site_url( '/' ), $image );
+				$image = str_replace( ABSPATH, site_url( '/' ), $image );
 				echo '<img class="payment-icon" src="' . esc_url( $image ) . '"/>';
 			}
 		}


### PR DESCRIPTION
If you use network_site_url() then it defaults to your primary site on the network, which is fine ... if you happen to be running from there. You may have the store as a subdomain, which in my case meant the images loaded from ipstenu.org while my SSL was setup on store.halfelf.org

Using site_url will fall back correctly and show the path to the site the page is on. And if you don't have SSL for THAT you have another problem :)
