### PR TITLE
Add Unique IDs when multiple purchase links on a page

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -184,7 +184,7 @@ function edd_get_purchase_link( $args = array() ) {
 
 		<?php do_action( 'edd_purchase_link_end', $args['download_id'] ); ?>
 
-	</form><!--end <?php echo esc_attr( $form_id ); ?>-->
+	</form><!--end #<?php echo esc_attr( $form_id ); ?>-->
 <?php
 	$purchase_form = ob_get_clean();
 


### PR DESCRIPTION
Addresses #2103 - Collects the Download IDs displayed during a page load, and tracks the count of each, allowing us to append '-#' to the IDs of additional items, where '#' is a number greater than 1.
