### PR TITLE
Allow empty fields to take into account custom template

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -594,10 +594,10 @@ function edd_process_profile_editor_updates( $data ) {
 	$user_id       = get_current_user_id();
 	$old_user_data = get_userdata( $user_id );
 
-	$display_name = sanitize_text_field( $data['edd_display_name'] );
-	$first_name   = sanitize_text_field( $data['edd_first_name'] );
-	$last_name    = sanitize_text_field( $data['edd_last_name'] );
-	$email        = sanitize_email( $data['edd_email'] );
+	$display_name = isset( $data['edd_display_name'] ) ? sanitize_text_field( $data['edd_display_name'] ) : $old_user_data->display_name;
+	$first_name   = isset( $data['edd_first_name'] ) ? sanitize_text_field( $data['edd_first_name'] ) : $old_user_data->first_name;
+	$last_name    = isset( $data['edd_last_name'] ) ? sanitize_text_field( $data['edd_last_name'] ) : $old_user_data->last_name;
+	$email        = isset( $data['edd_email'] ) ? sanitize_email( $data['edd_email'] ) : $old_user_data->user_email;
 	$line1        = ( isset( $data['edd_address_line1'] ) ? sanitize_text_field( $data['edd_address_line1'] ) : '' );
 	$line2        = ( isset( $data['edd_address_line2'] ) ? sanitize_text_field( $data['edd_address_line2'] ) : '' );
 	$city         = ( isset( $data['edd_address_city'] ) ? sanitize_text_field( $data['edd_address_city'] ) : '' );


### PR DESCRIPTION
If for some reason a custom shortcode template doesn't use display name, first/last name or email address it results in a undefined index. Ideally these should be optional and if they aren't provided they should fall back to the original values.
