### PR TITLE
Fix Error 400 Bad Request on API call

### DIFF
--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -173,7 +173,6 @@ class EDD_License {
 			add_query_arg( $api_params, $this->api_url ),
 			array(
 				'timeout'   => 15,
-				'body'      => $api_params,
 				'sslverify' => false
 			)
 		);


### PR DESCRIPTION
I was running into the same issue as mentioned at https://easydigitaldownloads.com/support/topic/error-400-bad-request-on-api-call/

License key activation does not work if you include the `$params` in the request body of a `wp_remote_get()` call. You get a 400 bad request.

By removing this line, the license activation is successful.
