### PR TITLE
Update view-order-details.php

### DIFF
--- a/includes/admin/payments/view-order-details.php
+++ b/includes/admin/payments/view-order-details.php
@@ -391,10 +391,12 @@ $address      = ! empty( $user_info['address'] ) ? $user_info['address'] : array
 							
 								<input type="hidden" name="edd-payment-downloads-changed" id="edd-payment-downloads-changed" value=""/>
 								
-								<?php do_action( 'edd_view_order_details_files_after', $payment_id ); ?>
+								<?php do_action ('edd_view_order_details_files_inside', $payment_id); ?>
 
 							</div><!-- /.inside -->
 						</div><!-- /#edd-purchased-files -->
+						
+						<?php do_action( 'edd_view_order_details_files_after', $payment_id ); ?>
 
 
 						<div id="edd-payment-notes" class="postbox">


### PR DESCRIPTION
Pushed up edd_view_order_details_files_after for cleaner hooking into "Purchase Details". This makes any additional information that you add into the div actually inside the div instead of the white space between Purchased Downloads and Payment Notes
