### PR TITLE
Create edd_download_metabox_fields() function

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -69,8 +69,7 @@ function edd_download_metabox_fields() {
 			'_edd_download_tax_exclusive',
 			'_edd_button_behavior',
 			'edd_product_notes'
-		)
-	);
+		);
 
 	if ( current_user_can( 'manage_shop_settings' ) ) {
 		$fields[] = '_edd_download_limit';


### PR DESCRIPTION
This does a couple helpful things: 

1) Allows plugins to unset, for example, the download limit for Shop Managers.  Potentially useful if that field is irrelevant for a shop.

2) My primary use case, allows plugins to filter the is_protected_meta fields for each of the EDD fields.  Useful when exposing the Custom Fields metabox in EDD downloads and not wanting end users to be able to edit EDD meta.

This is utterly untested.
