### PR TITLE
Added ob_flush() and flush() to edd_readfile_chunked()

### DIFF
--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -565,6 +565,8 @@ function edd_readfile_chunked( $file, $retbytes = true ) {
 	while ( ! @feof( $handle ) ) {
 		$buffer = @fread( $handle, $chunksize );
 		echo $buffer;
+		ob_flush();
+		flush();
 
 		if ( $retbytes ) {
 	   		$cnt += strlen( $buffer ); 


### PR DESCRIPTION
I was getting a 0 Byte download when downloading a "large" file (10Mb).
After trying some things and modifying some php variables I was getting the same issue. But when adding this two lines problem was solved and I was getting the correct size download.
