### PR TITLE
Remove duplicate payment meta

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -45,7 +45,6 @@ function edd_update_payment_details( $data ) {
 
 	$total      = edd_sanitize_amount( $_POST['edd-payment-total'] );
 	$tax        = isset( $_POST['edd-payment-tax'] ) ? edd_sanitize_amount( $_POST['edd-payment-tax'] ) : 0;
-	$meta       = edd_get_payment_meta( $payment_id );
 
 	// Setup date from input values
 	$date       = date( 'Y-m-d', strtotime( $date ) ) . ' ' . $hour . ':' . $minute . ':00';


### PR DESCRIPTION
edd_get_payment_meta() is called twice, can't see any reason why.
