### PR TITLE
Fix some coupon insert hooks + prevent notices

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -200,6 +200,8 @@ function edd_store_discount( $details, $discount_id = null ) {
 
 	$meta = array(
 		'code'              => isset( $details['code'] )             ? $details['code']              : '',
+		'name'              => isset( $details['name'] )             ? $details['name']              : '',
+		'status'            => isset( $details['status'] )           ? $details['status']            : 'active',
 		'uses'              => isset( $details['uses'] )             ? $details['uses']              : '',
 		'max_uses'          => isset( $details['max'] )              ? $details['max']               : '',
 		'amount'            => isset( $details['amount'] )           ? $details['amount']            : '',
@@ -229,34 +231,34 @@ function edd_store_discount( $details, $discount_id = null ) {
 	if ( edd_discount_exists( $discount_id ) && ! empty( $discount_id ) ) {
 		// Update an existing discount
 
-		$details = apply_filters( 'edd_update_discount', $details, $discount_id );
+		$meta = apply_filters( 'edd_update_discount', $meta, $discount_id );
 
-		do_action( 'edd_pre_update_discount', $details, $discount_id );
+		do_action( 'edd_pre_update_discount', $meta, $discount_id );
 
 		wp_update_post( array(
 			'ID'          => $discount_id,
-			'post_title'  => $details['name'],
-			'post_status' => $details['status']
+			'post_title'  => $meta['name'],
+			'post_status' => $meta['status']
 		) );
 
 		foreach( $meta as $key => $value ) {
 			update_post_meta( $discount_id, '_edd_discount_' . $key, $value );
 		}
 
-		do_action( 'edd_post_update_discount', $details, $discount_id );
+		do_action( 'edd_post_update_discount', $meta, $discount_id );
 
 		// Discount code updated
 		return $discount_id;
 	} else {
 		// Add the discount
 
-		$details = apply_filters( 'edd_insert_discount', $details );
+		$meta = apply_filters( 'edd_insert_discount', $meta );
 
-		do_action( 'edd_pre_insert_discount', $details );
+		do_action( 'edd_pre_insert_discount', $meta );
 
 		$discount_id = wp_insert_post( array(
 			'post_type'   => 'edd_discount',
-			'post_title'  => isset( $details['name'] ) ? $details['name'] : '',
+			'post_title'  => $meta['name'],
 			'post_status' => 'active'
 		) );
 
@@ -264,7 +266,7 @@ function edd_store_discount( $details, $discount_id = null ) {
 			update_post_meta( $discount_id, '_edd_discount_' . $key, $value );
 		}
 
-		do_action( 'edd_post_insert_discount', $details, $discount_id );
+		do_action( 'edd_post_insert_discount', $meta, $discount_id );
 
 		// Discount code created
 		return $discount_id;
@@ -1070,7 +1072,7 @@ function edd_get_cart_item_discount_amount( $item = array() ) {
 		        if( ! $code_id ) {
 		            continue;
 		        }
-		        
+
 			$reqs              = edd_get_discount_product_reqs( $code_id );
 			$excluded_products = edd_get_discount_excluded_products( $code_id );
 


### PR DESCRIPTION
Hey Pippin,

Not sure if you want me to create a issue for this, if so let me know.

I've made this PR to solve the following:
- To prevent some notices (when `$details['name']` or `$details['status']` is not set)
- Main reason; The code filtered `$details` while `$meta` are the used values

Hope it helps!

Cheers,
Jeroen
