### PR TITLE
Fix formatting for CSV export. See #2889

### DIFF
--- a/includes/admin/reporting/class-export.php
+++ b/includes/admin/reporting/class-export.php
@@ -97,7 +97,7 @@ class EDD_Export {
 		$i = 1;
 		foreach( $cols as $col_id => $column ) {
 			echo '"' . $column . '"';
-			echo $i == count( $cols ) ? '' : ';';
+			echo $i == count( $cols ) ? '' : ',';
 			$i++;
 		}
 		echo "\r\n";
@@ -148,7 +148,7 @@ class EDD_Export {
 				// Make sure the column is valid
 				if ( array_key_exists( $col_id, $cols ) ) {
 					echo '"' . $column . '"';
-					echo $i == count( $cols ) ? '' : ';';
+					echo $i == count( $cols ) ? '' : ',';
 					$i++;
 				}
 			}


### PR DESCRIPTION
Fixes the formatting of CSV exports so that values are separated using a comma in lieu of a semi-colon. See #2889 
