### PR TITLE
MySQL version support over multiple PHP versions

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -524,9 +524,7 @@ function edd_tools_sysinfo_get() {
 	// Server configuration (really just versioning)
 	$return .= "\n" . '-- Webserver Configuration' . "\n\n";
 	$return .= 'PHP Version:              ' . PHP_VERSION . "\n";
-	if ( function_exists( 'mysqli_get_client_version' ) ) {
-		$return .= 'MySQL Version:            ' . mysqli_get_client_version() . "\n";
-	}
+	$return .= 'MySQL Version:            ' . $wpdb->db_version() . "\n";
 	$return .= 'Webserver Info:           ' . $_SERVER['SERVER_SOFTWARE'] . "\n";
 
 	$return  = apply_filters( 'edd_sysinfo_after_webserver_config', $return );


### PR DESCRIPTION
PHP 5.4 and less use mysql_get_server_info()
PHP 5.5 and above use mysqli_get_server_info()
