### PR TITLE
number_format_i18n() on sales

### DIFF
--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -171,9 +171,9 @@ function edd_reports_graph() {
 				?>
 				
 				<p class="edd_graph_totals"><strong><?php _e( 'Total earnings for period shown: ', 'edd' ); echo edd_currency_filter( edd_format_amount( $earnings_totals ) ); ?></strong></p>
-				<p class="edd_graph_totals"><strong><?php _e( 'Total sales for period shown: ', 'edd' ); echo number_format_i18n( $sales_totals ); ?></strong></p>
+				<p class="edd_graph_totals"><strong><?php _e( 'Total sales for period shown: ', 'edd' ); echo edd_format_amount( $sales_totals ); ?></strong></p>
 				<p class="edd_graph_totals"><strong><?php _e( 'Estimated monthly earnings: ', 'edd' ); echo edd_currency_filter( edd_format_amount( $estimated['earnings'] ) ); ?></strong></p>
-				<p class="edd_graph_totals"><strong><?php _e( 'Estimated monthly sales: ', 'edd' ); echo number_format_i18n( $estimated['sales'] ); ?></strong></p>
+				<p class="edd_graph_totals"><strong><?php _e( 'Estimated monthly sales: ', 'edd' ); echo edd_format_amount( $estimated['sales'] ); ?></strong></p>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Because 1286 is more annoying than 1,286.
