### PR TITLE
Format the "Total Sales" figure in the dashboard widget

### DIFF
--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -73,7 +73,7 @@ function edd_dashboard_sales_widget() {
 						<td class="last t earnings"><?php _e( 'Total Earnings', 'edd' ); ?></td>
 					</tr>
 					<tr>
-						<td class="b b-sales"><?php echo edd_get_total_sales(); ?></td>
+						<td class="b b-sales"><?php echo edd_format_amount( edd_get_total_sales(), false ); ?></td>
 						<td class="last t sales"><?php _e( 'Total Sales', 'edd' ); ?></td>
 					</tr>
 				</tbody>


### PR DESCRIPTION
This change passes the "Total Sales" figure in the dashboard through edd_format_amount() to insert thousands separators where required. 

E.g. 

Before - 1333
After - 1,333
