### PR TITLE
Load EDD on `plugins_loaded`

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -334,4 +334,4 @@ function EDD() {
 }
 
 // Get EDD Running
-EDD();
+add_action( 'plugins_loaded', 'EDD' );


### PR DESCRIPTION
If EDD is included as an MU plugin, this will prevent it from instantiating itself too early.