### PR TITLE
Add $payment_id to download title filter

### DIFF
--- a/includes/emails/email-tags.php
+++ b/includes/emails/email-tags.php
@@ -396,7 +396,7 @@ function edd_email_tag_download_list( $payment_id ) {
 					$title .= "&nbsp;&ndash;&nbsp;" . edd_get_price_option_name( $item['id'], $price_id );
 				}
 
-				$download_list .= '<li>' . apply_filters( 'edd_email_receipt_download_title', $title, $item, $price_id ) . '<br/>';
+				$download_list .= '<li>' . apply_filters( 'edd_email_receipt_download_title', $title, $item, $price_id, $payment_id ) . '<br/>';
 				$download_list .= '<ul>';
 			}
 


### PR DESCRIPTION
There may be info within the payment meta to add to the title. Passing the $payment_id makes this possible.
