### PR TITLE
Add $price_id to edd_price filters

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -177,9 +177,9 @@ function edd_price( $download_id = 0, $echo = true, $price_id = false ) {
 
 	}
 
-	$price           = apply_filters( 'edd_download_price', edd_sanitize_amount( $price ), $download_id );
+	$price           = apply_filters( 'edd_download_price', edd_sanitize_amount( $price ), $download_id, $price_id );
 	$formatted_price = '<span class="edd_price" id="edd_price_' . $download_id . '">' . $price . '</span>';
-	$formatted_price = apply_filters( 'edd_download_price_after_html', $formatted_price, $download_id, $price );
+	$formatted_price = apply_filters( 'edd_download_price_after_html', $formatted_price, $download_id, $price, $price_id );
 
 	if ( $echo ) {
 		echo $formatted_price;


### PR DESCRIPTION
The price_id should be passed so those who need it to filter the price for variable priced products can