### PR TITLE
#2446 Fix for issue with wrong price, tax and discount when quantity > 1 and tax is applied after discount.

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -446,7 +446,7 @@ function edd_get_cart_item_tax( $item = array() ) {
 		}
 
 		if( edd_taxes_after_discounts() ) {
-			$price -= apply_filters( 'edd_get_cart_item_tax_item_discount_amount', edd_get_cart_item_discount_amount( $item ), $item );
+			$price -= apply_filters( 'edd_get_cart_item_tax_item_discount_amount', edd_get_cart_item_discount_amount( $item ), $item ) / $item['quantity'];
 		}
 
 		$country = ! empty( $_POST['billing_country'] ) ? $_POST['billing_country'] : false;


### PR DESCRIPTION
`edd_get_cart_item_tax()` function in `/includes/cart/functions.php` is being used to get tax for a single item (`$item['quantity'] = 1`).
It uses `edd_get_cart_item_discount_amount()` function to get discount. In case tax is calculated after discount.
But `edd_get_cart_item_discount_amount()` function returns discount for all items (`$item['quantity']`).
Thus in case `$item['quantity']>1` we have wrong discount for each item. And wrong tax.
1. The easiest way to fix this is to divide discount by `$item['quantity']`.
2. Second way is to change it in the `edd_get_cart_item_discount_amount()` function.
   But this function is being used twice in `/includes/cart/functions.php`
   And in one place we need discount for one item and in other place we need discount for all cart items…
   
   In case if we change the `edd_get_cart_item_discount_amount()` function, we need also multiply it on items quantity in other place in `/includes/cart/functions.php:48` and only if discount is not flat…
   Otherwise it may cause bugs for flat discounts.
   Too much changes as for me.
   But sure it’s up to you =)
