### PR TITLE
Update select dropdown output - do not try to use null value as selected

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -68,7 +68,7 @@ class EDD_HTML_Elements {
 					$options[$item] = get_the_title( $item );
 				}
 			}
-		} elseif ( is_numeric( $args['selected'] ) ) {
+		} elseif ( is_numeric( $args['selected'] ) && $args['selected'] !== 0 ) {
 			if ( ! in_array( $args['selected'], $options ) ) {
 				$options[$args['selected']] = get_the_title( $args['selected'] );
 			}
@@ -353,7 +353,7 @@ class EDD_HTML_Elements {
 		}
 
 		$output = '<span id="edd-' . sanitize_key( $args[ 'name' ] ) . '-wrap">';
-			
+
 			$output .= '<label class="edd-label" for="edd-' . sanitize_key( $args[ 'name' ] ) . '">' . esc_html( $args[ 'label' ] ) . '</label>';
 
 			if ( ! empty( $args[ 'desc' ] ) ) {
@@ -435,7 +435,7 @@ class EDD_HTML_Elements {
 
 		$args['class'] = 'edd-ajax-user-search ' . $args['class'];
 
-		$output  = '<span class="edd_user_search_wrap">'; 
+		$output  = '<span class="edd_user_search_wrap">';
 			$output .= $this->text( $args );
 			$output .= '<span class="edd_user_search_results"></span>';
 		$output .= '</span>';


### PR DESCRIPTION
**The Bug**
If a product bundle doesn't have any bundled products, then the current product is added to the bundle select field.

**What Causes it**
The reason for this is that when the product dropdown field is created, the value passed for the selected option is `null`. However in the `product_dropdown` function - if the selected value is not an array, the following code is run:

```
if ( ! in_array( $args['selected'], $options ) ) {
    $options[$args['selected']] = get_the_title( $args['selected'] );
}
```

which results in the current post getting added to the options array.

**Solution**
This pull request fixes the issue by only trying to add the selected item to the options array if the selected value passed is numeric and not 0. Ensuring that it is always a valid post.
