### PR TITLE
Calculating tax rate for logged-out customers

### DIFF
--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -75,8 +75,8 @@ function edd_get_tax_rate( $country = false, $state = false ) {
 	$user_address = edd_get_customer_address();
 
 	if( empty( $country ) ) {
-		if( ! empty( $_POST['country'] ) ) {
-			$country = $_POST['country'];
+		if( ! empty( $_POST['billing_country'] ) ) {
+			$country = $_POST['billing_country'];
 		} elseif( is_user_logged_in() && ! empty( $user_address ) ) {
 			$country = $user_address['country'];
 		}


### PR DESCRIPTION
Creating this pull request as per [this support topic on the EDD forums](https://easydigitaldownloads.com/support/topic/eu-tax-rules-wrong-taxes-applied/#post-175095).

When calculating the tax rate for logged-out users, the function was checking for 'country' in the $_POST array. The field is named `billing_country` though, so it always defaulted to the store its operating country.
