### PR TITLE
Per-download quantities

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -106,6 +106,9 @@ function edd_ajax_add_to_cart() {
 			if( $_POST['download_id'] == $options['price_id'] )
 				$options = array();
 
+			parse_str( $_POST['post_data'], $post_data );
+			$options['quantity'] = $post_data['edd_download_quantity'];
+
 			$key = edd_add_to_cart( $_POST['download_id'], $options );
 
 			$item = array(

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -115,6 +115,10 @@ function edd_get_purchase_link( $args = array() ) {
 
 		<?php do_action( 'edd_purchase_link_top', $args['download_id'], $args ); ?>
 
+		<?php if ( edd_item_quantities_enabled() ) : ?>
+			<input type="number" min="1" step="1" name="edd_download_quantity" class="edd-input edd-item-quantity" value="1" />
+		<?php endif; ?>
+
 		<div class="edd_purchase_submit_wrapper">
 			<?php
 			$class = implode( ' ', array( $args['style'], $args['color'], trim( $args['class'] ) ) );


### PR DESCRIPTION
PR for https://github.com/easydigitaldownloads/Easy-Digital-Downloads/issues/2125 to get the ball rolling.

To do:
- [ ] Checkbox that displays (when quantities are enabled) on each download edit/publish screen that either enables or disables quantities for that particular download. Which should it do? enable it?
- [ ] Get it working when ajax is not enabled. This currently only modifies the ajax call.
- [ ] CSS styling on the input field. should be same size as one at checkout
- [ ] Option (or filter) to enable it to show on the download grid. It would look a lot nicer if it only appeared on single download pages for now, agreed?
- [ ] When the quantity is initially changed, it should retrieve the current value from the cart and allow the customer to update it from the same input field
