### PR TITLE
API call for Yesterday should work on Jan 1

### DIFF
--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -527,7 +527,7 @@ class EDD_API {
 					$dates['day']		= $yesterday;
 					$dates['m_start'] 	= $month;
 					$dates['m_end'] 	= $month;
-					$dates['year']		= $month == 1 && date( 'd', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
+					$dates['year']		= date( 'd', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
 				break;
 
 				case 'this_quarter' :

--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -527,7 +527,7 @@ class EDD_API {
 					$dates['day']       = $yesterday;
 					$dates['m_start']   = $month;
 					$dates['m_end']     = $month;
-					$dates['year']      = $month == 1 && date( 'd', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
+					$dates['year']      = date( 'n', $current_time ) == 1 && date( 'd', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
 				break;
 
 				case 'this_quarter' :

--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -490,74 +490,74 @@ class EDD_API {
 			$startdate          = strtotime( $args['startdate'] );
 			$enddate            = strtotime( $args['enddate'] );
 			$dates['day_start'] = date( 'd', $startdate );
-			$dates['day_end'] 	= date( 'd', $enddate );
-			$dates['m_start'] 	= date( 'n', $startdate );
-			$dates['m_end'] 	= date( 'n', $enddate );
-			$dates['year'] 		= date( 'Y', $startdate );
+			$dates['day_end']   = date( 'd', $enddate );
+			$dates['m_start']   = date( 'n', $startdate );
+			$dates['m_end']     = date( 'n', $enddate );
+			$dates['year']      = date( 'Y', $startdate );
 			$dates['year_end'] 	= date( 'Y', $enddate );
 		} else {
 			// Modify dates based on predefined ranges
 			switch ( $args['date'] ) :
 
 				case 'this_month' :
-					$dates['day'] 	    = null;
-					$dates['m_start'] 	= date( 'n', $current_time );
-					$dates['m_end']		= date( 'n', $current_time );
-					$dates['year']		= date( 'Y', $current_time );
+					$dates['day']       = null;
+					$dates['m_start']   = date( 'n', $current_time );
+					$dates['m_end']     = date( 'n', $current_time );
+					$dates['year']      = date( 'Y', $current_time );
 				break;
 
 				case 'last_month' :
-					$dates['day'] 	  = null;
+					$dates['day']     = null;
 					$dates['m_start'] = date( 'n', $current_time ) == 1 ? 12 : date( 'n', $current_time ) - 1;
-					$dates['m_end']	  = $dates['m_start'];
+					$dates['m_end']   = $dates['m_start'];
 					$dates['year']    = date( 'n', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
 				break;
 
 				case 'today' :
-					$dates['day']		= date( 'd', $current_time );
-					$dates['m_start'] 	= date( 'n', $current_time );
-					$dates['m_end']		= date( 'n', $current_time );
-					$dates['year']		= date( 'Y', $current_time );
+					$dates['day']       = date( 'd', $current_time );
+					$dates['m_start']   = date( 'n', $current_time );
+					$dates['m_end']     = date( 'n', $current_time );
+					$dates['year']      = date( 'Y', $current_time );
 				break;
 
 				case 'yesterday' :
 					$month              = date( 'n', $current_time ) == 1 && date( 'd', $current_time ) == 1 ? 12 : date( 'n', $current_time );
 					$days_in_month      = cal_days_in_month( CAL_GREGORIAN, $month, date( 'Y', $current_time ) );
 					$yesterday          = date( 'd', $current_time ) == 1 ? $days_in_month : date( 'd', $current_time ) - 1;
-					$dates['day']		= $yesterday;
-					$dates['m_start'] 	= $month;
-					$dates['m_end'] 	= $month;
-					$dates['year']		= date( 'd', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
+					$dates['day']       = $yesterday;
+					$dates['m_start']   = $month;
+					$dates['m_end']     = $month;
+					$dates['year']      = $month == 1 && date( 'd', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
 				break;
 
 				case 'this_quarter' :
 					$month_now = date( 'n', $current_time );
 
-					$dates['day'] 	        = null;
+					$dates['day']           = null;
 
 					if ( $month_now <= 3 ) {
 
-						$dates['m_start'] 	= 1;
-						$dates['m_end']		= 3;
-						$dates['year']		= date( 'Y', $current_time );
+						$dates['m_start']   = 1;
+						$dates['m_end']     = 3;
+						$dates['year']      = date( 'Y', $current_time );
 
 					} else if ( $month_now <= 6 ) {
 
-						$dates['m_start'] 	= 4;
-						$dates['m_end']		= 6;
-						$dates['year']		= date( 'Y', $current_time );
+						$dates['m_start']   = 4;
+						$dates['m_end']     = 6;
+						$dates['year']      = date( 'Y', $current_time );
 
 					} else if ( $month_now <= 9 ) {
 
-						$dates['m_start'] 	= 7;
-						$dates['m_end']		= 9;
-						$dates['year']		= date( 'Y', $current_time );
+						$dates['m_start']   = 7;
+						$dates['m_end']     = 9;
+						$dates['year']      = date( 'Y', $current_time );
 
 					} else {
 
-						$dates['m_start'] 	= 10;
-						$dates['m_end']		= 12;
-						$dates['year']		= date( 'Y', $current_time );
+						$dates['m_start']   = 10;
+						$dates['m_end']     = 12;
+						$dates['year']      = date( 'Y', $current_time );
 
 					}
 				break;
@@ -565,47 +565,47 @@ class EDD_API {
 				case 'last_quarter' :
 					$month_now = date( 'n', $current_time );
 
-					$dates['day'] 	        = null;
+					$dates['day']           = null;
 
 					if ( $month_now <= 3 ) {
 
-						$dates['m_start'] 	= 10;
-						$dates['m_end']		= 12;
-						$dates['year']		= date( 'Y', $current_time ) - 1; // Previous year
+						$dates['m_start']   = 10;
+						$dates['m_end']     = 12;
+						$dates['year']      = date( 'Y', $current_time ) - 1; // Previous year
 
 					} else if ( $month_now <= 6 ) {
 
-						$dates['m_start'] 	= 1;
-						$dates['m_end']		= 3;
-						$dates['year']		= date( 'Y', $current_time );
+						$dates['m_start']   = 1;
+						$dates['m_end']     = 3;
+						$dates['year']      = date( 'Y', $current_time );
 
 					} else if ( $month_now <= 9 ) {
 
-						$dates['m_start'] 	= 4;
-						$dates['m_end']		= 6;
-						$dates['year']		= date( 'Y', $current_time );
+						$dates['m_start']   = 4;
+						$dates['m_end']     = 6;
+						$dates['year']      = date( 'Y', $current_time );
 
 					} else {
 
-						$dates['m_start'] 	= 7;
-						$dates['m_end']		= 9;
-						$dates['year']		= date( 'Y', $current_time );
+						$dates['m_start']   = 7;
+						$dates['m_end']     = 9;
+						$dates['year']      = date( 'Y', $current_time );
 
 					}
 				break;
 
 				case 'this_year' :
-					$dates['day'] 	    = null;
-					$dates['m_start'] 	= null;
-					$dates['m_end']		= null;
-					$dates['year']		= date( 'Y', $current_time );
+					$dates['day']       = null;
+					$dates['m_start']   = null;
+					$dates['m_end']     = null;
+					$dates['year']      = date( 'Y', $current_time );
 				break;
 
 				case 'last_year' :
-					$dates['day'] 	    = null;
-					$dates['m_start'] 	= null;
-					$dates['m_end']		= null;
-					$dates['year']		= date( 'Y', $current_time ) - 1;
+					$dates['day']       = null;
+					$dates['m_start']   = null;
+					$dates['m_end']     = null;
+					$dates['year']      = date( 'Y', $current_time ) - 1;
 				break;
 
 			endswitch;

--- a/tests/tests-html-elements.php
+++ b/tests/tests-html-elements.php
@@ -40,7 +40,7 @@ class Test_HTML_Elements extends WP_UnitTestCase {
 	}
 
 	public function test_year_dropdown() {
-		$expected = '<select name="year" id="" class="edd-select " data-placeholder=""><option value="2009">2009</option><option value="2010">2010</option><option value="2011">2011</option><option value="2012">2012</option><option value="2013">2013</option><option value="2014" selected=\'selected\'>2014</option></select>';
+		$expected = '<select name="year" id="" class="edd-select " data-placeholder=""><option value="2010">2010</option><option value="2011">2011</option><option value="2012">2012</option><option value="2013">2013</option><option value="2014">2014</option><option value="2015" selected=\'selected\'>2015</option></select>';
 		$this->assertEquals( $expected, EDD()->html->year_dropdown() );
 	}
 

--- a/tests/tests-html-elements.php
+++ b/tests/tests-html-elements.php
@@ -40,7 +40,16 @@ class Test_HTML_Elements extends WP_UnitTestCase {
 	}
 
 	public function test_year_dropdown() {
-		$expected = '<select name="year" id="" class="edd-select " data-placeholder=""><option value="2010">2010</option><option value="2011">2011</option><option value="2012">2012</option><option value="2013">2013</option><option value="2014">2014</option><option value="2015" selected=\'selected\'>2015</option></select>';
+		$current_year = date( 'Y' );
+		$expected = '<select name="year" id="" class="edd-select " data-placeholder="">';
+		$i = 5;
+		while ( $i >= 0 ) {
+			$selected  = 0 === $i ? ' selected=\'selected\'' : '';
+			$option_year = $current_year - $i;
+			$expected .= '<option value="' . $option_year . '"' . $selected . '>' . $option_year . '</option>';
+			$i--;
+		}
+		$expected .= '</select>';
 		$this->assertEquals( $expected, EDD()->html->year_dropdown() );
 	}
 


### PR DESCRIPTION
Contains fixes for #2906 and some whitespace cleanup. Also includes a unit test 'fix' for the hardcoded years in the HTML Year Dropdown test. I've #2907 to address this.