### PR TITLE
Allowing cart to be filtered while adding to cart

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -101,7 +101,7 @@ function edd_get_cart_quantity() {
  * @return string Cart key of the new item
  */
 function edd_add_to_cart( $download_id, $options = array() ) {
-	$cart = apply_filters( 'edd_pre_add_to_cart_content', edd_get_cart_contents() );
+	$cart = apply_filters( 'edd_pre_add_to_cart_contents', edd_get_cart_contents() );
 	$download = get_post( $download_id );
 
 	if( 'download' != $download->post_type )


### PR DESCRIPTION
#2017 - Proposed solution to https://easydigitaldownloads.com/support/topic/empty-current-cart-before-adding-new-download/
