### PR TITLE
Use correct capability to check ability to export records

### DIFF
--- a/includes/admin/reporting/class-export.php
+++ b/includes/admin/reporting/class-export.php
@@ -35,7 +35,7 @@ class EDD_Export {
 	 * @return bool Whether we can export or not
 	 */
 	public function can_export() {
-		return (bool) apply_filters( 'edd_export_capability', current_user_can( 'manage_options' ) );
+		return (bool) apply_filters( 'edd_export_capability', current_user_can( 'export_shop_reports' ) );
 	}
 
 	/**


### PR DESCRIPTION
See issue #2534

Users with export_shop_reports capability should be able to export the shop reports. By validating against manage_options the code was denying users with the role shop_manager or shop_accountant (who have export_shop_reports capability but don't have manage_options) and limiting export to administrators only.
