### PR TITLE
Show default filename in history-downloads.php if none

### DIFF
--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -56,7 +56,7 @@ if ( $purchases ) :
 
 											<div class="edd_download_file">
 												<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link">
-													<?php echo esc_html( $file['name'] ); ?>
+													<?php echo isset( $file['name'] ) ? esc_html( $file['name'] ) : esc_html( $name ); ?>
 												</a>
 											</div>
 


### PR DESCRIPTION
Right now, if the store owner doesn't put a Name on the deliverable file(s), it triggers an error on the account pages using history-downloads.php

I recommend setting it to default to the name given if no filename was provided by changing line 59 from this:

<?php echo esc_html( $file['name'] ); ?>

to this:

<?php echo isset( $file['name'] ) ? esc_html( $file['name'] ) : esc_html( $name ); ?>

Signed-off-by: Phil Johnston support@mintplugins.com
