### PR TITLE
Change all uses of $_REQUEST in the SL Updater Changelog to $_GET.

### DIFF
--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -289,15 +289,15 @@ class EDD_SL_Plugin_Updater {
     public function show_changelog() {
 
 
-        if( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
+        if( empty( $_GET['edd_sl_action'] ) || 'view_plugin_changelog' != $_GET['edd_sl_action'] ) {
             return;
         }
 
-        if( empty( $_REQUEST['plugin'] ) ) {
+        if( empty( $_GET['plugin'] ) ) {
             return;
         }
 
-        if( empty( $_REQUEST['slug'] ) ) {
+        if( empty( $_GET['slug'] ) ) {
             return;
         }
 
@@ -305,7 +305,7 @@ class EDD_SL_Plugin_Updater {
             wp_die( __( 'You do not have permission to install plugin updates' ) );
         }
 
-        $response = $this->api_request( 'plugin_latest_version', array( 'slug' => $_REQUEST['slug'] ) );
+        $response = $this->api_request( 'plugin_latest_version', array( 'slug' => $_GET['slug'] ) );
 
         if( $response && isset( $response->sections['changelog'] ) ) {
             echo '<div style="background:#fff;padding:10px;">' . $response->sections['changelog'] . '</div>';


### PR DESCRIPTION
http://stackoverflow.com/questions/2142497/whats-wrong-with-using-request

While I haven't run into an issue with the updater particularly, I came across this while fixing issues on a PHP 5.2 site where `$_COOKIE` data was included in `$_REQUEST` for a different plugin.

Since `view_plugin_changelog` is never handled via POST, `$_GET` should be sufficient.