### PR TITLE
add break below country select

### DIFF
--- a/templates/shortcode-profile-editor.php
+++ b/templates/shortcode-profile-editor.php
@@ -72,6 +72,7 @@ if ( is_user_logged_in() ):
 					<option value="<?php echo $key; ?>"<?php selected( $address['country'], $key ); ?>><?php echo $country; ?></option>
 					<?php endforeach; ?>
 				</select>
+				<br/>
 				<label for="edd_address_state"><?php _e( 'State / Province', 'edd' ); ?></label>
 				<input name="edd_address_state" id="edd_address_state" class="text edd-input" type="text" value="<?php echo $address['state']; ?>" />
 				<br/>


### PR DESCRIPTION
I've been seeing this for a long time. Not sure why it never struck me as wrong. The state text input should be on its own line, right? http://glui.me/?i=zusndg2g14wj2a4/2014-04-08_at_11.47_PM.png/ Every other input on the page is followed by a break tag except for the select.
