### PR TITLE
Improve consistency of widget Initialization.

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -32,8 +32,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 */
 class edd_cart_widget extends WP_Widget {
 	/** Constructor */
-	function edd_cart_widget() {
-		parent::WP_Widget( false, __( 'Downloads Cart', 'edd' ), array( 'description' => __( 'Display the downloads shopping cart', 'edd' ) ) );
+	function __construct() {
+		parent::__construct( 'edd_cart_widget', __( 'Downloads Cart', 'edd' ), array( 'description' => __( 'Display the downloads shopping cart', 'edd' ) ) );
 	}
 
 	/** @see WP_Widget::widget */
@@ -110,8 +110,8 @@ class edd_cart_widget extends WP_Widget {
 */
 class edd_categories_tags_widget extends WP_Widget {
 	/** Constructor */
-	function edd_categories_tags_widget() {
-		parent::WP_Widget( false, __( 'Downloads Categories / Tags', 'edd' ), array( 'description' => __( 'Display the downloads categories or tags', 'edd' ) ) );
+	function __construct() {
+		parent::__construct( 'edd_categories_tags_widget', __( 'Downloads Categories / Tags', 'edd' ), array( 'description' => __( 'Display the downloads categories or tags', 'edd' ) ) );
 	}
 
 	/** @see WP_Widget::widget */


### PR DESCRIPTION
When trying to work directly with registered widgets, Categories/Tags
Widget and the Download Cart Widget behave oddly. Specifically,
calling the  method would not save the widget.

It turns out that these widgets are initialized in strange ways:
- Constructors for the widget are the name of the class, which is only
  necessary in PHP4. Using  is sufficient as EDD does not
  support PHP4 and it brings these widgets in line with current best
  practices and the Product Detail Widget.
- The first argument in the parent class constructor was passed as
  `false`. This argument sets the base ID for the widget.  `false` means
  nothing in this case. This was updated to an appropriate value.

Fixing these two issues fixes my use case, as well as brings the widget
in line with best practices.
