### PR TITLE
Password is sent in notification e-mail

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -374,6 +374,6 @@ function edd_get_customer_address( $user_id = 0 ) {
  * @return 		void
  */
 function edd_new_user_notification( $user_id = 0, $user_data = array() ) {
-	wp_new_user_notification( $user_id, $user_data['user_pass'] );
+	wp_new_user_notification( $user_id, __( '[Password entered at checkout]', 'edd' ) );
 }
 add_action( 'edd_insert_user', 'edd_new_user_notification', 10, 2 );


### PR DESCRIPTION
I only realised this after I purchased something using EDD, but if you've provided a username and password it e-mails both of these to the user.  (Via `edd_new_user_notification()`).

I may be on my own with this, but I don't think password should be included. First and foremost an e-mail with a password in plaintext is dangerous. Temporary/auto-generated passwords are ok as it's understood that the user won't be using it for long, and certainly not any other accounts. 

Secondly, it doesn't serve much purpose: I know the password I just entered, and if I had forgotten it, I know the e-mail address and username to which it associated and can reset the password that way. 

I'll be removing this on my own install, but would be great to see the password excluded altogether. 

In the attached pull-request I've kept with `wp_new_user_notification()` but replaced the password with dummy text. Equally it would work with asterisks.

(...alternatively, a password could be automatically generated).
