### PR TITLE
Reverse how we handled #2794 by reimplementing the download attribute and checking the filter

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1096,10 +1096,9 @@ function edd_can_access_download( $bool = true, $purchase_data = array(), $args 
  * @return nool If a user can access the file
  */
 function edd_get_html5_download_attribute( $bool = true, $purchase_data = array(), $args = array(), $file = array ) {
+	$string = '';
 	if ( edd_can_access_download( $bool, $purchase_data, $arg ){
-		return 'download="'.edd_get_file_name( $file ).'"';	
+		$string = 'download="'  .edd_get_file_name( $file ) . '"';	
 	}
-	else{
-		return '';
-	}
+	return apply_filters( 'edd_get_html5_download_attribute', $string, $bool, $purchase_data, $args, $file );
 }

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1069,3 +1069,37 @@ function edd_get_random_downloads( $num = 3, $post_ids = true ) {
 	$args  = apply_filters( 'edd_get_random_downloads', $args );
 	return get_posts( $args );
 }
+
+/**
+ * Returns if a user can access a download of a purchase
+ *
+ * @since 2.2
+ * @author Chris Christoff
+ * @param bool $bool Default for has_access
+ * @param mixed $purchase_data Array of purchase data 
+ * @param mixed $args Array of arguments
+ * @return nool If a user can access the file
+ */
+function edd_can_access_download( $bool = true, $purchase_data = array(), $args = array() ) {
+	return apply_filters( 'edd_file_download_has_access', $bool, $purchase_data, $args );
+}
+
+/**
+ * Returns `download` attribute for download link if user can access download 
+ *
+ * @since 2.2
+ * @author Chris Christoff
+ * @param bool $bool Default for has_access for edd_can_access_download()
+ * @param mixed $purchase_data Array of purchase data  for edd_can_access_download()
+ * @param mixed $args Array of arguments for edd_can_access_download()
+ * @param mixed $args The file array
+ * @return nool If a user can access the file
+ */
+function edd_get_html5_download_attribute( $bool = true, $purchase_data = array(), $args = array(), $file = array ) {
+	if ( edd_can_access_download( $bool, $purchase_data, $arg ){
+		return 'download="'.edd_get_file_name( $file ).'"';	
+	}
+	else{
+		return '';
+	}
+}

--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -416,10 +416,11 @@ function edd_email_tag_download_list( $payment_id ) {
 			if ( ! empty( $files ) ) {
 
 				foreach ( $files as $filekey => $file ) {
+					$attribute = edd_get_html5_download_attribute( true, $payment_data, array(), $file );
 
 					$download_list .= '<div>';
 						$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $item['id'], $price_id );
-						$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
+						$download_list .= '<a href="' . esc_url( $file_url ) . '" ' . $attribute . ' >' . edd_get_file_name( $file ) . '</a>';
 					$download_list .= '</div>';
 
 				}
@@ -435,6 +436,7 @@ function edd_email_tag_download_list( $payment_id ) {
 					$files = edd_get_download_files( $bundle_item );
 
 					foreach ( $files as $filekey => $file ) {
+						$attribute = edd_get_html5_download_attribute( true, $payment_data, array(), $file );
 						$download_list .= '<div>';
 						$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $price_id );
 						$download_list .= '<a href="' . esc_url( $file_url ) . '">' . $file['name'] . '</a>';

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -47,7 +47,7 @@ function edd_process_download() {
 	$method  = edd_get_file_download_method();
 
 	// Defaulting this to true for now because the method below doesn't work well
-	$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $args );
+	$has_access = edd_can_access_download( true, $payment, $args );
 
 	//$has_access = ( edd_logged_in_only() && is_user_logged_in() ) || !edd_logged_in_only() ? true : false;
 	if ( $payment && $has_access ) {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -456,6 +456,7 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 	$payment_key = edd_get_payment_key( $payment_id );
 	$email       = edd_get_payment_user_email( $payment_id );
 	$links       = '<ul class="edd_download_links">';
+	$purchase    = edd_get_payment_meta( $payment_id );
 
 	foreach ( $downloads as $download ) {
 		$links .= '<li>';
@@ -465,7 +466,8 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 			if ( is_array( $files ) ) {
 				foreach ( $files as $filekey => $file ) {
 					$links .= '<div class="edd_download_link_file">';
-						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '">';
+						$attribute = edd_get_html5_download_attribute( true, $purchase, array(), $file );
+						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '" ' . $attribute . '> ';
 							if ( isset( $file['name'] ) )
 								$links .= esc_html( $file['name'] );
 							else

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -53,11 +53,17 @@ if ( $purchases ) :
 
 										foreach ( $download_files as $filekey => $file ) :
 
-											$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $download['id'], $price_id );
+											$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $download['id'], $price_id );																		$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
+											$attribute = '';
+											$has_access = apply_filters( 'edd_file_download_has_access', true, $purchase_data, array() );
+										
+											if ( $has_access ){
+												$attribute = 'download="'.edd_get_file_name( $file ).'"';
+											}
 											?>
 
 											<div class="edd_download_file">
-												<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link">
+												<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link">
 													<?php echo isset( $file['name'] ) ? esc_html( $file['name'] ) : esc_html( $name ); ?>
 												</a>
 											</div>

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -54,7 +54,6 @@ if ( $purchases ) :
 										foreach ( $download_files as $filekey => $file ) :
 
 											$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $download['id'], $price_id );																		$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
-											$attribute = '';
 											$attribute = edd_get_html5_download_attribute( true, $purchase_data, array(), $file );
 											?>
 

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -55,11 +55,7 @@ if ( $purchases ) :
 
 											$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $download['id'], $price_id );																		$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
 											$attribute = '';
-											$has_access = apply_filters( 'edd_file_download_has_access', true, $purchase_data, array() );
-										
-											if ( $has_access ){
-												$attribute = 'download="'.edd_get_file_name( $file ).'"';
-											}
+											$attribute = edd_get_html5_download_attribute( true, $purchase_data, array(), $file );
 											?>
 
 											<div class="edd_download_file">

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -156,9 +156,15 @@ $status    = edd_get_payment_status( $payment, true );
 								foreach ( $download_files as $filekey => $file ) :
 
 									$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $item['id'], $price_id );
+									$attribute = '';
+									$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
+									if ( $has_access ){
+										$attribute = 'download="'.edd_get_file_name( $file ).'"';
+									}
+									}
 									?>
 									<li class="edd_download_file">
-										<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
+										<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
 									</li>
 									<?php
 									do_action( 'edd_receipt_files', $filekey, $file, $item['id'], $payment->ID, $meta );
@@ -176,12 +182,15 @@ $status    = edd_get_payment_status( $payment, true );
 											$download_files = edd_get_download_files( $bundle_item );
 
 											if( $download_files && is_array( $download_files ) ) :
-
+												$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
+												if ( $has_access ){
+													$attribute = 'download="'.edd_get_file_name( $file ).'"';
+												}
 												foreach ( $download_files as $filekey => $file ) :
 
 													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); ?>
 													<li class="edd_download_file">
-														<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
+														<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $has_access; ?> class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
 													</li>
 													<?php
 													do_action( 'edd_receipt_bundle_files', $filekey, $file, $item['id'], $bundle_item, $payment->ID, $meta );

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -156,12 +156,7 @@ $status    = edd_get_payment_status( $payment, true );
 								foreach ( $download_files as $filekey => $file ) :
 
 									$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $item['id'], $price_id );
-									$attribute = '';
-									$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
-									if ( $has_access ){
-										$attribute = 'download="'.edd_get_file_name( $file ).'"';
-									}
-									}
+									$attribute = edd_get_html5_download_attribute( true, $payment, $edd_receipt_args, $file );
 									?>
 									<li class="edd_download_file">
 										<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
@@ -182,13 +177,8 @@ $status    = edd_get_payment_status( $payment, true );
 											$download_files = edd_get_download_files( $bundle_item );
 
 											if( $download_files && is_array( $download_files ) ) :
-												$attribute = '';
-												$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
-												if ( $has_access ){
-													$attribute = 'download="'.edd_get_file_name( $file ).'"';
-												}
 												foreach ( $download_files as $filekey => $file ) :
-
+													$attribute = edd_get_html5_download_attribute( true, $payment, $edd_receipt_args, $file );
 													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); ?>
 													<li class="edd_download_file">
 														<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -182,6 +182,7 @@ $status    = edd_get_payment_status( $payment, true );
 											$download_files = edd_get_download_files( $bundle_item );
 
 											if( $download_files && is_array( $download_files ) ) :
+												$attribute = '';
 												$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
 												if ( $has_access ){
 													$attribute = 'download="'.edd_get_file_name( $file ).'"';
@@ -190,7 +191,7 @@ $status    = edd_get_payment_status( $payment, true );
 
 													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); ?>
 													<li class="edd_download_file">
-														<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $has_access; ?> class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
+														<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
 													</li>
 													<?php
 													do_action( 'edd_receipt_bundle_files', $filekey, $file, $item['id'], $bundle_item, $payment->ID, $meta );


### PR DESCRIPTION
The `download` attribute is useful in several cases. It completely put an end to the "my file opened in my browser instead of downloading" tickets. Instead of removing the attribute, and all of its benefits, instead lets only show it when the file can be downloaded. This pr also adds the attribute to bundled products on the receipts page (where it wasn't before) as wells as the download history page