### PR TITLE
Fix: invalid argument and  Warning: array_merge(): Argument #2 is not an...

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -656,10 +656,11 @@ function edd_settings_sanitize( $input = array() ) {
 
 	parse_str( $_POST['_wp_http_referer'], $referrer );
 
-	$settings  = edd_get_registered_settings();
-	$tab       = isset( $referrer['tab'] ) ? $referrer['tab'] : 'general';
+	$settings  	= edd_get_registered_settings();
+	$tab       	= isset( $referrer['tab'] ) ? $referrer['tab'] : 'general';
 
-	$input = $input ? apply_filters( 'edd_settings_' . $tab . '_sanitize', $input ) : array();
+	$input 		= $input ? $input : array();
+	$input 		= apply_filters( 'edd_settings_' . $tab . '_sanitize', $input );
 
 	// Loop through each setting being saved and pass it through a sanitization filter
 	foreach( $input as $key => $value ) {

--- a/includes/cart/actions.php
+++ b/includes/cart/actions.php
@@ -27,7 +27,7 @@ function edd_add_rewrite_endpoints( $rewrite_rules ) {
 add_action( 'init', 'edd_add_rewrite_endpoints' );
 
 /**
- * Process Cart Endpointss
+ * Process Cart Endpoints
  *
  * Listens for add/remove requests sent from the cart
  *


### PR DESCRIPTION
EDD 1.9.2

When I save the extensions tab in EDD settings without any options selected it breaks with:

`Warning: Invalid argument supplied for foreach() in /wp-content/plugins/easy-digital-downloads/includes/admin/settings/register-settings.php on line 668`

`Warning: array_merge(): Argument #2 is not an array in /wp-content/plugins/easy-digital-downloads/includes/admin/settings/register-settings.php on line 700`

Noticed this when I saved the options for EDD Downloads As Services and did not have any of the multicheck boxes selected.

It also seems to reset the settings back to default and you have to reselect EDD pages and payment gateway
