### PR TITLE
Use $item instead of $item['id'] in edd_email_receipt_download_title

### DIFF
--- a/includes/emails/email-tags.php
+++ b/includes/emails/email-tags.php
@@ -394,7 +394,7 @@ function edd_email_tag_download_list( $payment_id ) {
 					$title .= "&nbsp;&ndash;&nbsp;" . edd_get_price_option_name( $item['id'], $price_id );
 				}
 
-				$download_list .= '<li>' . apply_filters( 'edd_email_receipt_download_title', $title, $item['id'], $price_id ) . '<br/>';
+				$download_list .= '<li>' . apply_filters( 'edd_email_receipt_download_title', $title, $item, $price_id ) . '<br/>';
 				$download_list .= '<ul>';
 			}
 


### PR DESCRIPTION
In EDD 1.8.x the filter passed `$title`, `$item`, `$item['id']` and `$price_id`. In EDD 1.9 the `$item` was removed.

I'd like to propose we drop `$item['id']` and put `$item` back in seeing as you can access everything from $item like quantity, price, id, etc.

PS can't see any add-ons using this filter (in dropbox) except my downloads as services plugin
