### PR TITLE
Fix for when there is no $post on the page

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -54,11 +54,13 @@ function edd_get_purchase_link( $args = array() ) {
 		edd_print_errors();
 		return false;
 	}
+	
+	$post_id = is_object( $post ) ? $post->ID : 0;
 
 	$defaults = apply_filters( 'edd_purchase_link_defaults', array(
-		'download_id' => $post->ID,
+		'download_id' => $post_id,
 		'price'       => (bool) true,
-		'direct'      => edd_get_download_button_behavior( $post->ID ) == 'direct' ? true : false,
+		'direct'      => edd_get_download_button_behavior( $post_id ) == 'direct' ? true : false,
 		'text'        => ! empty( $edd_options[ 'add_to_cart_text' ] ) ? $edd_options[ 'add_to_cart_text' ] : __( 'Purchase', 'edd' ),
 		'style'       => isset( $edd_options[ 'button_style' ] ) 	   ? $edd_options[ 'button_style' ]     : 'button',
 		'color'       => isset( $edd_options[ 'checkout_color' ] ) 	   ? $edd_options[ 'checkout_color' ] 	: 'blue',


### PR DESCRIPTION
This gives support for Pods Pages which can be created as standalone URLs apart from Post archives and singular templates. In certain cases, $post is not setup (like a 404 would have) and this throws errors when trying to utilize edd_get_purchase_link and passing in $args to manually set download_id.
