### PR TITLE
Fixing notice when no flat discounts are applied

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -934,10 +934,11 @@ function edd_get_cart_discounted_amount( $discounts = false ) {
 	}
 
 	$cart_discounts = edd_get_cart_discounts();
-	foreach ( $cart_discounts as $discount ) {
-		$discount_id = edd_get_discount_id_by_code( $discount );
-		if ( 'flat' === edd_get_discount_type( $discount_id ) ) {
-			$amount += edd_get_discount_amount( $discount_id )	;
+	if ( ! empty( $cart_discounts ) ) {
+		foreach ( $cart_discounts as $discount ) {
+			$discount_id = edd_get_discount_id_by_code( $discount );
+			if ( 'flat' === edd_get_discount_type( $discount_id ) )
+				$amount += edd_get_discount_amount( $discount_id );
 		}
 	}
 


### PR DESCRIPTION
#1917 While testing this, had forgotten to test it with zero flat discount codes and we ended up with a notice about an invalid argument for a foreach. This should resolve the matter.
