### PR TITLE
Don't use mode argument (or check for _edd_payment_mode) anywhere in core

### DIFF
--- a/includes/admin/export-functions.php
+++ b/includes/admin/export-functions.php
@@ -5,9 +5,6 @@ function edd_export_payment_history() {
 
 	if( !isset( $_GET['export'] ) )
 		return; // get out quick if not required.
-
-	$mode = isset( $_GET['mode'] ) ? $_GET['mode'] : 'live';
-	if( edd_is_test_mode() && !isset( $_GET['mode'] ) ) $mode = 'test';
 	
 	$orderby = isset( $_GET['orderby'] ) ? $_GET['orderby'] : 'ID';
 	$order = isset( $_GET['order'] ) ? $_GET['order'] : 'DESC';
@@ -28,12 +25,12 @@ function edd_export_payment_history() {
 		$payments = edd_get_payments( array(
 			'offset'  => 0, 
 			'number'  => -1, 
-			'mode'    => $mode, 
 			'orderby' => $orderby, 
 			'order'   => $order, 
 			'user'    => $user, 
 			'status'  => $status
 		) );
+		
 		if($payments){
 			$i = 0;
 			echo '"' . __( 'ID', 'edd' ) .  '",';

--- a/includes/admin/payments/payments-history.php
+++ b/includes/admin/payments/payments-history.php
@@ -49,16 +49,21 @@ function edd_payment_history_page() {
 			$status 		= isset( $_GET['status'] ) ? $_GET['status'] : 'any';
 			$meta_key		= isset( $_GET['meta_key'] ) ? $_GET['meta_key'] : null;
 
-			$payments 		= edd_get_payments( array(
+			$payment_args = array(
 					'offset'   => $offset,
 					'number'   => $per_page, 
-					'mode'     => $mode, 
 					'orderby'  => $orderby, 
 					'order'    => $order, 
 					'user'     => $user, 
 					'status'   => $status, 
 					'meta_key' => $meta_key 
-			) );
+			);
+			
+			if ( isset( $_GET['mode'] ) ) {
+				$payment_args['mode'] = $mode, 
+			}
+
+			$payments 		= edd_get_payments( $payment_args );
 			$payment_count 	= wp_count_posts( 'edd_payment' );
 
 			$total_count 	= $payment_count->publish + $payment_count->pending + $payment_count->refunded + $payment_count->trash;

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -26,7 +26,6 @@ function edd_count_payments( $mode, $user = null ) {
 	$payments = edd_get_payments( array(
 		'offset'  => 0, 
 		'number'  => -1, 
-		'mode'    => $mode, 
 		'orderby' => 'ID', 
 		'order'   => 'DESC', 
 		'user'    => $user 

--- a/includes/payment-actions.php
+++ b/includes/payment-actions.php
@@ -230,8 +230,7 @@ function edd_update_old_payments_with_totals( $data ) {
 
 	$payments = edd_get_payments( array(
 		'offset' => 0, 
-		'number' => -1, 
-		'mode'   => 'all' 
+		'number' => -1
 	) );
 
 	if( $payments ) {

--- a/includes/payment-functions.php
+++ b/includes/payment-functions.php
@@ -330,9 +330,7 @@ function edd_get_earnings_by_date($day = null, $month_num, $year) {
 		'post_type' => 'edd_payment', 
 		'posts_per_page' => -1, 
 		'year' => $year, 
-		'monthnum' => $month_num, 
-		'meta_key' => '_edd_payment_mode',
-		'meta_value' => 'live'
+		'monthnum' => $month_num,
 	);
 	if( $day )
 		$args['day'] = $day;
@@ -363,9 +361,7 @@ function edd_get_sales_by_date( $day = null, $month_num, $year ) {
 		'post_type' => 'edd_payment', 
 		'posts_per_page' => -1, 
 		'year' => $year, 
-		'monthnum' => $month_num, 
-		'meta_key' => '_edd_payment_mode',
-		'meta_value' => 'live'
+		'monthnum' => $month_num
 	);
 	if( $day )
 		$args['day'] = $day;
@@ -435,9 +431,7 @@ function edd_get_total_sales() {
 	$sales = get_posts(
 		array(
 			'post_type' => 'edd_payment', 
-			'posts_per_page' => -1,
-			'meta_key' => '_edd_payment_mode',
-			'meta_value' => 'live'
+			'posts_per_page' => -1
 		)
 	);
 	$total = 0;
@@ -462,8 +456,7 @@ function edd_get_total_earnings() {
 	if( false === $payments || '' === $payments ) {
 		$payments = edd_get_payments( array(
 			'offset' 	=> 0, 
-			'number' 	=> -1, 
-			'mode'   	=> 'live', 
+			'number' 	=> -1,
 			'orderby' 	=> 'ID', 
 			'order'   	=> 'DESC', 
 			'user'    	=> null, 

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -30,16 +30,12 @@ function edd_get_users_purchases( $user_id = 0, $number = -1 ) {
 	}
 
 	$purchases = get_transient( 'edd_user_' . $user_id . '_purchases' );
+
 	if( false === $purchases || edd_is_test_mode() ) {
-		$mode = edd_is_test_mode() ? 'test' : 'live';
+
 		$purchases = get_posts(
 			array(
 				'meta_query'   => array(
-					'relation' => 'AND',
-					array(
-						'key'   => '_edd_payment_mode',
-						'value' => $mode
-					),
 					array(
 						'key'   => '_edd_payment_user_id',
 						'value' => $user_id
@@ -51,7 +47,7 @@ function edd_get_users_purchases( $user_id = 0, $number = -1 ) {
 		);
 		set_transient( 'edd_user_' . $user_id . '_purchases', $purchases, 7200 );
 	}
-	if( $purchases ) {
+	if ( $purchases ) {
 	    // return the download list
 		return $purchases;
 	}
@@ -163,7 +159,6 @@ function edd_has_purchases( $user_id = null ) {
 function edd_count_purchases_of_customer( $user = null ) {
 	$args = array(
 		'number'   => -1,
-		'mode'     => 'live',
 		'user'     => $user,
 		'status'   => 'publish'
 	);
@@ -187,7 +182,6 @@ function edd_count_purchases_of_customer( $user = null ) {
 function edd_purchase_total_of_user( $user = null ) {
 	$args = array(
 		'number'   => -1,
-		'mode'     => 'live',
 		'user'     => $user,
 		'status'   => 'publish'
 	);


### PR DESCRIPTION
In the admin - most especially in the reporting area and in the payment history, we're getting some super slow queries due to joining the meta table for the payment mode.  This is unnecessary and should be avoided in core.

I'm going to take this opportunity to riff on Pippin's name a bit:
- If he wore Warby Parkers and skinny jeans - He'd be a Pipster.
- If he started a show on Fx - it would be called Pip/Tuck.
- If he started an online messaging service, naturally, it would be called PipChat.
