### PR TITLE
Add full changelog page

### DIFF
--- a/includes/admin/welcome.php
+++ b/includes/admin/welcome.php
@@ -57,8 +57,8 @@ class EDD_Welcome {
 
 		// Changelog Page
 		add_dashboard_page(
-			__( 'Welcome to Easy Digital Downloads', 'edd' ),
-			__( 'Welcome to Easy Digital Downloads', 'edd' ),
+			__( 'Easy Digital Downloads Changelog', 'edd' ),
+			__( 'Easy Digital Downloads Changelog', 'edd' ),
 			$this->minimum_capability,
 			'edd-changelog',
 			array( $this, 'changelog_screen' )


### PR DESCRIPTION
Fixes issue #2344 by adding a small link to the bottom of the 'What's New' page allowing advanced users to view the full changelog. The full changelog isn't accessible via a tab like other pages are, meaning it's not providing unnecessary clutter for less-interested users, but is still easily accessible to those who care.
