### PR TITLE
Apply 100% width to Chosens added dynamically.

### DIFF
--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -1034,8 +1034,8 @@ jQuery(document).ready(function ($) {
 	});
 
 	// This fixes the Chosen box being 0px wide when the thickbox is opened
-	$('.edd-thickbox').on('click', function() {
-		$('#choose-download .edd-select-chosen').css('width', '100%');
+	$( '#post' ).on( 'click', '.edd-thickbox', function() {
+		$( '.edd-select-chosen', '#choose-download' ).css( 'width', '100%' );
 	});
 
 	/**


### PR DESCRIPTION
When clicking the "Insert Download" button in the WordPress for an editor that is dynamically added to the edit screen, the select box is broken because the CSS fix is not applied to the select box. This issue is caused by the event being improperly delegated. By binding the event to `#post`, it will be applied to WordPress editors that are added dynamically.

Additionally, the `$('#choose-download .edd-select-chosen')` is an inefficient selector and has been improved (test http://jsperf.com/jquery-selector-race).
