### PR TITLE
* Limit payments count by start and end date

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -461,6 +461,14 @@ class EDD_Payment_History_Table extends WP_List_Table {
 			$args['s'] = urldecode( $_GET['s'] );
 		}
 
+		if ( ! empty( $_GET['start-date'] ) ) {
+			$args['start-date'] = urldecode( $_GET['start-date'] );
+		}
+
+		if ( ! empty( $_GET['end-date'] ) ) {
+			$args['end-date'] = urldecode( $_GET['end-date'] );
+		}
+
 		$payment_count        = edd_count_payments( $args );
 		$this->complete_count = $payment_count->publish;
 		$this->pending_count  = $payment_count->pending;

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -275,8 +275,10 @@ function edd_count_payments( $args = array() ) {
 	global $wpdb;
 
 	$defaults = array(
-		'user' => null,
-		's'    => null
+		'user'       => null,
+		's'          => null,
+		'start-date' => null,
+		'end-date'   => null,
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -329,6 +331,19 @@ function edd_count_payments( $args = array() ) {
 			$where .= "AND ((p.post_title LIKE '%{$args['s']}%') OR (p.post_content LIKE '%{$args['s']}%'))";
 		}
 
+	}
+
+	// Limit payments count by date
+	if ( ! empty( $args['start-date'] ) ) {
+		$date = new DateTime( $args['start-date'] );
+		$where .= "
+			AND p.post_date >= '" . $date->format( 'Y-m-d' ) . "'";
+	}
+
+	if ( ! empty ( $args['end-date'] ) ) {
+		$date = new DateTime( $args['end-date'] );
+		$where .= "
+			AND p.post_date <= '" . $date->format( 'Y-m-d' ) . "'";
 	}
 
 	$where = apply_filters( 'edd_count_payments_where', $where );


### PR DESCRIPTION
Start and end date filters used on the payments table will now impact
the total count of payments shown in the views (status) and pagination
UIs on the table. Previously, the total number of payments was returned,
which meant that more results would be indicated in the views and
pagination than were actually displayed in the table.

**Note** 

While testing this change, I noticed that a warning is thrown when an End Date is provided but a Start Date is missing:

`Warning: date() expects parameter 2 to be long, object given in C:\Program Files (x86)\wamp\www\themeofthecrop\wp-content\plugins\Easy-Digital-Downloads\includes\class-edd-stats.php on line 516`

This commit does not cause or effect that warning. If a Start Date is entered but no End Date is provided, no warning is thrown. But no results are returned either.

While digging into this issue, I noticed this in EDD_Stats::setup_dates():

```
        if( empty( $_start_date ) ) {
            $this->start_date = 'this_month';
        }

        $this->start_date = $_start_date;
```

As far as I can tell, an empty $_start_date will still result in an empty $this->start_date. This gets passed on to EDD_Stats::convert_date(), which can not handle an empty date. I umm'd and ahh'd over this for a while, but eventually decided not to tamper with it. EDD_Stats::setup_dates() is used by the reports, I think, and I'm not very familiar with that part of the plugin. I fear any tampering on my part will have adverse consequences.
