### PR TITLE
List all products in admin dropdowns. Fixes #2067

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -47,7 +47,7 @@ class EDD_HTML_Elements {
 			'post_type'      => 'download',
 			'orderby'        => 'title',
 			'order'          => 'ASC',
-			'posts_per_page' => 30
+			'posts_per_page' => -1
 		) );
 
 		$options = array();


### PR DESCRIPTION
Only 30 products are currently listed in the Bundled Products and Discounts sections in the WP Admin. This makes product bundles containing more than 30 products impossible. This commit will list all. Fixes #2067
