### PR TITLE
Tests for negative discounts

### DIFF
--- a/tests/unit-tests/discounts.php
+++ b/tests/unit-tests/discounts.php
@@ -40,7 +40,7 @@ class Tests_Discounts extends EDD_UnitTestCase {
 			'type' => 'percent',
 			'amount' => '-100',
 			'code' => 'DOUBLE',
-			'production_condition' => 'all',
+			'product_condition' => 'all',
 			'max' => 10,
 			'uses' => 54,
 			'min_price' => 0


### PR DESCRIPTION
#2247 - Makes the discount tests a bit more flexible as it's not all done on setup, and adds a few cases to test that negative discounts are being applied to totals and formats correctly.
