### PR TITLE
Compare by seconds instead of date value

### DIFF
--- a/includes/class-edd-stats.php
+++ b/includes/class-edd-stats.php
@@ -212,7 +212,7 @@ class EDD_Stats {
 				case 'this_week' :
 
 					$days_to_week_start = ( date( 'w', current_time( 'timestamp' ) ) - 1 ) *60*60*24;
-				 	$today = date( 'd', current_time( 'timestamp' ) );
+				 	$today = date( 'd', current_time( 'timestamp' ) ) *60*60*24;
 
 				 	if( $today < $days_to_week_start ) {
 
@@ -245,7 +245,7 @@ class EDD_Stats {
 				case 'last_week' :
 
 					$days_to_week_start = ( date( 'w', current_time( 'timestamp' ) ) - 1 ) *60*60*24;
-				 	$today = date( 'd', current_time( 'timestamp' ) );
+				 	$today = date( 'd', current_time( 'timestamp' ) ) *60*60*24;
 
 				 	if( $today < $days_to_week_start ) {
 


### PR DESCRIPTION
Existing code will always calculate `$today` as less than `$days_to_week_start` except on Sundays and Mondays where `$days_to_week_start` is `0` and `1` respectively.

This ensures the comparison is made with the converted value so that a proper check is performed.

This could also probably use a regression test.
