### PR TITLE
Dashboard widget deleted user check

### DIFF
--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -161,7 +161,9 @@ function edd_dashboard_sales_widget() {
 								</a>
 								<?php if ( $payment->user_info['id'] > 0 ) {
 									$user = get_user_by( 'id', $payment->user_info['id'] );
-									echo "(" . $user->data->user_login . ")";
+									if ( $user ) {
+										echo "(" . $user->data->user_login . ")";
+									}
 								} ?>
 							</td>
 							<td class="edd_order_price">


### PR DESCRIPTION
If user has been deleted, dashboard widget will throw an error, so we
need to check if user exist before printing his username
