### PR TITLE
Make column counter variable available in filter

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -359,7 +359,7 @@ function edd_downloads_query( $atts, $content = null ) {
 		ob_start(); ?>
 		<div class="edd_downloads_list <?php echo apply_filters( 'edd_downloads_list_wrapper_class', $wrapper_class, $atts ); ?>">
 			<?php while ( $downloads->have_posts() ) : $downloads->the_post(); ?>
-				<div itemscope itemtype="http://schema.org/Product" class="<?php echo apply_filters( 'edd_download_class', 'edd_download', get_the_ID(), $atts ); ?>" id="edd_download_<?php echo get_the_ID(); ?>" style="width: <?php echo $column_width; ?>; float: left;">
+				<div itemscope itemtype="http://schema.org/Product" class="<?php echo apply_filters( 'edd_download_class', 'edd_download', get_the_ID(), $atts, $i ); ?>" id="edd_download_<?php echo get_the_ID(); ?>" style="width: <?php echo $column_width; ?>; float: left;">
 					<div class="edd_download_inner">
 						<?php
 


### PR DESCRIPTION
This commit simply makes the existing column counter variable (`$i`) available as a parameter within the `edd_download_class` filter hook. This is beneficial in cases where you want to apply specific styles to downloads in the grid based on which column they are in or their order in the list.

Example usage:

``` php
function my_edd_download_class( $class, $id, $atts, $i ) {
    if ( 0 === $i % 2 ) {
        $class .= ' edd_download_even';
    }
    return $class;
}
add_filter( 'edd_download_class', 'my_edd_download_class', 10, 4 );
```
