### PR TITLE
Fixing undefined variable notice of  on filter

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -402,7 +402,7 @@ function edd_get_cart_item_price( $download_id = 0, $options = array() ) {
 
 	}
 
-	return apply_filters( 'edd_cart_item_price', $price, $download_id, $options, $include_taxes );
+	return apply_filters( 'edd_cart_item_price', $price, $download_id, $options );
 }
 
 /**


### PR DESCRIPTION
#2347 - Since we removed the `$include_taxes` argument for the chain of events leading to this function, we need to remove it from the filter.
