### PR TITLE
Run price & earnings through utf8_encode

### DIFF
--- a/includes/admin/reporting/pdf-reports.php
+++ b/includes/admin/reporting/pdf-reports.php
@@ -110,8 +110,8 @@ function edd_generate_pdf( $data ) {
 
 				if( function_exists( 'iconv' ) ) {
 					// Ensure characters like euro; are properly converted. See GithuB issue #472 and #1570
-					$price    = iconv('UTF-8', 'windows-1252', $price );
-					$earnings = iconv('UTF-8', 'windows-1252', $earnings );
+					$price    = iconv('UTF-8', 'windows-1252', utf8_encode( $price ) );
+					$earnings = iconv('UTF-8', 'windows-1252', utf8_encode( $earnings ) );
 				}
 
 				$pdf->Row( array( $title, $price, $categories, $tags, $sales, $earnings ) );


### PR DESCRIPTION
This fixes the following notices (when using GBP) -

Notice: iconv() [function.iconv]: Detected an illegal character in input string in /wp-content/plugins/easy-digital-downloads/includes/admin/reporting/pdf-reports.php on line 113

Notice: iconv() [function.iconv]: Detected an illegal character in input string in /wp-content/plugins/easy-digital-downloads/includes/admin/reporting/pdf-reports.php on line 114

Also ensures that other currency symbols are displayed correctly (such as the Euro).
