### PR TITLE
jQuery dynamic TABs for EDD backend - using edd_header_callback

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1,0 +1,46 @@
+FORMAT: 1A
+
+# Mashshare
+Notes API is a *short texts saving* service similar to its physical paper presence on your table.
+
+# Group Notes
+Notes related resources of the **Notes API**
+
+## Notes Collection [/notes]
+### List all Notes [GET]
++ Response 200 (application/json)
+
+        [{
+          "id": 1, "title": "Jogging in park"
+        }, {
+          "id": 2, "title": "Pick-up posters from post-office"
+        }]
+
+### Create a Note [POST]
++ Request (application/json)
+
+        { "title": "Buy cheese and bread for breakfast." }
+
++ Response 201 (application/json)
+
+        { "id": 3, "title": "Buy cheese and bread for breakfast." }
+
+## Note [/notes/{id}]
+A single Note object with all its details
+
++ Parameters
+    + id (required, number, `1`) ... Numeric `id` of the Note to perform action with. Has example value.
+
+### Retrieve a Note [GET]
++ Response 200 (application/json)
+
+    + Header
+
+            X-My-Header: The Value
+
+    + Body
+
+            { "id": 2, "title": "Pick-up posters from post-office" }
+
+### Remove a Note [DELETE]
++ Response 204

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -263,3 +263,59 @@ td.edd_order_price { text-align: right; }
 /* API Table Styles
 -------------------------------------------------------------- */
 .download_page_edd-tools .apikeys .column-user { width: 192px; }
+
+/* CSS for Tabs */
+
+#tab_container ul {
+list-style: none;
+margin: 0;
+padding: 0;
+background: #f1f1f1;
+float: left;
+max-width:200px;
+padding-top: 20px;
+/*list-style-type: square;*/
+}
+
+#tab_container ul li:first-child.selected-tab {
+border-top: none;
+}
+
+#tab_container ul li a.selected-tab {
+font-weight: bold;
+text-decoration: none;
+}
+
+#tab_container ul li a {
+text-decoration: none;
+}
+
+#tab_container ul li {
+margin-bottom:10px;
+}
+
+#tab_container .panel-container {
+padding:10px;
+overflow:auto;
+}
+
+#tab_container .row{ 
+    padding-top:10px; 
+    padding-bottom:12px;
+}
+
+#tab_container .col-title{
+    float:left;
+    min-width:180px;
+    max-width:180px;
+}
+
+#tab_container .col-title strong{
+    white-space: pre;
+}
+
+@media (max-width:680px) {
+    #tab_container ul {
+        float:none;
+    }
+}

--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -1,4 +1,728 @@
 jQuery(document).ready(function ($) {
+	
+// Start easytabs()
+if ( $( ".mashsb-tabs" ).length ) {
+$('#tab_container').easytabs({
+    animate:false
+});
+}
+
+/*
+ * jQuery hashchange event - v1.3 - 7/21/2010
+ * http://benalman.com/projects/jquery-hashchange-plugin/
+ * 
+ * Copyright (c) 2010 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ 
+ * This is optional and allows browser back and forward buttons on jQuery easytabs()
+ */
+(function($,e,b){var c="hashchange",h=document,f,g=$.event.special,i=h.documentMode,d="on"+c in e&&(i===b||i>7);function a(j){j=j||location.href;return"#"+j.replace(/^[^#]*#?(.*)$/,"$1")}$.fn[c]=function(j){return j?this.bind(c,j):this.trigger(c)};$.fn[c].delay=50;g[c]=$.extend(g[c],{setup:function(){if(d){return false}$(f.start)},teardown:function(){if(d){return false}$(f.stop)}});f=(function(){var j={},p,m=a(),k=function(q){return q},l=k,o=k;j.start=function(){p||n()};j.stop=function(){p&&clearTimeout(p);p=b};function n(){var r=a(),q=o(m);if(r!==m){l(m=r,q);$(e).trigger(c)}else{if(q!==m){location.href=location.href.replace(/#.*/,"")+q}}p=setTimeout(n,$.fn[c].delay)}$.browser.msie&&!d&&(function(){var q,r;j.start=function(){if(!q){r=$.fn[c].src;r=r&&r+a();q=$('<iframe tabindex="-1" title="empty"/>').hide().one("load",function(){r||l(a());n()}).attr("src",r||"javascript:0").insertAfter("body")[0].contentWindow;h.onpropertychange=function(){try{if(event.propertyName==="title"){q.document.title=h.title}}catch(s){}}}};j.stop=k;o=function(){return a(q.location.href)};l=function(v,s){var u=q.document,t=$.fn[c].domain;if(v!==s){u.title=h.title;u.open();t&&u.write('<script>document.domain="'+t+'"<\/script>');u.close();q.location.hash=v}}})();return j})()})(jQuery,this);
+
+/*
+ * jQuery EasyTabs plugin 3.2.0
+ *
+ * Copyright (c) 2010-2011 Steve Schwartz (JangoSteve)
+ *
+ * Dual licensed under the MIT and GPL licenses:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *   http://www.gnu.org/licenses/gpl.html
+ *
+ * Date: Thu May 09 17:30:00 2013 -0500
+ */
+( function($) {
+
+  $.easytabs = function(container, options) {
+
+        // Attach to plugin anything that should be available via
+        // the $container.data('easytabs') object
+    var plugin = this,
+        $container = $(container),
+
+        defaults = {
+          animate: true,
+          panelActiveClass: "active",
+          tabActiveClass: "active",
+          defaultTab: "li:first-child",
+          animationSpeed: "normal",
+          tabs: "> ul > li",
+          updateHash: true,
+          cycle: false,
+          collapsible: false,
+          collapsedClass: "collapsed",
+          collapsedByDefault: true,
+          uiTabs: false,
+          transitionIn: 'fadeIn',
+          transitionOut: 'fadeOut',
+          transitionInEasing: 'swing',
+          transitionOutEasing: 'swing',
+          transitionCollapse: 'slideUp',
+          transitionUncollapse: 'slideDown',
+          transitionCollapseEasing: 'swing',
+          transitionUncollapseEasing: 'swing',
+          containerClass: "",
+          tabsClass: "",
+          tabClass: "",
+          panelClass: "",
+          cache: true,
+          event: 'click',
+          panelContext: $container
+        },
+
+        // Internal instance variables
+        // (not available via easytabs object)
+        $defaultTab,
+        $defaultTabLink,
+        transitions,
+        lastHash,
+        skipUpdateToHash,
+        animationSpeeds = {
+          fast: 200,
+          normal: 400,
+          slow: 600
+        },
+
+        // Shorthand variable so that we don't need to call
+        // plugin.settings throughout the plugin code
+        settings;
+
+    // =============================================================
+    // Functions available via easytabs object
+    // =============================================================
+
+    plugin.init = function() {
+
+      plugin.settings = settings = $.extend({}, defaults, options);
+      settings.bind_str = settings.event+".easytabs";
+
+      // Add jQuery UI's crazy class names to markup,
+      // so that markup will match theme CSS
+      if ( settings.uiTabs ) {
+        settings.tabActiveClass = 'ui-tabs-selected';
+        settings.containerClass = 'ui-tabs ui-widget ui-widget-content ui-corner-all';
+        settings.tabsClass = 'ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all';
+        settings.tabClass = 'ui-state-default ui-corner-top';
+        settings.panelClass = 'ui-tabs-panel ui-widget-content ui-corner-bottom';
+      }
+
+      // If collapsible is true and defaultTab specified, assume user wants defaultTab showing (not collapsed)
+      if ( settings.collapsible && options.defaultTab !== undefined && options.collpasedByDefault === undefined ) {
+        settings.collapsedByDefault = false;
+      }
+
+      // Convert 'normal', 'fast', and 'slow' animation speed settings to their respective speed in milliseconds
+      if ( typeof(settings.animationSpeed) === 'string' ) {
+        settings.animationSpeed = animationSpeeds[settings.animationSpeed];
+      }
+
+      $('a.anchor').remove().prependTo('body');
+
+      // Store easytabs object on container so we can easily set
+      // properties throughout
+      $container.data('easytabs', {});
+
+      plugin.setTransitions();
+
+      plugin.getTabs();
+
+      addClasses();
+
+      setDefaultTab();
+
+      bindToTabClicks();
+
+      initHashChange();
+
+      initCycle();
+
+      // Append data-easytabs HTML attribute to make easy to query for
+      // easytabs instances via CSS pseudo-selector
+      $container.attr('data-easytabs', true);
+    };
+
+    // Set transitions for switching between tabs based on options.
+    // Could be used to update transitions if settings are changes.
+    plugin.setTransitions = function() {
+      transitions = ( settings.animate ) ? {
+          show: settings.transitionIn,
+          hide: settings.transitionOut,
+          speed: settings.animationSpeed,
+          collapse: settings.transitionCollapse,
+          uncollapse: settings.transitionUncollapse,
+          halfSpeed: settings.animationSpeed / 2
+        } :
+        {
+          show: "show",
+          hide: "hide",
+          speed: 0,
+          collapse: "hide",
+          uncollapse: "show",
+          halfSpeed: 0
+        };
+    };
+
+    // Find and instantiate tabs and panels.
+    // Could be used to reset tab and panel collection if markup is
+    // modified.
+    plugin.getTabs = function() {
+      var $matchingPanel;
+
+      // Find the initial set of elements matching the setting.tabs
+      // CSS selector within the container
+      plugin.tabs = $container.find(settings.tabs),
+
+      // Instantiate panels as empty jquery object
+      plugin.panels = $(),
+
+      plugin.tabs.each(function(){
+        var $tab = $(this),
+            $a = $tab.children('a'),
+
+            // targetId is the ID of the panel, which is either the
+            // `href` attribute for non-ajax tabs, or in the
+            // `data-target` attribute for ajax tabs since the `href` is
+            // the ajax URL
+            targetId = $tab.children('a').data('target');
+
+        $tab.data('easytabs', {});
+
+        // If the tab has a `data-target` attribute, and is thus an ajax tab
+        if ( targetId !== undefined && targetId !== null ) {
+          $tab.data('easytabs').ajax = $a.attr('href');
+        } else {
+          targetId = $a.attr('href');
+        }
+        targetId = targetId.match(/#([^\?]+)/)[1];
+
+        $matchingPanel = settings.panelContext.find("#" + targetId);
+
+        // If tab has a matching panel, add it to panels
+        if ( $matchingPanel.length ) {
+
+          // Store panel height before hiding
+          $matchingPanel.data('easytabs', {
+            position: $matchingPanel.css('position'),
+            visibility: $matchingPanel.css('visibility')
+          });
+
+          // Don't hide panel if it's active (allows `getTabs` to be called manually to re-instantiate tab collection)
+          $matchingPanel.not(settings.panelActiveClass).hide();
+
+          plugin.panels = plugin.panels.add($matchingPanel);
+
+          $tab.data('easytabs').panel = $matchingPanel;
+
+        // Otherwise, remove tab from tabs collection
+        } else {
+          plugin.tabs = plugin.tabs.not($tab);
+          if ('console' in window) {
+            console.warn('Warning: tab without matching panel for selector \'#' + targetId +'\' removed from set');
+          }
+        }
+      });
+    };
+
+    // Select tab and fire callback
+    plugin.selectTab = function($clicked, callback) {
+      var url = window.location,
+          hash = url.hash.match(/^[^\?]*/)[0],
+          $targetPanel = $clicked.parent().data('easytabs').panel,
+          ajaxUrl = $clicked.parent().data('easytabs').ajax;
+
+      // Tab is collapsible and active => toggle collapsed state
+      if( settings.collapsible && ! skipUpdateToHash && ($clicked.hasClass(settings.tabActiveClass) || $clicked.hasClass(settings.collapsedClass)) ) {
+        plugin.toggleTabCollapse($clicked, $targetPanel, ajaxUrl, callback);
+
+      // Tab is not active and panel is not active => select tab
+      } else if( ! $clicked.hasClass(settings.tabActiveClass) || ! $targetPanel.hasClass(settings.panelActiveClass) ){
+        activateTab($clicked, $targetPanel, ajaxUrl, callback);
+
+      // Cache is disabled => reload (e.g reload an ajax tab).
+      } else if ( ! settings.cache ){
+        activateTab($clicked, $targetPanel, ajaxUrl, callback);
+      }
+
+    };
+
+    // Toggle tab collapsed state and fire callback
+    plugin.toggleTabCollapse = function($clicked, $targetPanel, ajaxUrl, callback) {
+      plugin.panels.stop(true,true);
+
+      if( fire($container,"easytabs:before", [$clicked, $targetPanel, settings]) ){
+        plugin.tabs.filter("." + settings.tabActiveClass).removeClass(settings.tabActiveClass).children().removeClass(settings.tabActiveClass);
+
+        // If panel is collapsed, uncollapse it
+        if( $clicked.hasClass(settings.collapsedClass) ){
+
+          // If ajax panel and not already cached
+          if( ajaxUrl && (!settings.cache || !$clicked.parent().data('easytabs').cached) ) {
+            $container.trigger('easytabs:ajax:beforeSend', [$clicked, $targetPanel]);
+
+            $targetPanel.load(ajaxUrl, function(response, status, xhr){
+              $clicked.parent().data('easytabs').cached = true;
+              $container.trigger('easytabs:ajax:complete', [$clicked, $targetPanel, response, status, xhr]);
+            });
+          }
+
+          // Update CSS classes of tab and panel
+          $clicked.parent()
+            .removeClass(settings.collapsedClass)
+            .addClass(settings.tabActiveClass)
+            .children()
+              .removeClass(settings.collapsedClass)
+              .addClass(settings.tabActiveClass);
+
+          $targetPanel
+            .addClass(settings.panelActiveClass)
+            [transitions.uncollapse](transitions.speed, settings.transitionUncollapseEasing, function(){
+              $container.trigger('easytabs:midTransition', [$clicked, $targetPanel, settings]);
+              if(typeof callback == 'function') callback();
+            });
+
+        // Otherwise, collapse it
+        } else {
+
+          // Update CSS classes of tab and panel
+          $clicked.addClass(settings.collapsedClass)
+            .parent()
+              .addClass(settings.collapsedClass);
+
+          $targetPanel
+            .removeClass(settings.panelActiveClass)
+            [transitions.collapse](transitions.speed, settings.transitionCollapseEasing, function(){
+              $container.trigger("easytabs:midTransition", [$clicked, $targetPanel, settings]);
+              if(typeof callback == 'function') callback();
+            });
+        }
+      }
+    };
+
+
+    // Find tab with target panel matching value
+    plugin.matchTab = function(hash) {
+      return plugin.tabs.find("[href='" + hash + "'],[data-target='" + hash + "']").first();
+    };
+
+    // Find panel with `id` matching value
+    plugin.matchInPanel = function(hash) {
+      return ( hash && plugin.validId(hash) ? plugin.panels.filter(':has(' + hash + ')').first() : [] );
+    };
+
+    // Make sure hash is a valid id value (admittedly strict in that HTML5 allows almost anything without a space)
+    // but jQuery has issues with such id values anyway, so we can afford to be strict here.
+    plugin.validId = function(id) {
+      return id.substr(1).match(/^[A-Za-z]+[A-Za-z0-9\-_:\.].$/);
+    };
+
+    // Select matching tab when URL hash changes
+    plugin.selectTabFromHashChange = function() {
+      var hash = window.location.hash.match(/^[^\?]*/)[0],
+          $tab = plugin.matchTab(hash),
+          $panel;
+
+      if ( settings.updateHash ) {
+
+        // If hash directly matches tab
+        if( $tab.length ){
+          skipUpdateToHash = true;
+          plugin.selectTab( $tab );
+
+        } else {
+          $panel = plugin.matchInPanel(hash);
+
+          // If panel contains element matching hash
+          if ( $panel.length ) {
+            hash = '#' + $panel.attr('id');
+            $tab = plugin.matchTab(hash);
+            skipUpdateToHash = true;
+            plugin.selectTab( $tab );
+
+          // If default tab is not active...
+          } else if ( ! $defaultTab.hasClass(settings.tabActiveClass) && ! settings.cycle ) {
+
+            // ...and hash is blank or matches a parent of the tab container or
+            // if the last tab (before the hash updated) was one of the other tabs in this container.
+            if ( hash === '' || plugin.matchTab(lastHash).length || $container.closest(hash).length ) {
+              skipUpdateToHash = true;
+              plugin.selectTab( $defaultTabLink );
+            }
+          }
+        }
+      }
+    };
+
+    // Cycle through tabs
+    plugin.cycleTabs = function(tabNumber){
+      if(settings.cycle){
+        tabNumber = tabNumber % plugin.tabs.length;
+        $tab = $( plugin.tabs[tabNumber] ).children("a").first();
+        skipUpdateToHash = true;
+        plugin.selectTab( $tab, function() {
+          setTimeout(function(){ plugin.cycleTabs(tabNumber + 1); }, settings.cycle);
+        });
+      }
+    };
+
+    // Convenient public methods
+    plugin.publicMethods = {
+      select: function(tabSelector){
+        var $tab;
+
+        // Find tab container that matches selector (like 'li#tab-one' which contains tab link)
+        if ( ($tab = plugin.tabs.filter(tabSelector)).length === 0 ) {
+
+          // Find direct tab link that matches href (like 'a[href="#panel-1"]')
+          if ( ($tab = plugin.tabs.find("a[href='" + tabSelector + "']")).length === 0 ) {
+
+            // Find direct tab link that matches selector (like 'a#tab-1')
+            if ( ($tab = plugin.tabs.find("a" + tabSelector)).length === 0 ) {
+
+              // Find direct tab link that matches data-target (lik 'a[data-target="#panel-1"]')
+              if ( ($tab = plugin.tabs.find("[data-target='" + tabSelector + "']")).length === 0 ) {
+
+                // Find direct tab link that ends in the matching href (like 'a[href$="#panel-1"]', which would also match http://example.com/currentpage/#panel-1)
+                if ( ($tab = plugin.tabs.find("a[href$='" + tabSelector + "']")).length === 0 ) {
+
+                  $.error('Tab \'' + tabSelector + '\' does not exist in tab set');
+                }
+              }
+            }
+          }
+        } else {
+          // Select the child tab link, since the first option finds the tab container (like <li>)
+          $tab = $tab.children("a").first();
+        }
+        plugin.selectTab($tab);
+      }
+    };
+
+    // =============================================================
+    // Private functions
+    // =============================================================
+
+    // Triggers an event on an element and returns the event result
+    var fire = function(obj, name, data) {
+      var event = $.Event(name);
+      obj.trigger(event, data);
+      return event.result !== false;
+    }
+
+    // Add CSS classes to markup (if specified), called by init
+    var addClasses = function() {
+      $container.addClass(settings.containerClass);
+      plugin.tabs.parent().addClass(settings.tabsClass);
+      plugin.tabs.addClass(settings.tabClass);
+      plugin.panels.addClass(settings.panelClass);
+    };
+
+    // Set the default tab, whether from hash (bookmarked) or option,
+    // called by init
+    var setDefaultTab = function(){
+      var hash = window.location.hash.match(/^[^\?]*/)[0],
+          $selectedTab = plugin.matchTab(hash).parent(),
+          $panel;
+
+      // If hash directly matches one of the tabs, active on page-load
+      if( $selectedTab.length === 1 ){
+        $defaultTab = $selectedTab;
+        settings.cycle = false;
+
+      } else {
+        $panel = plugin.matchInPanel(hash);
+
+        // If one of the panels contains the element matching the hash,
+        // make it active on page-load
+        if ( $panel.length ) {
+          hash = '#' + $panel.attr('id');
+          $defaultTab = plugin.matchTab(hash).parent();
+
+        // Otherwise, make the default tab the one that's active on page-load
+        } else {
+          $defaultTab = plugin.tabs.parent().find(settings.defaultTab);
+          if ( $defaultTab.length === 0 ) {
+            $.error("The specified default tab ('" + settings.defaultTab + "') could not be found in the tab set ('" + settings.tabs + "') out of " + plugin.tabs.length + " tabs.");
+          }
+        }
+      }
+
+      $defaultTabLink = $defaultTab.children("a").first();
+
+      activateDefaultTab($selectedTab);
+    };
+
+    // Activate defaultTab (or collapse by default), called by setDefaultTab
+    var activateDefaultTab = function($selectedTab) {
+      var defaultPanel,
+          defaultAjaxUrl;
+
+      if ( settings.collapsible && $selectedTab.length === 0 && settings.collapsedByDefault ) {
+        $defaultTab
+          .addClass(settings.collapsedClass)
+          .children()
+            .addClass(settings.collapsedClass);
+
+      } else {
+
+        defaultPanel = $( $defaultTab.data('easytabs').panel );
+        defaultAjaxUrl = $defaultTab.data('easytabs').ajax;
+
+        if ( defaultAjaxUrl && (!settings.cache || !$defaultTab.data('easytabs').cached) ) {
+          $container.trigger('easytabs:ajax:beforeSend', [$defaultTabLink, defaultPanel]);
+          defaultPanel.load(defaultAjaxUrl, function(response, status, xhr){
+            $defaultTab.data('easytabs').cached = true;
+            $container.trigger('easytabs:ajax:complete', [$defaultTabLink, defaultPanel, response, status, xhr]);
+          });
+        }
+
+        $defaultTab.data('easytabs').panel
+          .show()
+          .addClass(settings.panelActiveClass);
+
+        $defaultTab
+          .addClass(settings.tabActiveClass)
+          .children()
+            .addClass(settings.tabActiveClass);
+      }
+
+      // Fire event when the plugin is initialised
+      $container.trigger("easytabs:initialised", [$defaultTabLink, defaultPanel]);
+    };
+
+    // Bind tab-select funtionality to namespaced click event, called by
+    // init
+    var bindToTabClicks = function() {
+      plugin.tabs.children("a").bind(settings.bind_str, function(e) {
+
+        // Stop cycling when a tab is clicked
+        settings.cycle = false;
+
+        // Hash will be updated when tab is clicked,
+        // don't cause tab to re-select when hash-change event is fired
+        skipUpdateToHash = false;
+
+        // Select the panel for the clicked tab
+        plugin.selectTab( $(this) );
+
+        // Don't follow the link to the anchor
+        e.preventDefault ? e.preventDefault() : e.returnValue = false;
+      });
+    };
+
+    // Activate a given tab/panel, called from plugin.selectTab:
+    //
+    //   * fire `easytabs:before` hook
+    //   * get ajax if new tab is an uncached ajax tab
+    //   * animate out previously-active panel
+    //   * fire `easytabs:midTransition` hook
+    //   * update URL hash
+    //   * animate in newly-active panel
+    //   * update CSS classes for inactive and active tabs/panels
+    //
+    // TODO: This could probably be broken out into many more modular
+    // functions
+    var activateTab = function($clicked, $targetPanel, ajaxUrl, callback) {
+      plugin.panels.stop(true,true);
+
+      if( fire($container,"easytabs:before", [$clicked, $targetPanel, settings]) ){
+        var $visiblePanel = plugin.panels.filter(":visible"),
+            $panelContainer = $targetPanel.parent(),
+            targetHeight,
+            visibleHeight,
+            heightDifference,
+            showPanel,
+            hash = window.location.hash.match(/^[^\?]*/)[0];
+
+        if (settings.animate) {
+          targetHeight = getHeightForHidden($targetPanel);
+          visibleHeight = $visiblePanel.length ? setAndReturnHeight($visiblePanel) : 0;
+          heightDifference = targetHeight - visibleHeight;
+        }
+
+        // Set lastHash to help indicate if defaultTab should be
+        // activated across multiple tab instances.
+        lastHash = hash;
+
+        // TODO: Move this function elsewhere
+        showPanel = function() {
+          // At this point, the previous panel is hidden, and the new one will be selected
+          $container.trigger("easytabs:midTransition", [$clicked, $targetPanel, settings]);
+
+          // Gracefully animate between panels of differing heights, start height change animation *after* panel change if panel needs to contract,
+          // so that there is no chance of making the visible panel overflowing the height of the target panel
+          if (settings.animate && settings.transitionIn == 'fadeIn') {
+            if (heightDifference < 0)
+              $panelContainer.animate({
+                height: $panelContainer.height() + heightDifference
+              }, transitions.halfSpeed ).css({ 'min-height': '' });
+          }
+
+          if ( settings.updateHash && ! skipUpdateToHash ) {
+            //window.location = url.toString().replace((url.pathname + hash), (url.pathname + $clicked.attr("href")));
+            // Not sure why this behaves so differently, but it's more straight forward and seems to have less side-effects
+            window.location.hash = '#' + $targetPanel.attr('id');
+          } else {
+            skipUpdateToHash = false;
+          }
+
+          $targetPanel
+            [transitions.show](transitions.speed, settings.transitionInEasing, function(){
+              $panelContainer.css({height: '', 'min-height': ''}); // After the transition, unset the height
+              $container.trigger("easytabs:after", [$clicked, $targetPanel, settings]);
+              // callback only gets called if selectTab actually does something, since it's inside the if block
+              if(typeof callback == 'function'){
+                callback();
+              }
+          });
+        };
+
+        if ( ajaxUrl && (!settings.cache || !$clicked.parent().data('easytabs').cached) ) {
+          $container.trigger('easytabs:ajax:beforeSend', [$clicked, $targetPanel]);
+          $targetPanel.load(ajaxUrl, function(response, status, xhr){
+            $clicked.parent().data('easytabs').cached = true;
+            $container.trigger('easytabs:ajax:complete', [$clicked, $targetPanel, response, status, xhr]);
+          });
+        }
+
+        // Gracefully animate between panels of differing heights, start height change animation *before* panel change if panel needs to expand,
+        // so that there is no chance of making the target panel overflowing the height of the visible panel
+        if( settings.animate && settings.transitionOut == 'fadeOut' ) {
+          if( heightDifference > 0 ) {
+            $panelContainer.animate({
+              height: ( $panelContainer.height() + heightDifference )
+            }, transitions.halfSpeed );
+          } else {
+            // Prevent height jumping before height transition is triggered at midTransition
+            $panelContainer.css({ 'min-height': $panelContainer.height() });
+          }
+        }
+
+        // Change the active tab *first* to provide immediate feedback when the user clicks
+        plugin.tabs.filter("." + settings.tabActiveClass).removeClass(settings.tabActiveClass).children().removeClass(settings.tabActiveClass);
+        plugin.tabs.filter("." + settings.collapsedClass).removeClass(settings.collapsedClass).children().removeClass(settings.collapsedClass);
+        $clicked.parent().addClass(settings.tabActiveClass).children().addClass(settings.tabActiveClass);
+
+        plugin.panels.filter("." + settings.panelActiveClass).removeClass(settings.panelActiveClass);
+        $targetPanel.addClass(settings.panelActiveClass);
+
+        if( $visiblePanel.length ) {
+          $visiblePanel
+            [transitions.hide](transitions.speed, settings.transitionOutEasing, showPanel);
+        } else {
+          $targetPanel
+            [transitions.uncollapse](transitions.speed, settings.transitionUncollapseEasing, showPanel);
+        }
+      }
+    };
+
+    // Get heights of panels to enable animation between panels of
+    // differing heights, called by activateTab
+    var getHeightForHidden = function($targetPanel){
+
+      if ( $targetPanel.data('easytabs') && $targetPanel.data('easytabs').lastHeight ) {
+        return $targetPanel.data('easytabs').lastHeight;
+      }
+
+      // this is the only property easytabs changes, so we need to grab its value on each tab change
+      var display = $targetPanel.css('display'),
+          outerCloak,
+          height;
+
+      // Workaround with wrapping height, because firefox returns wrong
+      // height if element itself has absolute positioning.
+      // but try/catch block needed for IE7 and IE8 because they throw
+      // an "Unspecified error" when trying to create an element
+      // with the css position set.
+      try {
+        outerCloak = $('<div></div>', {'position': 'absolute', 'visibility': 'hidden', 'overflow': 'hidden'});
+      } catch (e) {
+        outerCloak = $('<div></div>', {'visibility': 'hidden', 'overflow': 'hidden'});
+      }
+      height = $targetPanel
+        .wrap(outerCloak)
+        .css({'position':'relative','visibility':'hidden','display':'block'})
+        .outerHeight();
+
+      $targetPanel.unwrap();
+
+      // Return element to previous state
+      $targetPanel.css({
+        position: $targetPanel.data('easytabs').position,
+        visibility: $targetPanel.data('easytabs').visibility,
+        display: display
+      });
+
+      // Cache height
+      $targetPanel.data('easytabs').lastHeight = height;
+
+      return height;
+    };
+
+    // Since the height of the visible panel may have been manipulated due to interaction,
+    // we want to re-cache the visible height on each tab change, called
+    // by activateTab
+    var setAndReturnHeight = function($visiblePanel) {
+      var height = $visiblePanel.outerHeight();
+
+      if( $visiblePanel.data('easytabs') ) {
+        $visiblePanel.data('easytabs').lastHeight = height;
+      } else {
+        $visiblePanel.data('easytabs', {lastHeight: height});
+      }
+      return height;
+    };
+
+    // Setup hash-change callback for forward- and back-button
+    // functionality, called by init
+    var initHashChange = function(){
+
+      // enabling back-button with jquery.hashchange plugin
+      // http://benalman.com/projects/jquery-hashchange-plugin/
+      if(typeof $(window).hashchange === 'function'){
+        $(window).hashchange( function(){
+          plugin.selectTabFromHashChange();
+        });
+      } else if ($.address && typeof $.address.change === 'function') { // back-button with jquery.address plugin http://www.asual.com/jquery/address/docs/
+        $.address.change( function(){
+          plugin.selectTabFromHashChange();
+        });
+      }
+    };
+
+    // Begin cycling if set in options, called by init
+    var initCycle = function(){
+      var tabNumber;
+      if (settings.cycle) {
+        tabNumber = plugin.tabs.index($defaultTab);
+        setTimeout( function(){ plugin.cycleTabs(tabNumber + 1); }, settings.cycle);
+      }
+    };
+
+
+    plugin.init();
+
+  };
+
+  $.fn.easytabs = function(options) {
+    var args = arguments;
+
+    return this.each(function() {
+      var $this = $(this),
+          plugin = $this.data('easytabs');
+
+      // Initialization was called with $(el).easytabs( { options } );
+      if (undefined === plugin) {
+        plugin = new $.easytabs(this, options);
+        $this.data('easytabs', plugin);
+      }
+
+      // User called public method
+      if ( plugin.publicMethods[options] ){
+        return plugin.publicMethods[options](Array.prototype.slice.call( args, 1 ));
+      }
+    });
+  };
+
+})(jQuery);
 
 	/**
 	 * Download Configuration Metabox

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -12,6 +12,101 @@
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/* Returns list elements for jQuery tab navigation 
+ * based on header callback
+ * 
+ * @scince 2.1.2
+ * @todo Use sprintf to sanitize  $field['id'] instead using str_replace() Should be faster!
+ * @return string
+ */
+
+function edd_getTabHeader($page, $section){
+    global $mashsb_options;
+    global $wp_settings_fields;
+    
+    if (!isset($wp_settings_fields[$page][$section]))
+        return;
+    
+    echo '<ul>';
+    foreach ((array) $wp_settings_fields[$page][$section] as $field) {  
+    $sanitizedID = str_replace('[', '', $field['id'] );
+    $sanitizedID = str_replace(']', '', $sanitizedID );     
+     if (strpos($field['callback'],'header') !== false) { 
+         echo '<li class="mashsb-tabs"><a href="#' . $sanitizedID . '">' . $field['title'] .'</a></li>';
+     }      
+    }
+    echo '</ul>';
+}
+
+
+/**
+ * Print out the settings fields for a particular settings section
+ *
+ * Part of the Settings API. Use this in a settings page to output
+ * a specific section. Should normally be called by do_settings_sections()
+ * rather than directly.
+ *
+ * @global $wp_settings_fields Storage array of settings fields and their pages/sections
+ * @return string
+ *
+ * @since 2.1.2
+ *
+ * @param string $page Slug title of the admin page who's settings fields you want to show.
+ * @param section $section Slug title of the settings section who's fields you want to show.
+ * 
+ * Copied from WP Core 4.0 /wp-admin/includes/template.php do_settings_fields()
+ * We use our own function to be able to create jQuery tabs with easytabs()
+ * 
+*  We dont use tables here any longer. Are we stuck in the nineties?
+ * @todo Use sprintf to sanitize  $field['id'] instead using str_replace() Should be faster?
+ * @todo Push this code into EasyDigitalDownload EDD@github
+ * @todo some media queries for better responsibility
+ * @todo remove style overflow:auto; and put it in separate class
+ */
+function edd_do_settings_fields($page, $section) {
+    global $wp_settings_fields;
+    $header = false;
+    $firstHeader = false;
+    
+    if (!isset($wp_settings_fields[$page][$section]))
+        return;
+    
+    // Check first if any callback header is registered and set $header var to true than
+    foreach ((array) $wp_settings_fields[$page][$section] as $field) {
+       strpos($field['callback'],'header') !== false ? $header = true : $header = false; 
+       if ($header === true)
+               break;
+    }
+    
+    foreach ((array) $wp_settings_fields[$page][$section] as $field) {
+        
+       $sanitizedID = str_replace('[', '', $field['id'] );
+       $sanitizedID = str_replace(']', '', $sanitizedID );
+       
+       // Check if header has been created previously
+       if (strpos($field['callback'],'header') !== false && $firstHeader === false) { 
+           echo '<div id="' . $sanitizedID . '">'; 
+           $firstHeader = true;
+       } elseif (strpos($field['callback'],'header') !== false && $firstHeader === true) { 
+       // Header has been created previously so we have to close the first opened div
+           echo '</div><div id="' . $sanitizedID . '">'; 
+       } 
+        echo '<div class="row">';
+        if (!empty($field['args']['label_for']))
+            echo '<label for="' . esc_attr($field['args']['label_for']) . '">' . $field['title'] . '</label>';
+        else
+            echo '<div class="col-title">' . $field['title'] . '</div>';
+        echo '<div style="overflow:auto;">';
+        call_user_func($field['callback'], $field['args']);
+        echo '</div>';
+        echo '</div>';
+        
+    }
+    if ($header === true){
+    echo '</div>';
+    }
+}
+
 /**
  * Options Page
  *
@@ -46,16 +141,18 @@ function edd_options_page() {
 			}
 			?>
 		</h2>
-		<div id="tab_container">
+		<div id="tab_container" class="tab_container">
+                        <?php edd_getTabHeader( 'edd_settings_' . $active_tab, 'edd_settings_' . $active_tab ); ?>   
+                    <div class="panel-container"> <!-- new //-->
 			<form method="post" action="options.php">
-				<table class="form-table">
 				<?php
 				settings_fields( 'edd_settings' );
-				do_settings_fields( 'edd_settings_' . $active_tab, 'edd_settings_' . $active_tab );
+				edd_do_settings_fields( 'edd_settings_' . $active_tab, 'edd_settings_' . $active_tab );
 				?>
-				</table>
+				<!--</table>-->
 				<?php submit_button(); ?>
 			</form>
+                    </div> <!-- new //-->
 		</div><!-- #tab_container-->
 	</div><!-- .wrap -->
 	<?php

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -860,9 +860,10 @@ function edd_get_pages( $force = false ) {
  * @since 1.0
  * @param array $args Arguments passed by the setting
  * @return void
+ * @deprecated not used any longer. Fallback function
  */
 function edd_header_callback( $args ) {
-	echo '<hr/>';
+	echo '&nbsp;';
 }
 
 /**


### PR DESCRIPTION
This is a enhancement for the EDD settings panel. Especially useful for the extension section when a lot of Add-Ons are installed but the jQuery tabs are working on every section as well.

Tabs are created automatically. They use the edd_header_callback function for title and navigation and integrates seemless into the concept of extending EDD. No change in any EDD development paradigm is necessary to create this setting tabs.

There is still some place for improvements:
- Make this feature optional so people can decide if they want to use the original "static" list of settings or the dynamic one.

- The side bar navigation can be easily changed to a left to right navigation when backend is opened on mobile devices and i am sure the code can be improved as well.

I really love to see that feature in edd because it makes fiddling arround with dozens of options and extensions more comfortable.

**Preview (its currently used in my dev version of mashshare)**

![EDD Tabs](https://www.mashshare.net/wp-content/uploads/edd_tabs1.PNG)

![EDD Tabs](https://www.mashshare.net/wp-content/uploads/edd_tabs2.PNG)


