### PR TITLE
Include item quantities when calculating cart quantity.

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -103,7 +103,17 @@ function edd_get_cart_content_details() {
  * @return int Quantity of items in the cart
  */
 function edd_get_cart_quantity() {
-	return ( $cart = edd_get_cart_contents() ) ? count( $cart ) : 0;
+	
+	$cart     = edd_get_cart_contents();
+	$quantity = 0;
+	
+	if( $cart ){
+		foreach( $cart as $item ){
+			$quantity += isset( $item['quantity'] ) ? intval( $item['quantity'] ) : 1;
+		}
+	}
+	
+	return $quantity;
 }
 
 /**


### PR DESCRIPTION
This might be intended behaviour but `edd_get_cart_quantity()` doesn't take item quantities into account. So if I have a cart containing one product with quantity 2, `edd_get_cart_quantity()` returns 1 rather two. 

This pull request changes that behaviour, summing the quantities of each item in the cart.