### PR TITLE
Make sure discount code exists before trying to apply it

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1064,7 +1064,13 @@ function edd_get_cart_item_discount_amount( $item = array() ) {
 
 		foreach ( $discounts as $discount ) {
 
-			$code_id           = edd_get_discount_id_by_code( $discount );
+			$code_id = edd_get_discount_id_by_code( $discount );
+
+			// Check discount exists
+		        if( ! $code_id ) {
+		            continue;
+		        }
+		        
 			$reqs              = edd_get_discount_product_reqs( $code_id );
 			$excluded_products = edd_get_discount_excluded_products( $code_id );
 


### PR DESCRIPTION
Checks that the discount code exists before trying to apply it, otherwise `edd_get_discounted_amount()` will return `0`.

When this is then subtracted from `$price` and inverted to make `$discounted_price` here:

`$discounted_price -= $price - edd_get_discounted_amount( $discount, $price );`

 it'll always equal the negative value of the price giving the user a 100% discount.
