### PR TITLE
Use a non-broken cache key

### DIFF
--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -119,14 +119,14 @@ class EDD_Payment_Stats extends EDD_Stats {
 				'update_post_term_cache' => false,
 				'suppress_filters'       => false,
 				'start_date'             => $this->start_date, // These dates are not valid query args, but they are used for cache keys
-				'end_date'               => $this->end_date
+				'end_date'               => $this->end_date,
+				'edd_transient_type'     => 'edd_earnings', // This is not a valid query arg, but is used for cache keying
 			);
 
-			$args = apply_filters( 'edd_stats_earnings_args', $args );
+			$args     = apply_filters( 'edd_stats_earnings_args', $args );
+			$key      = md5( serialize( $args ) );
 
-			$key = md5( 'edd_earnings_' . $start_date . $start_date );
 			$earnings = get_transient( $key );
-
 			if( false === $earnings ) {
 				$sales = get_posts( $args );
 				$earnings = 0;
@@ -145,17 +145,18 @@ class EDD_Payment_Stats extends EDD_Stats {
 			global $edd_logs, $wpdb;
 
 			$args = array(
-				'post_parent'      => $download_id,
-				'nopaging'         => true,
-				'log_type'         => 'sale',
-				'fields'           => 'ids',
-				'suppress_filters' => false,
-				'start_date'       => $this->start_date, // These dates are not valid query args, but they are used for cache keys
-				'end_date'         => $this->end_date
+				'post_parent'        => $download_id,
+				'nopaging'           => true,
+				'log_type'           => 'sale',
+				'fields'             => 'ids',
+				'suppress_filters'   => false,
+				'start_date'         => $this->start_date, // These dates are not valid query args, but they are used for cache keys
+				'end_date'           => $this->end_date,
+				'edd_transient_type' => 'edd_earnings', // This is not a valid query arg, but is used for cache keying
 			);
 
-			$args = apply_filters( 'edd_stats_earnings_args', $args );
-			$key  = md5( serialize( $args ) );
+			$args     = apply_filters( 'edd_stats_earnings_args', $args );
+			$key      = md5( serialize( $args ) );
 
 			$earnings = get_transient( $key );
 			if( false === $earnings ) {


### PR DESCRIPTION
Currently earnings stats retrieved by calling get_earnings() on an instance of EDD_Payment_Stats are cached in a transient. Unfortunately the cache key is incorrect causing conflicts. The current cache key is:

```
$key = md5( 'edd_earnings_' . $start_date . $start_date );
```

Note the double use of $start_date. I expect that the second of these was intended to be $end_date. However as the code stood then incorrect results could be returned as cached values would be returned for an enquiry that shared the same start time as a previous query even if the end time was different. 

This PR replaces this cache key with `md5( serialize( $args ) );` which is the same cache keying approach used elsewhere and correctly caches in the base case. It also has the advantage that it will cache correctly even the start/end date are identical but other query args are changed by other plugins via the provided filters
