### PR TITLE
Take all payment statuses into account for total payment counts

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -472,7 +472,6 @@ class EDD_Payment_History_Table extends WP_List_Table {
 		foreach( $payment_count as $count ) {
 			$this->total_count += $count;
 		}
-		$this->total_count    = apply_filters( 'edd_total_payment_count', $this->total_count, $payment_count );
 	}
 
 	/**


### PR DESCRIPTION
This commit adds a filter to the total count of payments found in the admin list at Downloads > Payment History. This filter allows addons to adjust the total count of payments, adding any payments with custom payment statuses the addon has created.

I encountered the problem with custom payment statuses created by the Stripe payment gateway addon. If you have 29 Completed payments and 2 Cancelled payments, the payment list will not show any pagination links to reach the 31st payment in the list. It only counts 29 payments.

In order to fix this in the Stripe payment gateway addon, the following should be added to hook into the filter added by this commit:

```
/**
 * Add preapproval and cancelled payments to the total payment count
 *
 * @since 1.7.2
 * @return int
 */
function edd_payments_total_count( $total_count, $payment_count ) {
    $total_count += $payment_count->preapproval + $payment_count->cancelled;

    return $total_count;
}
add_filter( 'edd_total_payment_count', 'edd_payments_total_count', 10, 2 );
```

While reproducing this issue, you may notice that when you use the Bulk Action mechanism to change a payment from Complete to Cancelled, the total item count does not update. You need to refresh the page to see that the total item count has reduced. I would guess this is because the total item count is calculated before the status change is completed, but haven't looked into it.
