### PR TITLE
Wrong variable name in function edd_format_amount

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -73,7 +73,7 @@ function edd_format_amount( $amount, $decimals = true ) {
 	$decimal_sep   = edd_get_option( 'decimal_separator', '.' );
 
 	// Format the amount
-	if ( $decimal_sep == ',' && false !== ( $found = strpos( $amount, $decimal_sep ) ) ) {
+	if ( $decimal_sep == ',' && false !== ( $sep_found = strpos( $amount, $decimal_sep ) ) ) {
 		$whole = substr( $amount, 0, $sep_found );
 		$part = substr( $amount, $sep_found + 1, ( strlen( $amount ) - 1 ) );
 		$amount = $whole . '.' . $part;


### PR DESCRIPTION
$found was used instead of $sep_found leading to a wrong calculation of taxes in the cart and other misbehaviour when the total amount included decimals.

Debugging this fixes errors discussed in https://easydigitaldownloads.com/support/topic/wrong-tax-amount-and-cart-total/ on the support forum
