### PR TITLE
Delete EDD posts with any post status

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -23,7 +23,7 @@ if( edd_get_option( 'uninstall_on_delete' ) ) {
 	$edd_post_types = array( 'download', 'edd_payment', 'edd_discount', 'edd_log' );
 	foreach ( $edd_post_types as $post_type ) {
 
-		$items = get_posts( array( 'post_type' => $post_type, 'numberposts' => -1, 'fields' => 'ids' ) );
+		$items = get_posts( array( 'post_type' => $post_type, 'post_status' => 'any', 'numberposts' => -1, 'fields' => 'ids' ) );
 
 		if ( $items ) {
 			foreach ( $items as $item ) {


### PR DESCRIPTION
During an EDD uninstall I noticed that posts of type 'download' with a 'draft' post status were not deleted. 
