### PR TITLE
Make edd_format_amount() non-currency friendly

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -47,10 +47,13 @@ function edd_sanitize_amount( $amount ) {
  * Returns a nicely formatted amount.
  *
  * @since 1.0
- * @param string $amount Price amount to format
+ * 
+ * @param string $amount   Price amount to format
+ * @param string $decimals Whether or not to use decimals.  Useful when set to false for non-currency numbers.
+ * 
  * @return string $amount Newly formatted amount or Price Not Available
  */
-function edd_format_amount( $amount ) {
+function edd_format_amount( $amount, $decimals = true ) {
 	global $edd_options;
 
 	$thousands_sep 	= ! empty( $edd_options['thousands_separator'] ) ? $edd_options['thousands_separator'] : '';
@@ -68,10 +71,11 @@ function edd_format_amount( $amount ) {
 		$amount = str_replace( ',', '', $amount );
 	}
 
-	if( empty( $amount ) )
+	if ( empty( $amount ) ) {
 		$amount = 0;
-
-	$decimals  = apply_filters( 'edd_format_amount_decimals', 2, $amount );
+	}
+	
+	$decimals  = apply_filters( 'edd_format_amount_decimals', $decimals ? 2 : 0, $amount );
 	$formatted = number_format( $amount, $decimals, $decimal_sep, $thousands_sep );
 
 	return apply_filters( 'edd_format_amount', $formatted, $amount, $decimals, $decimal_sep, $thousands_sep );


### PR DESCRIPTION
When a second optional parameter is passed ($decimals, defaults to true) as false, no decimal places are returned.  This is helpful when formatting non-currency numbers.
