### PR TITLE
Quantities on cart widget are incorrect when adding with quantities > 1

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -160,12 +160,11 @@ jQuery(document).ready(function ($) {
 	                 $('.cart_item.edd_subtotal span').html( response.subtotal );
 
 	                // Update the cart quantity
-	                var items_added = $( '.edd-cart-item-title', response.cart_item ).length;
-
+	                //
 	                $('span.edd-cart-quantity').each(function() {
-	                    var quantity = parseInt($(this).text(), 10) + items_added;
-	                    $(this).text(quantity);
-	                    $('body').trigger('edd_quantity_updated', [ quantity ]);
+	                    $(this).text(response.cart_quantity);
+
+	                    $('body').trigger('edd_quantity_updated', [ response.cart_quantity ]);
 	                });
 
 	                // Show the "number of items in cart" message

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -185,9 +185,10 @@ function edd_ajax_add_to_cart() {
 		}
 
 		$return = array(
-			'subtotal'  => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_subtotal() ) ), ENT_COMPAT, 'UTF-8' ),
-			'total'     => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' ),
-			'cart_item' => $items
+			'subtotal'      => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_subtotal() ) ), ENT_COMPAT, 'UTF-8' ),
+			'total'         => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' ),
+			'cart_item'     => $items,
+			'cart_quantity' => html_entity_decode( edd_get_cart_quantity() )
 		);
 
 		echo json_encode( $return );

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -100,10 +100,20 @@ function edd_get_cart_content_details() {
  * Get Cart Quantity
  *
  * @since 1.0
- * @return int Quantity of items in the cart
+ * @return int Sum quantity of items in the cart
  */
 function edd_get_cart_quantity() {
-	return ( $cart = edd_get_cart_contents() ) ? count( $cart ) : 0;
+
+	$total_quantity = 0;
+	$cart           = edd_get_cart_contents();
+
+	if ( ! empty( $cart ) ) {
+		$quantities     = wp_list_pluck( $cart, 'quantity' );
+		$total_quantity = absint( array_sum( $quantities ) );
+	}
+
+
+	return apply_filters( 'edd_get_cart_quantity', $total_quantity, $cart );
 }
 
 /**


### PR DESCRIPTION
Fixes #2931 and updates the ```edd_get_cart_quantity()``` to return the sum of the  cart quantities instead of a sum of the different products in the cart.