### PR TITLE
Addition to requesting user details on checkout

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -327,6 +327,9 @@ function edd_purchase_form_required_fields() {
 			'error_id' => 'invalid_email',
 			'error_message' => __( 'Please enter a valid email address', 'edd' )
 		);
+	}
+
+	if ( ! is_user_logged_in() || ! wp_get_current_user()->user_firstname ) {
 		$required_fields['edd_first'] = array(
 			'error_id' => 'invalid_first_name',
 			'error_message' => __( 'Please enter your first name', 'edd' )


### PR DESCRIPTION
Don't require 'edd_email' and 'edd_first' fields if user is looged in,
cause if they are not sent we will pull them from current user.
Otherwise current user details don't mean anything because error will
be set to edd system that will prevent the checkout.
- some extra spaces and commas removed
