### PR TITLE
Remove margin and padding from body

### DIFF
--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -156,7 +156,7 @@ function edd_get_email_body_header() {
 	<head>
 		<style type="text/css">#outlook a { padding: 0; }</style>
 	</head>
-	<body dir="<?php echo is_rtl() ? 'rtl' : 'ltr'; ?>">
+	<body dir="<?php echo is_rtl() ? 'rtl' : 'ltr'; ?>" style="margin: 0; padding: 0;">
 	<?php
 	do_action( 'edd_email_body_header' );
 	return ob_get_clean();


### PR DESCRIPTION
When changing the background colour there's always a margin/padding applied which causes white space when rendering the emails.

In most cases there isn't a need for the margin/padding.
