### PR TITLE
Bug in EDD reports if columns are deleted

### DIFF
--- a/includes/admin/reporting/class-export.php
+++ b/includes/admin/reporting/class-export.php
@@ -148,10 +148,9 @@ class EDD_Export {
 				// Make sure the column is valid
 				if ( array_key_exists( $col_id, $cols ) ) {
 					echo '"' . $column . '"';
-					echo $i == count( $cols ) + 1 ? '' : ',';
+					echo $i == count( $cols ) ? '' : ',';
+					$i++;
 				}
-
-				$i++;
 			}
 			echo "\r\n";
 		}


### PR DESCRIPTION
This fixes issue #2526

I'm using the edd_export_csv_cols_payments filter to remove (and add - but I don't think that's important) some columns from a report with "unset( $columns['address1'] )" etc.

The bug showed itself in the omission of a comma between two fields in the CSV file (in my case I was looking at the products report, but I think it probably affects other reports too). As a result, when you import the CSV file into a spreadsheet, you get two fields joined in the same cell. Delete one field & it's the last comma missing in each row (between fields n & 'n-1'). Each additional field you delete moves the missing comma one field to the left.

Looking at the code here, if you delete any columns from the report then the number of 'columns' in the data array ($data) is greater than the number in the column headers array ($cols).

The loop on line 147 goes through each element in the data, then line 149 discards any items which aren't in the required output columns.

The code manages a counter $i which tracks when you get to the final column (judged by the number of column headers) and decides whether or not to add a comma after the value.

The OLD code incremented the counter regardless of whether the data value was output into the report. This has to be wrong - you only want to advance the counter if you've actually outputted the value as discarded fields don't affect the layout.

Also the "+1" in the comparison is at odds with the code on line 100 - I don't think the offset is needed.
