### PR TITLE
Add filter to ajax discount code

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -171,7 +171,7 @@ function edd_ajax_apply_discount() {
 		}
 
 		// Allow for custom discount code handling
-		$return = apply_filters( 'edd_discount_response', $return );
+		$return = apply_filters( 'edd_ajax_discount_response', $return );
 
 		echo json_encode($return);
 	}


### PR DESCRIPTION
This allows for plugins to create discount "aliases", thus preventing the need to create tons of different discount posts.

**Example use case:**

A user enters their existing license key. A plugin could validate the license key and, if successful, replace it with the (existing) "RENEW" discount code.
