### PR TITLE
Exclude tests folder from grunt workflow

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,7 @@ grunt.initConfig({
           '!.gitignore',
           '!.gitmodules',
           '!.tx/**',
+          '!tests/**',
           '!**/Gruntfile.js',
           '!**/package.json',
           '!**/README.md',


### PR DESCRIPTION
Right now it copies the tests folder which it shouldn't. This fixes that.
