### PR TITLE
Add Flywheel and fallback to system info

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -295,6 +295,10 @@ function edd_is_host( $host = false ) {
 				if( strpos( DB_HOST, '.sysfix.eu' ) !== false )
 					$return = true;
 				break;
+			case 'flywheel':
+				if( strpos( $_SERVER['SERVER_NAME'], 'Flywheel' ) !== false )
+					$return = true;
+				break;
 			default:
 				$return = false;
 		}


### PR DESCRIPTION
Fixes issue #2695 

In addition to adding Flywheel, I've added a fallback to relay the `DB_HOST` constant and `$_SERVER['SERVER_NAME']` variable. Hopefully this will reveal data on other hosts not currently in our database allowing us to further refine the `$host` variable.
