### PR TITLE
Add downloads to At A Glance widget

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -127,7 +127,7 @@ textarea#edd-payment-note { width: 100%; height: 4em; margin: 0; }
 .edd_repeatable_upload_wrapper .pricing select, .edd_repeatable_product_wrapper .edd-select,
 #edd_products .edd-select { min-width: 100%; max-width: 200px; }
 .edd_repeatable_product_wrapper td { overflow: visible; }
-@media screen and ( max-width: 782px ) { 
+@media screen and ( max-width: 782px ) {
 	.order-data-column input[type="email"] {
 		padding: 6px 10px;
 	}
@@ -179,7 +179,7 @@ textarea#edd-payment-note { width: 100%; height: 4em; margin: 0; }
 @media screen and ( max-width: 1284px ) {
 	#edd-edit-order-form .column strong {
 		display:block;
-	} 
+	}
 }
 
 /** Stats */

--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -181,3 +181,31 @@ function edd_dashboard_sales_widget() {
 	</div>
 	<?php
 }
+
+/**
+ * Add download count to At a glance widget
+ *
+ * @author Daniel J Griffiths
+ * @since 2.1
+ * @return void
+ */
+function edd_dashboard_at_a_glance_widget( $items ) {
+	$num_posts = wp_count_posts( 'download' );
+
+	if ( $num_posts && $num_posts->publish ) {
+		$text = _n( '%s ' . edd_get_label_singular(), '%s ' . edd_get_label_plural(), $num_posts->publish );
+
+		$text = sprintf( $text, number_format_i18n( $num_posts->publish ) );
+
+		if ( current_user_can( 'edit_products' ) ) {
+			$text = sprintf( '<a class="download-count" href="edit.php?post_type=download">%1$s</a>', $text );
+		} else {
+			$text = sprintf( '<span class="download-count">%1$s</span>', $text );
+		}
+
+		$items[] = $text;
+	}
+
+	return $items;
+}
+add_filter( 'dashboard_glance_items', 'edd_dashboard_at_a_glance_widget', 1 );

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -224,7 +224,8 @@ function edd_admin_downloads_icon() {
 	?>
     <style type="text/css" media="screen">
         <?php if( version_compare( $wp_version, '3.8-RC', '>=' ) || version_compare( $wp_version, '3.8', '>=' ) ) { ?>
-            #adminmenu #menu-posts-download .wp-menu-image:before {
+            #adminmenu #menu-posts-download .wp-menu-image:before,
+            #dashboard_right_now .download-count:before {
                 content: '<?php echo $menu_icon; ?>';
             }
         <?php } else { ?>


### PR DESCRIPTION
Fixes issue #2451. Accidentally added a whitespace trim to the edd-admin.css file, can resubmit without if you'd like, but figured since it's just whitespace it probably isn't a big deal...
