### PR TITLE
Added filter to allow modifying the variable prices

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -129,7 +129,7 @@ function edd_get_download_final_price( $download_id, $user_purchase_info, $amoun
  */
 function edd_get_variable_prices( $download_id ) {
 	$variable_prices = get_post_meta( $download_id, 'edd_variable_prices', true );
-	return apply_filters( 'edd_get_variable_prices', $variable_prices );
+	return apply_filters( 'edd_get_variable_prices', $variable_prices, $download_id );
 }
 
 /**


### PR DESCRIPTION
For simple downloads, the download price can be altered by adding a `edd_get_download_price` hook. The new hook will allow to do the same with variable prices, which, at the moment, cannot be modified if needed, because they are used straight away, in their raw form, as soon as they are loaded.

**Note**  
The only workaround, without the new filter, is to implement a hook for each and every single filter fired whenever the variables prices are loaded. This can easily become hard to maintain in the long run, especially when the task to be performed against the variable prices is the same every time.
