### PR TITLE
Fixed bug with default gateway when no gateways are active

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -387,7 +387,8 @@ function edd_tools_sysinfo_get() {
 	if( $active_gateways ) {
 		$default_gateway_is_active = edd_is_gateway_active( edd_get_default_gateway() );
 		if( $default_gateway_is_active ) {
-			$default_gateway = $active_gateways[edd_get_default_gateway()]['admin_label'];
+			$default_gateway = edd_get_default_gateway();
+			$default_gateway = $active_gateways[$default_geteway]['admin_label'];
 		} else {
 			$default_gateway = 'Test Payment';
 		}


### PR DESCRIPTION
Fixed an issue with system info erroring if no gateway or only test gateway is active... the issue originally referenced in #2233 is actually already fixed because I don't display that section at ALL in the new version if no state specific taxes are setup.
