### PR TITLE
Start sessions properly. Perform check and start at same time.

### DIFF
--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -58,10 +58,7 @@ class EDD_Session {
 		if( $this->use_php_sessions ) {
 
 			// Use PHP SESSION (must be enabled via the EDD_USE_PHP_SESSIONS constant)
-
-			if( ! session_id() ) {
-				add_action( 'init', 'session_start', -2 );
-			}
+			add_action( 'init', array( $this, 'maybe_start_session' ), -2 );
 
 		} else {
 
@@ -92,7 +89,6 @@ class EDD_Session {
 		}
 
 	}
-
 
 	/**
 	 * Setup the WP_Session instance
@@ -215,5 +211,16 @@ class EDD_Session {
 	 */
 	public function set_expiration_time( $exp ) {
 		return ( 30 * 60 * 24 );
+	}
+
+	/**
+	 * Starts a new session if one hasn't started yet.
+	 *
+	 * @return null
+	 */
+	public function maybe_start_session() {
+		if( ! session_id() ) {
+			session_start();
+		}
 	}
 }


### PR DESCRIPTION
The code was checking for `session_id` and then adding an action to later start a session. In the meantime, a session could have been started.

In this PR, the check for a session and the start happen at the same time.

Also, when using `add_action` to start the session the `session_start()` function is called with parameters, which throws notices on certain PHP versions.

Hoping to get this in before v2.1. :smile:
