### PR TITLE
Add filter to args for purchase link

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -99,6 +99,8 @@ function edd_get_purchase_link( $args = array() ) {
 	}
 
 	$form_id = ! empty( $args['form_id'] ) ? $args['form_id'] : 'edd_purchase_' . $args['download_id'];
+	
+	$args = apply_filters( 'edd_purchase_link_args', $args );
 
 	ob_start();
 ?>


### PR DESCRIPTION
Currently you can only modify the default args. This doesn't give you access to the actual download if used in a shortcode (as it's the current post ID).
