### PR TITLE
Bug: General filter doesn't respect all field type specific filters

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -703,7 +703,7 @@ function edd_settings_sanitize( $input = array() ) {
 
 		if ( $type ) {
 			// Field type specific filter
-			$input[$key] = apply_filters( 'edd_settings_sanitize_' . $type, $value, $key );
+			$value = apply_filters( 'edd_settings_sanitize_' . $type, $value, $key );
 		}
 
 		// General filter


### PR DESCRIPTION
In the function edd_settings_sanitize, general filter edd_settings_sanitize use $value as one of the filter arguments. This ignores all field type specific filters 'edd_settings_sanitize_' . $type.

```
if ( $type ) {
    // Field type specific filter
    $input[$key] = apply_filters( 'edd_settings_sanitize_' . $type, $value, $key );
}
// General filter
$input[$key] = apply_filters( 'edd_settings_sanitize', $value, $key );
```

See issue #2532 
