### PR TITLE
Set same meta on cart items added manually to a payment

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -85,7 +85,7 @@ function edd_update_payment_details( $data ) {
 				'id'          => $download['id'],
 				'item_number' => $item,
 				'price'       => $download['amount'],
-				'item_price'  => $download['amount'] / $download['quantity'],
+				'item_price'  => round( $download['amount'] / $download['quantity'], 2 ),
 				'quantity'    => $download['quantity'],
 				'discount'    => 0,
 				'tax'         => 0,


### PR DESCRIPTION
This make sure that the same meta keys are set on cart items that are added to a payment manually through the edit payment screen as occur on a normal order.

Fixes #2404.
