### PR TITLE
Allow the list of registered settings to be filtered

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -664,7 +664,7 @@ function edd_get_registered_settings() {
 		)
 	);
 
-	return $edd_settings;
+	return apply_filters( 'edd_registered_settings', $edd_settings );
 }
 
 /**


### PR DESCRIPTION
Currently if an extension wants to register settings into the EDD settings page they can add an additional tab using the edd_settings_tabs filter. However there doesn't seem to be a way for a plugin to register the settings using the main EDD infrastructure, the only way to actually add the fields is to use the main add_settings_field WP APIs which means you can't take advantage of the more succinct EDD API. 

Adding the filter in the attached PR allows addons to register their settings and have them handled by EDD, e.g. 

``` php
    public function construct() {
        add_filter( 'edd_settings_tabs', array( $this, 'add_edd_settings_tab' ) );
        add_filter( 'edd_settings', array( $this, 'edd_settings' ) );
    }

    public function add_edd_settings_tab( $tabs ) {
        $tabs['edd_addon'] = __( 'My Adddon', 'edd_addon' );
        return $tabs;
    }

    public function edd_settings( $settings ) {
        $settings['edd_addon'] = array(
            array(
                'id' => 'some_value',
                'name' => __('Some Value', 'edd_addon'),
                'desc' => __('Description of some value setting', 'edd_addon'),
                'type' => 'text',
                'size' => 'regular',
            ),
        );
        return $settings;
    }
```

Of course, it's possible I've missed the "right way" to do this ... 
