### PR TITLE
Add serialized form data to ajax call

### DIFF
--- a/assets/js/edd-checkout-global.js
+++ b/assets/js/edd-checkout-global.js
@@ -147,7 +147,8 @@ jQuery(document).ready(function($) {
 
         var postData = {
             action: 'edd_apply_discount',
-            code: discount_code
+            code: discount_code,
+            form: $( '#edd_purchase_form' ).serialize()
         };
 
         $('#edd-discount-error-wrap').html('').hide();


### PR DESCRIPTION
Hi Pippin,

Small PR, this adds the fields of the purchase form to the AJAX call to validate the coupon when pressing 'apply'.

In my scenario I want to validate the user email; which is possible when someone is logged in, but when a guest wants to checkout I want to verify the checkout email. 

The code is pretty global and can also be used for other purposes.

Let me know what you think.

Thanks and happy new year :fireworks:,
Jeroen

PS. what do you use for minification/uglification of JS?