### PR TITLE
Update edd-ajax.js

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -282,7 +282,7 @@ jQuery(document).ready(function ($) {
                 $('.edd_errors').remove();
                 $('#edd_purchase_form').submit();
             } else {
-                $('#edd_purchase_form input[type=submit]#edd-purchase-button').val(complete_purchase_val);
+                $('#edd_purchase_form #edd-purchase-button').val(complete_purchase_val);
                 $('.edd-cart-ajax').remove();
                 $('.edd_errors').remove();
                 $('#edd_purchase_submit').before(data);


### PR DESCRIPTION
Purchase button in checkout needed a more targeted jquery specifier to change its text back from Please wait... to Purchase.
Before, if there was an error in the purchase form, the Apply button (for discount codes) and any Login button would also change their text to 'Purchase'! They still worked fine, but the text was wrong - up to three buttons on the page all said 'Purchase' at that point.
