### PR TITLE
Remove button needs true page/post id

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -772,14 +772,15 @@ function edd_add_collection_to_cart( $taxonomy, $terms ) {
  * @return string $remove_url URL to remove the cart item
  */
 function edd_remove_item_url( $cart_key, $post, $ajax = false ) {
-	global $post;
+	
+	global $wp_query;
 
-	if ( defined('DOING_AJAX') ){	
+	if ( defined('DOING_AJAX') ){
 		$current_page = edd_get_checkout_uri();
 	} else if( is_page() ) {
-		$current_page = add_query_arg( 'page_id', $post->ID, home_url( 'index.php' ) );
+		$current_page = add_query_arg( 'page_id', $wp_query->queried_object_id, home_url( 'index.php' ) );
 	} else if( is_singular() ) {
-		$current_page = add_query_arg( 'p', $post->ID, home_url( 'index.php' ) );
+		$current_page = add_query_arg( 'p', $wp_query->queried_object_id, home_url( 'index.php' ) );
 	} else {
 		$current_page = edd_get_current_page_url();
 	}


### PR DESCRIPTION
This is for the remove button in the cart. It is getting the wrong query arg for the post id in a situation where you are running a loop on a page and have the cart loading inside that loop somewhere. The global $post var is actually not the true post object for the page or post we are on.

If we use $wp_query instead, we will get the id of the parent page no matter what loops might be running on the page.
