### PR TITLE
remove checkout cart tax info from cart items that ignore tax settings

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -349,7 +349,7 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
 
 	$price_id = isset( $options['price_id'] ) ? $options['price_id'] : false;
 
-	if ( ! edd_is_free_download( $item_id, $price_id ) ) {
+	if ( ! edd_is_free_download( $item_id, $price_id ) && ! edd_download_is_tax_exclusive( $item_id ) ) {
 
 		if( edd_prices_show_tax_on_checkout() && ! edd_prices_include_tax() ) {
 


### PR DESCRIPTION
adds a check for the "Ignore Tax" setting to the conditional that hides tax information for free downloads https://github.com/easydigitaldownloads/Easy-Digital-Downloads/issues/2691
