### PR TITLE
Always pass payment_id when calling edd_get_price_option_name

### DIFF
--- a/includes/admin/reporting/class-export-payments.php
+++ b/includes/admin/reporting/class-export-payments.php
@@ -150,7 +150,7 @@ class EDD_Payments_Export extends EDD_Export {
 						$price_options = $downloads[ $key ]['item_number']['options'];
 
 						if ( isset( $price_options['price_id'] ) ) {
-							$products .= edd_get_price_option_name( $id, $price_options['price_id'] ) . ' - ';
+							$products .= edd_get_price_option_name( $id, $price_options['price_id'], $payment->ID ) . ' - ';
 						}
 					}
 					$products .= html_entity_decode( edd_currency_filter( $price ) );

--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -405,7 +405,7 @@ function edd_email_tag_download_list( $payment_id ) {
 				}
 
 				if ( $price_id !== null ) {
-					$title .= "&nbsp;&ndash;&nbsp;" . edd_get_price_option_name( $item['id'], $price_id );
+					$title .= "&nbsp;&ndash;&nbsp;" . edd_get_price_option_name( $item['id'], $price_id, $payment_id );
 				}
 
 				$download_list .= '<li>' . apply_filters( 'edd_email_receipt_download_title', $title, $item, $price_id, $payment_id ) . '<br/>';
@@ -501,7 +501,7 @@ function edd_email_tag_download_list_plain( $payment_id ) {
 				}
 
 				if ( $price_id !== null ) {
-					$title .= edd_get_price_option_name( $item['id'], $price_id );
+					$title .= edd_get_price_option_name( $item['id'], $price_id, $payment_id );
 				}
 
 				$download_list .= "\n";

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -139,7 +139,7 @@ $status    = edd_get_payment_status( $payment, true );
 						<div class="edd_purchase_receipt_product_name">
 							<?php echo esc_html( $item['name'] ); ?>
 							<?php if( ! is_null( $price_id ) ) : ?>
-							<span class="edd_purchase_receipt_price_name">&nbsp;&ndash;&nbsp;<?php echo edd_get_price_option_name( $item['id'], $price_id ); ?></span>
+							<span class="edd_purchase_receipt_price_name">&nbsp;&ndash;&nbsp;<?php echo edd_get_price_option_name( $item['id'], $price_id, $payment->ID ); ?></span>
 							<?php endif; ?>
 						</div>
 


### PR DESCRIPTION
The payment ID is needed for those using the edd_get_price_option_name filter in that function

Fix #2685
