### PR TITLE
Add padding to upload field to stop upload link obscuring end of file URL

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -71,6 +71,7 @@ tr.status-refunded td { background: #cecece; border-top-color: #ccc; }
 #downloadinformation .edd_meta_table_wrap table .submit input { width: auto; }
 .edd_repeatable_upload_wrapper .edd_repeatable_upload_field_container { position: relative; }
 .edd_upload_file { position: absolute; top: 3px; right: 7px; padding: 2px 8px 2px; display: block; background: #fff; }
+.edd_upload_field { padding-right: 8em; }
 .edd_remove_repeatable { margin: 8px 0 0 0; cursor: pointer; width: 10px; height: 10px; display: inline-block; text-indent: -9999px; overflow: hidden; }
 .edd_remove_repeatable:active, .edd_remove_repeatable:hover { background-position: -10px 0!important }
 .edd_draghandle { display: block; width: 20px; height: 20px; background: url(../images/edd-cross-hair.png); cursor: move; margin: 4px 0 0 0; }


### PR DESCRIPTION
Currently the "Upload a file" link obscures the end of the File URL, which is a pain if you want to check that you've uploaded the right version.

Assuming you've got the version number at the end of the filename - but who doesn't right?

After this change it's still obscured by default, but at least you can scroll along to view it. 
