### PR TITLE
Discount field focus & enter key improvements

### DIFF
--- a/assets/js/edd-checkout-global.js
+++ b/assets/js/edd-checkout-global.js
@@ -261,8 +261,7 @@ jQuery(document).ready(function($) {
     $body.on('click', '.edd_discount_link', function(e) {
         e.preventDefault();
         $('.edd_discount_link').parent().hide();
-        $('#edd-discount-code-wrap').show()
-            .find('#edd-discount').focus();
+        $('#edd-discount-code-wrap').show().find('#edd-discount').focus();
     });
 
     // Hide / show discount fields for browsers without javascript enabled


### PR DESCRIPTION
When the user clicks the link to show the discount field, set focus to it to save them an additional click.

Then when they enter the discount code and hit Enter, attempt to apply the code.
