### PR TITLE
Fix edd-reports page not working on HHVM

### DIFF
--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -176,6 +176,8 @@ function edd_reports_graph() {
 		__( 'Sales', 'edd' )    => $sales_data
 	);
 
+	// start our own output buffer
+	ob_start();
 	?>
 	<div id="edd-dashboard-widgets-wrap">
 		<div class="metabox-holder" style="padding-top: 0;">
@@ -206,7 +208,11 @@ function edd_reports_graph() {
 		</div>
 	</div>
 	<?php
-	echo ob_get_clean();
+	// get output buffer contents and end our own buffer
+	$output = ob_get_contents();
+	ob_end_clean();
+	
+	echo $output;
 }
 
 /**


### PR DESCRIPTION
This fixes [the issue we discussed on Twitter](https://twitter.com/pippinsplugins/status/512231253832400897) yesterday and gets the Reports > Earnings page to work again.

Note that `CAL_GREGORIAN` is still undefined on HHVM, could be an idea to just define that to `0` if it  isn't defined but I am not sure if that is the best way to go about this. 
