### PR TITLE
Remove backticks from CREATE TABLE SQL.

### DIFF
--- a/includes/class-edd-db-customers.php
+++ b/includes/class-edd-db-customers.php
@@ -467,15 +467,15 @@ class EDD_DB_Customers extends EDD_DB  {
 		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 
 		$sql = "CREATE TABLE " . $this->table_name . " (
-		`id` bigint(20) NOT NULL AUTO_INCREMENT,
-		`user_id` bigint(20) NOT NULL,
-		`email` varchar(50) NOT NULL,
-		`name` mediumtext NOT NULL,
-		`purchase_value` mediumtext NOT NULL,
-		`purchase_count` bigint(20) NOT NULL,
-		`payment_ids` longtext NOT NULL,
-		`notes` longtext NOT NULL,
-		`date_created` datetime NOT NULL,
+		id bigint(20) NOT NULL AUTO_INCREMENT,
+		user_id bigint(20) NOT NULL,
+		email varchar(50) NOT NULL,
+		name mediumtext NOT NULL,
+		purchase_value mediumtext NOT NULL,
+		purchase_count bigint(20) NOT NULL,
+		payment_ids longtext NOT NULL,
+		notes longtext NOT NULL,
+		date_created datetime NOT NULL,
 		PRIMARY KEY  (id),
 		UNIQUE KEY email (email),
 		KEY user (user_id)


### PR DESCRIPTION
These are not supported by dbDelta and cause a Notice. Fixes #2781.
