### PR TITLE
Cache the User ID when making a call to the API.

### DIFF
--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -228,7 +228,7 @@ class EDD_API {
 
 		$user = get_transient( md5( 'edd_api_user_' . $key ) );
 
-		if ( ! $user ) {
+		if ( false === $user ) {
 			$user = $wpdb->get_var( $wpdb->prepare( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = 'edd_user_public_key' AND meta_value = %s LIMIT 1", $key ) );
 			set_transient( md5( 'edd_api_user_' . $key ) , $user, DAY_IN_SECONDS );
 		}


### PR DESCRIPTION
Uses transients to store the user ID based off the key, hashed with a string to make sure we don't run over the 44 character limit on transient names.

Also includes deleting the transients when an api key is revoked.
#2496
