### PR TITLE
Avoid using `query_posts()`

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -163,9 +163,9 @@ function edd_get_discount_by( $field = '', $value = '' ) {
 			break;
 
 		case 'name':
-			$discount = query_posts( array(
+			$discount = get_posts( array(
 				'post_type'      => 'edd_discount',
-				'name'           => sanitize_title( $value ),
+				'name'           => $value,
 				'posts_per_page' => 1,
 				'post_status'    => 'any'
 			) );

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -39,9 +39,9 @@ function edd_get_download_by( $field = '', $value = '' ) {
 
 		case 'slug':
 		case 'name':
-			$download = query_posts( array(
+			$download = get_posts( array(
 				'post_type'      => 'download',
-				'name'           => sanitize_title_for_query( $value ),
+				'name'           => $value,
 				'posts_per_page' => 1,
 				'post_status'    => 'any'
 			) );
@@ -53,7 +53,7 @@ function edd_get_download_by( $field = '', $value = '' ) {
 			break;
 
 		case 'sku':
-			$download = query_posts( array(
+			$download = get_posts( array(
 				'post_type'      => 'download',
 				'meta_key'       => 'edd_sku',
 				'meta_value'     => $value,


### PR DESCRIPTION
* Don't double sanitize 'name' argument, it's already being sanitazed by `WP_Query`.
* Ref: #2918.