### PR TITLE
Added total and subtotal values to some ajax returns

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -120,7 +120,7 @@ function edd_ajax_add_to_cart() {
 
 		$return = array(
 			'subtotal'  => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_subtotal() ) ), ENT_COMPAT, 'UTF-8' ),
-			'total'     => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' )
+			'total'     => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' ),
 			'cart_item' => $items
 		);
 


### PR DESCRIPTION
Added total value to ajax return when adding or removing item from cart, and subtotal value when updating item quantity.
In case discounts are already applied we need both total and subtotal values returned for these actions.
