### PR TITLE
fix: PHP warning when remove items from cart when discount is applied on...

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -583,7 +583,7 @@ function edd_discount_product_reqs_met( $code_id = null ) {
 	$condition    = edd_get_discount_product_condition( $code_id );
 	$excluded_ps  = edd_get_discount_excluded_products( $code_id );
 	$cart_items   = edd_get_cart_contents();
-	$cart_ids     = wp_list_pluck( $cart_items, 'id' );
+	$cart_ids     = $cart_items ? wp_list_pluck( $cart_items, 'id' ) : null;
 	$ret          = false;
 
 	if ( empty( $product_reqs ) ) {


### PR DESCRIPTION
reported here
https://easydigitaldownloads.com/support/topic/discount-code-doesnt-seem-to-work/#post-165307

Replicated customer's setup with a subfolder install (normal install works fine), EDD 1.9.4 and WP 3.8.

When a discount is applied to cart, and you remove any item from the cart, it bombs out an invalid foreach, referencing the line with `wp_list_pluck` on it
