### PR TITLE
Add descriptive_text as a settings type

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1441,6 +1441,18 @@ function edd_tax_rates_callback($args) {
 	echo ob_get_clean();
 }
 
+/**
+ * Descriptive text callback.
+ *
+ * Renders descriptive text onto the settings field.
+ *
+ * @since 2.1
+ * @param array $args Arguments passed by the setting
+ * @return void
+ */
+function edd_descriptive_text_callback( $args ) {
+	echo esc_html( $args['desc'] );
+}
 
 /**
  * Registers the license field callback for Software Licensing


### PR DESCRIPTION
Hi Pippin, 

This adds a new settings type called "descriptive text". This doesn't display any form fields, but does display the description as fixed text. E.g.

![image](https://cloud.githubusercontent.com/assets/1097338/4226020/affa0e9a-3933-11e4-8a70-95b363888494.png)

It can be useful to display information relating to settings in general without being attached to a specific setting field. The @since docblock will probably need updated.
