### PR TITLE
Restrict loading EDD scripts

### DIFF
--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -56,12 +56,16 @@ function edd_is_admin_page() {
 		return false;
 	}
 	
-	global $pagenow, $typenow, $edd_discounts_page, $edd_payments_page, $edd_settings_page, $edd_reports_page, $edd_system_info_page, $edd_add_ons_page, $edd_settings_export, $edd_upgrades_screen;
+	global $wp, $pagenow, $typenow, $edd_discounts_page, $edd_payments_page, $edd_settings_page, $edd_reports_page, $edd_system_info_page, $edd_add_ons_page, $edd_settings_export, $edd_upgrades_screen;
 
-	if ( 'download' == $typenow || 'index.php' == $pagenow || 'post-new.php' == $pagenow || 'post.php' == $pagenow ) {
+	if ( 'download' == $typenow ) { //|| 'index.php' == $pagenow || 'post-new.php' == $pagenow || 'post.php' == $pagenow ) {
 		return true;
 	}
 	
+	if ( 'index.php' == $pagenow && empty( $_SERVER['QUERY_STRING'] ) ) {
+		return true;
+	}
+
 	$edd_admin_pages = apply_filters( 'edd_admin_pages', array( $edd_discounts_page, $edd_payments_page, $edd_settings_page, $edd_reports_page, $edd_system_info_page, $edd_add_ons_page, $edd_settings_export, $edd_upgrades_screen, ) );
 	
 	if ( in_array( $pagenow, $edd_admin_pages ) ) {


### PR DESCRIPTION
Fixes #2364

I THINK this covers all possible scenarios for pages requiring EDD scripts without loading it anywhere crazy. Removed `page-new.php` and `page.php` as those are covered by the existing `'download' == $typenow` check and moved `'index.php' == $pagenow` to a separate check with the condition that the query string is empty so that it ONLY loads on the dashboard homepage. Seems loading it on all children of index.php was causing issues with other plugins...
