### PR TITLE
Fixed incorrect remove by ajax cart IDs and amounts

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -33,25 +33,26 @@ jQuery(document).ready(function ($) {
 
 	                // Remove the selected cart item
 	                $('.edd-cart').find("[data-cart-item='" + item + "']").parent().remove();
-
+					
+					//Reset the data-cart-item attributes to match their new values in the EDD session cart array
+					var cart_item_counter = 0;
+					$('.edd-cart').find("[data-cart-item]").each(function(){
+						$(this).attr('data-cart-item', cart_item_counter);
+						cart_item_counter = cart_item_counter + 1;
+					});
+					
 	                // Check to see if the purchase form for this download is present on this page
 	                if( $( '#edd_purchase_' + id ).length ) {
 	                    $( '#edd_purchase_' + id + ' .edd_go_to_checkout' ).hide();
 	                    $( '#edd_purchase_' + id + ' a.edd-add-to-cart' ).show().removeAttr('data-edd-loading');
 	                }
 
-	                $('span.edd-cart-quantity').each(function() {
-	                    var quantity = parseInt( $(this).text(), 10 ) - 1;
-	                    if( quantity < 1 ) {
-	                    	quantity = 0;
-	                    }
-	                    $(this).text( quantity );
-	                    $('body').trigger('edd_quantity_updated', [ quantity ]);
-	                });
+	                $('span.edd-cart-quantity').text( response.cart_quantity );
+	                $('body').trigger('edd_quantity_updated', [ response.cart_quantity ]);
 
 	                $('.cart_item.edd_subtotal span').html( response.subtotal );
 
-	                if(!$('.edd-cart-item').length) {
+	                if( response.cart_quantity == 0 ) {
 	                    $('.cart_item.edd_subtotal,.edd-cart-number-of-items,.cart_item.edd_checkout').hide();
 	                    $('.edd-cart').append('<li class="cart_item empty">' + edd_scripts.empty_cart_message + '</li>');
 	                }

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -124,7 +124,8 @@ function edd_ajax_remove_from_cart() {
 		$return = array(
 			'removed'  => 1,
 			'subtotal' => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_subtotal() ) ), ENT_COMPAT, 'UTF-8' ),
-			'total'    => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' )
+			'total'    => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' ),
+			'cart_quantity' => html_entity_decode( edd_get_cart_quantity() ),
 		);
 
 		echo json_encode( $return );


### PR DESCRIPTION
When removing an item from the cart widget, it was removing the item we wanted it to, but not resetting the cart ID (data-cart-item). This means that if you had 3 items in the cart(0, 1, 2) and removed item 1, the items left were still labelled as 0 and 2, rather than 0 and 1. This meant that if you, then, removed item 3, it didn't exist. It would get removed from the screen using javascript BUT it didn't actually get removed from the PHP session. If you then refreshed the page you would see that the item is still in your cart - even though you thought you had removed it. This solves that problem by re-assigned the right data-cart-item ids after an item is removed.

Signed-off-by: Phil Johnston <support@mintplugins.com>