### PR TITLE
Allow Table in Reports Section for Download earnings/sales to be filtered

### DIFF
--- a/includes/admin/reporting/class-download-reports-table.php
+++ b/includes/admin/reporting/class-download-reports-table.php
@@ -237,6 +237,8 @@ class EDD_Download_Reports_Table extends WP_List_Table {
 				break;
 		endswitch;
 
+		$args = apply_filters( 'edd_download_reports_prepare_items_args', $args, $this );
+
 		$this->products = new WP_Query( $args );
 
 	}


### PR DESCRIPTION
Right now, it's not possible to filter the downloads that are returned.  Our use case for this is to show only certain posts for certain users (e.g. a specific taxonomy for the user role of a logged in user.)
