### PR TITLE
Attachments persistence

### DIFF
--- a/includes/emails/class-edd-emails.php
+++ b/includes/emails/class-edd-emails.php
@@ -189,7 +189,7 @@ class EDD_Emails {
 	 *
 	 * @since 2.1
 	 */
-	public function build_email( $message, $heading ) {
+	public function build_email( $message ) {
 
 		if ( false === $this->html ) {
 			return apply_filters( 'edd_email_message', wp_strip_all_tags( $message ), $this );
@@ -215,7 +215,6 @@ class EDD_Emails {
 
 		$body    = ob_get_clean();
 		$message = str_replace( '{email}', $message, $body );
-		$message = str_replace( '{heading}', $heading, $message );
 
 		return apply_filters( 'edd_email_message', $message, $this );
 	}
@@ -225,21 +224,14 @@ class EDD_Emails {
 	 * @param  string  $to               The To address to send to.
 	 * @param  string  $subject          The subject line of the email to send.
 	 * @param  string  $message          The body of the email to send.
-	 * @param  string  $heading          A heading to use at the top of the email body. If you pass an
-	 *                                   empty string (the default), then the subject will be used. To
-	 *                                   have no heading at all, pass NULL.
 	 * @param  string|array $attachments Attachments to the email in a format supported by wp_mail()
 	 * @since 2.1
 	 */
-	public function send( $to, $subject, $message, $heading = '', $attachments = '' ) {
+	public function send( $to, $subject, $message, $attachments = '' ) {
 
 		if ( ! did_action( 'init' ) && ! did_action( 'admin_init' ) ) {
 			_doing_it_wrong( __FUNCTION__, __( 'You cannot send email with EDD_Emails until init/admin_init has been reached', 'edd' ), null );
 			return false;
-		}
-
-		if ( !is_null( $heading ) && empty( $heading ) ) {
-			$heading = $subject;
 		}
 
 		do_action( 'edd_email_send_before', $this );
@@ -247,7 +239,7 @@ class EDD_Emails {
 		$subject = $this->parse_tags( $subject );
 		$message = $this->parse_tags( $message );
 
-		$message = $this->build_email( $message, $heading );
+		$message = $this->build_email( $message );
 		if ( empty( $attachments ) ) {
 			$attachments = apply_filters( 'edd_email_default_attachments', '' );
 		}

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -47,7 +47,7 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true ) {
 	$headers = apply_filters( 'edd_receipt_headers', $emails->get_headers(), $payment_id, $payment_data );
 	$emails->__set( 'headers', $headers );
 
-	$emails->send( $to_email, $subject, $message, $subject, $attachments );
+	$emails->send( $to_email, $subject, $message, $attachments );
 
 	if ( $admin_notice && ! edd_admin_notices_disabled( $payment_id ) ) {
 		do_action( 'edd_admin_sale_notice', $payment_id, $payment_data );
@@ -84,7 +84,7 @@ function edd_email_test_purchase_receipt() {
 	$headers = apply_filters( 'edd_receipt_headers', $emails->get_headers(), 0, array() );
 	$emails->__set( 'headers', $headers );
 
-	$emails->send( edd_get_admin_notice_emails(), $subject, $message, $subject, $attachments );
+	$emails->send( edd_get_admin_notice_emails(), $subject, $message, $attachments );
 
 }
 
@@ -123,7 +123,7 @@ function edd_admin_email_notice( $payment_id = 0, $payment_data = array() ) {
 	$emails->__set( 'from_email', $from_email );
 	$emails->__set( 'headers', $headers );
 
-	$emails->send( edd_get_admin_notice_emails(), $subject, $message, $subject, $attachments );
+	$emails->send( edd_get_admin_notice_emails(), $subject, $message, $attachments );
 
 }
 add_action( 'edd_admin_sale_notice', 'edd_admin_email_notice', 10, 2 );

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -137,7 +137,7 @@ function edd_display_email_template_preview() {
 		return;
 	}
 
-	echo EDD()->emails->build_email( edd_email_preview_template_tags( edd_get_email_body_content( 0, array() ) ), _e( 'Purchase Receipt', 'edd' ) );
+	echo EDD()->emails->build_email( edd_email_preview_template_tags( edd_get_email_body_content( 0, array() ) ) );
 	exit;
 
 }

--- a/templates/emails/header-default.php
+++ b/templates/emails/header-default.php
@@ -84,7 +84,7 @@ $header_img = edd_get_option( 'email_logo', '' );
 								<table border="0" cellpadding="0" cellspacing="0" width="520" id="template_header" style="<?php echo $template_header; ?>" bgcolor="#ffffff">
 									<tr>
 										<td>
-											<h1 style="<?php echo $header_content_h1; ?>">{heading}</h1>
+											<h1 style="<?php echo $header_content_h1; ?>"><?php _e( 'Purchase Receipt', 'edd' ); ?></h1>
 										</td>
 									</tr>
 								</table>


### PR DESCRIPTION
Hi Pippin, 

This is a revised version of the earlier PR. This just deals with making the attachments belong only to the call to send() so they're not accidentally reused. 

The issues with the hardcoded header are still there - unfortunately I've not had time to look at that today, but I think this PR is valid in isolation now.
