### PR TITLE
Stop directly enqueueing jquery

### DIFF
--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -27,8 +27,6 @@ function edd_load_scripts() {
 
 	$js_dir = EDD_PLUGIN_URL . 'assets/js/';
 
-	wp_enqueue_script( 'jquery' );
-
 	// Use minified libraries if SCRIPT_DEBUG is turned off
 	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 


### PR DESCRIPTION
Since the other wp_enqueue_script instances call out jquery as a dependency, there is no reason to enqueue it directly. Additionally, it breaks WordPress' wp_dequeue_script function when end users try to remove the edd-ajax script from pages that don't need it (jquery gets left enqueued when it may not be needed).
