### PR TITLE
Categories/Tags widget rewrite

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -128,9 +128,9 @@ class edd_categories_tags_widget extends WP_Widget {
 	function form( $instance ) {
         // Set up some default widget settings.
         $defaults = array(
-			'title' 		=> '',
-			'taxonomy'		=> 'download_category',
-			'count'			=> 'off',
+			'title'         => '',
+			'taxonomy'      => 'download_category',
+			'count'         => 'off',
 			'hide_empty'    => 'off'
         );
 


### PR DESCRIPTION
Fixes issue #1860

Updated to use wp_list_categories to display hierarchy
Added option to show category counts
Added option to hide empty categories
