### PR TITLE
fix EDD checkbox HTML output

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -304,7 +304,7 @@ class EDD_HTML_Elements {
 
 		$args = wp_parse_args( $args, $defaults );
 
-		$output = '<input type="checkbox" name="' . esc_attr( $args[ 'name' ] ) . '" id="' . esc_attr( $args[ 'name' ] ) . '" class="edd-checkbox ' . esc_attr( $args[ 'name'] ) . '" ' . checked( 1, $args[ 'current' ], false ) . '" class="' . $args[ 'class' ] .'"  />';
+		$output = '<input type="checkbox" name="' . esc_attr( $args[ 'name' ] ) . '" id="' . esc_attr( $args[ 'name' ] ) . '" class="' . $args[ 'class' ] . ' ' . esc_attr( $args[ 'name'] ) . '" ' . checked( 1, $args[ 'current' ], false ) . ' />';
 
 		return $output;
 	}


### PR DESCRIPTION
I was viewing source (edit download screen "Ignore Tax" checkbox) when I happened to notice these HTML issues. http://glui.me/?i=3rkrex0bn9g0pml/2014-03-27_at_10.30_PM.png/

Here's what I did:
1. removed the second "class" attribute and its value of $args[ 'class' ]
2. replaced the hardcoded "edd-checkout" value of the first class attribute with the $args[ 'class' ] value from the removed class attribute since it'll be getting "edd-checkout" from the $defaults array() anyway... I was sure to add proper spacing
3. checked() outputs an attribute with its value wrapped in single quotes by default... so I'm sure the trailing double quote was just a copy/paste error. It's gone now.

Looks to be all good now. http://glui.me/?i=ok4bzf1qinxcyue/2014-03-27_at_10.40_PM.png/
