### PR TITLE
Possible fix for taxonomy remaining after uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -34,16 +34,11 @@ if( edd_get_option( 'uninstall_on_delete' ) ) {
 
 	/** Delete All the Taxonomies */
 	$edd_taxonomies = array( 'download_tag', 'download_category', 'edd_log_type' );
-	foreach ( $edd_taxonomies as $taxonomy ) {
-		global $wp_taxonomies;
-		$terms = get_terms( $taxonomy );
-		if ( $terms ) {
+		$terms = get_terms( $edd_taxonomies );
+		
 			foreach ( $terms as $term ) {
-				wp_delete_term( $term->term_id, $taxonomy );
+				wp_delete_term( $term->term_id, $edd_taxonomies );
 			}
-		}
-		unset( $wp_taxonomies[ $taxonomy ] );
-	}
 
 	/** Delete the Plugin Pages */
 	$edd_created_pages = array( 'purchase_page', 'success_page', 'failure_page', 'purchase_history_page' );


### PR DESCRIPTION
Not sure if this really works, it may need more testing, but no more taxonomy appears to remain.
