### PR TITLE
Avoid warnings for users that have upgraded from pre-2.0

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -94,8 +94,8 @@ class edd_categories_tags_widget extends WP_Widget {
 
 		$title      = apply_filters( 'widget_title', $instance[ 'title' ], $instance, $id );
 		$tax        = $instance['taxonomy'];
-		$count      = isset($instance['count']) && $instance['count'] == 'on' ? 1 : 0;
-		$hide_empty = isset($instance['hide_empty']) && $instance['hide_empty'] == 'on' ? 1 : 0;
+		$count      = isset( $instance['count'] ) && $instance['count'] == 'on' ? 1 : 0;
+		$hide_empty = isset( $instance['hide_empty'] ) && $instance['hide_empty'] == 'on' ? 1 : 0;
 
 
 		global $post, $edd_options;


### PR DESCRIPTION
Users that have an existing tags widget published from pre-2.0 will not have values set for $instance['count'] or $instance['hide_empty'] causing warnings to be thrown. 
