### PR TITLE
Add class name to "remove" button in cart template.

### DIFF
--- a/templates/checkout_cart.php
+++ b/templates/checkout_cart.php
@@ -37,7 +37,7 @@
 							<input type="hidden" name="edd-cart-downloads[]" value="<?php echo $item['id']; ?>"/>
 							<input type="hidden" name="edd-cart-download-<?php echo $key; ?>-options" value="<?php esc_attr_e( serialize( $item['options'] ) ); ?>"/>
 						<?php endif; ?>
-						<a class="edd-cart-remove-item-btn" href="<?php echo esc_url( edd_remove_item_url( $key, $post ) ); ?>"><?php _e( 'Remove', 'edd' ); ?></a>
+						<a class="edd_cart_remove_item_btn" href="<?php echo esc_url( edd_remove_item_url( $key, $post ) ); ?>"><?php _e( 'Remove', 'edd' ); ?></a>
 					</td>
 					<?php do_action( 'edd_checkout_table_body_last', $item ); ?>
 				</tr>


### PR DESCRIPTION
The remove button in the default cart template doesn't have a class name. This makes it awkward to add a css style to it while developing themes. I have added a class name of "edd-cart-remove-item-btn" so that styles may easily be applied.
