### PR TITLE
Allowing multiple discounts to stack instead of overwrite

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1046,7 +1046,7 @@ function edd_get_cart_item_discount_amount( $item = array() ) {
 				foreach ( $reqs as $download_id ) {
 
 					if ( $download_id == $item['id'] && ! in_array( $item['id'], $excluded_products ) ) {
-						$discounted_price = edd_get_discounted_amount( $discount, $price );
+						$discounted_price -= $price - edd_get_discounted_amount( $discount, $price );
 					}
 
 				}
@@ -1069,8 +1069,7 @@ function edd_get_cart_item_discount_amount( $item = array() ) {
 						$discounted_price -= $discounted_amount;
 					} else {
 
-						$discounted_price = edd_get_discounted_amount( $discount, $price );
-
+						$discounted_price -= $price - edd_get_discounted_amount( $discount, $price );
 					}
 
 				}


### PR DESCRIPTION
#1904 - Seems to be working well. Even tested flat rates as well as the negative % discounts that Mika was using. The issue was mainly that we were just setting the discounted amount based off the full price, when in fact we needed a running discount tally, where we took the full price minus the discounted price to get the actual discount amount, and then subtract that from the running discounted amount.
