### PR TITLE
Enhancement to function edd_get_payment_meta_cart_details

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -734,7 +734,7 @@ function edd_get_payment_meta_cart_details( $payment_id, $include_bundle_files =
 					'in_bundle'   => 1,
 					'parent'		=> array(
 							'id' 			=> $cart_item['id'],
-							'options' 		=> $cart_item['item_number']['options']
+							'options' 		=> isset( $cart_item['item_number']['options'] ) ? $cart_item['item_number']['options'] : array()
 						)
 				);
 			}


### PR DESCRIPTION
Add some information about the associated bundle to the child products in the cart details. 

This is necessary to know for example which was the price option picked for a given download when we want a custom site count / expiration date for licensing.

Related support forum thread: https://easydigitaldownloads.com/support/topic/bundles-variable-pricing-custom-expirationsite-count/
