### PR TITLE
Should exit search early if no args['s'] is set

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -319,13 +319,15 @@ class EDD_Payments_Query extends EDD_Stats {
 	 */
 	public function search() {
 
-		if( ! isset( $this->args[ 's' ] ) )
+		if( ! isset( $this->args[ 's' ] ) ) {
 			return;
+		}
 		
 		$search = trim( $this->args[ 's' ] );
 
-		if( empty( $search ) )
+		if( empty( $search ) ) {
 			return;
+		}
 
 		$is_email = is_email( $search ) || strpos( $search, '@' ) !== false;
 


### PR DESCRIPTION
Should check `$this->args[ 's' ]` before using it, see #2200
