### PR TITLE
Add edd_is_success_page()

### DIFF
--- a/includes/checkout/functions.php
+++ b/includes/checkout/functions.php
@@ -55,6 +55,18 @@ function edd_get_success_page_uri() {
 }
 
 /**
+ * Determines if we're currently on the Success page.
+ *
+ * @since 1.9.9
+ * @return bool True if on the Success page, false otherwise.
+ */
+function edd_is_success_page() {
+	global $edd_options;
+	$is_success_page = isset( $edd_options['success_page'] ) ? is_page( $edd_options['success_page'] ) : false;
+	return apply_filters( 'edd_is_success_page', $is_success_page );
+}
+
+/**
  * Send To Success Page
  *
  * Sends the user to the succes page.


### PR DESCRIPTION
Adds a function that plugins can use to determine if the request is for the success page. Useful for plugins that want to load CSS/JS only on the thank you page. 
