### PR TITLE
Allow downloads shortcode to show all available downloads

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -249,10 +249,14 @@ function edd_downloads_query( $atts, $content = null ) {
 
 	$query = array(
 		'post_type'      => 'download',
-		'posts_per_page' => absint( $number ),
+		'posts_per_page' => (int) $number,
 		'orderby'        => $orderby,
 		'order'          => $order
 	);
+
+	if ( $query['posts_per_page'] < -1 ) {
+		$query['posts_per_page'] = abs( $query['posts_per_page'] );
+	}
 
 	switch ( $orderby ) {
 		case 'price':


### PR DESCRIPTION
When the `posts_per_page` argument is set to `-1` in a WP_Query object, it will [return all posts](http://codex.wordpress.org/Class_Reference/WP_Query#Pagination_Parameters). However, in the downloads shortcode, this value is not possible, because the `number` variable is being sanitized with `absint()`, forcing a positive integer.

This change is valuable in cases where you don't know how many downloads will be displayed with the other given criteria, but you want to make sure you get all of them.
