### PR TITLE
Make "Remove" from Cart Button work within Ajax calls

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -774,7 +774,9 @@ function edd_add_collection_to_cart( $taxonomy, $terms ) {
 function edd_remove_item_url( $cart_key, $post, $ajax = false ) {
 	global $post;
 
-	if( is_page() ) {
+	if ( defined('DOING_AJAX') ){	
+		$current_page = edd_get_checkout_uri();
+	} else if( is_page() ) {
 		$current_page = add_query_arg( 'page_id', $post->ID, home_url( 'index.php' ) );
 	} else if( is_singular() ) {
 		$current_page = add_query_arg( 'p', $post->ID, home_url( 'index.php' ) );


### PR DESCRIPTION
In the "edd_remove_item_url" function, there is a Boolean parameter for $ajax - however, it isn't actually used - neither is it actually necessary.

I have modified the function so it can be used in ajax functions and uses the checkout page by default.

The change involves checking the "DOING_AJAX" constant, and if we are using ajax, we use the edd_get_checkout_uri() function as the $current_page used to create the URL in the "Remove" button.
