### PR TITLE
avoiding number_format expects double error

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -41,7 +41,7 @@ function edd_sanitize_amount( $amount ) {
 	}
 
 	$decimals = apply_filters( 'edd_sanitize_amount_decimals', 2, $amount );
-	$amount   = number_format( $amount, $decimals, '.', '' );
+	$amount   = number_format( (double) $amount, $decimals, '.', '' );
 
 	return apply_filters( 'edd_sanitize_amount', $amount );
 }


### PR DESCRIPTION
Under some circumstances `number_format` can return an error since it expects the var type to be `double`.

Now we're casting to make sure we get the proper type of var.
