### PR TITLE
Dashicon as EDD media button

### DIFF
--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -26,11 +26,11 @@ function edd_media_button() {
 	if ( in_array( $pagenow, array( 'post.php', 'page.php', 'post-new.php', 'post-edit.php' ) ) && $typenow != 'download' ) {
 		/* check current WP version */
 		if ( version_compare( $wp_version, '3.5', '<' ) ) {
-			$img = '<img src="' . EDD_PLUGIN_URL . 'assets/images/edd-media.png" alt="' . sprintf( __( 'Insert %s', 'edd' ), edd_get_label_singular() ) . '"/>';
+			$img    = '<img src="' . EDD_PLUGIN_URL . 'assets/images/edd-media.png" alt="' . sprintf( __( 'Insert %s', 'edd' ), edd_get_label_singular() ) . '" />';
 			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox" title="' . __( 'Insert Download', 'edd' ) . '">' . $img . '</a>';
 		} else {
-			$img = '<span class="wp-media-buttons-icon" id="edd-media-button"></span>';
-			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox button edd-thickbox" title="' . sprintf( __( 'Insert %s', 'edd' ), strtolower ( edd_get_label_singular() ) ) . '" style="padding-left: .4em;">' . $img . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '</a>';
+			$img    = '<span class="wp-media-buttons-icon" id="edd-media-button"></span>';
+			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox button edd-thickbox" title="' . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '" style="padding-left: .4em;">' . $img . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '</a>';
 		}
 	}
 	echo $output;
@@ -54,46 +54,46 @@ function edd_admin_footer_for_thickbox() {
 	// Only run in post/page creation and edit screens
 	if ( in_array( $pagenow, array( 'post.php', 'page.php', 'post-new.php', 'post-edit.php' ) ) && $typenow != 'download' ) { ?>
 		<script type="text/javascript">
-            function insertDownload() {
-                var id = jQuery('#products').val(),
-                    direct = jQuery('#select-edd-direct').val(),
-                    style = jQuery('#select-edd-style').val(),
-                    color = jQuery('#select-edd-color').is(':visible') ? jQuery('#select-edd-color').val() : '',
-                    text = jQuery('#edd-text').val() || '<?php _e( "Purchase", "edd" ); ?>';
+			function insertDownload() {
+				var id = jQuery('#products').val(),
+					direct = jQuery('#select-edd-direct').val(),
+					style = jQuery('#select-edd-style').val(),
+					color = jQuery('#select-edd-color').is(':visible') ? jQuery('#select-edd-color').val() : '',
+					text = jQuery('#edd-text').val() || '<?php _e( "Purchase", "edd" ); ?>';
 
-                // Return early if no download is selected
-                if ('' === id) {
-                    alert('<?php _e( "You must choose a download", "edd" ); ?>');
-                    return;
-                }
+				// Return early if no download is selected
+				if ('' === id) {
+					alert('<?php _e( "You must choose a download", "edd" ); ?>');
+					return;
+				}
 
-                if( '2' == direct ) {
-                	direct = ' direct="true"';
-                } else {
-                	direct = '';
-                }
+				if ('2' == direct) {
+					direct = ' direct="true"';
+				} else {
+					direct = '';
+				}
 
-                // Send the shortcode to the editor
-                window.send_to_editor('[purchase_link id="' + id + '" style="' + style + '" color="' + color + '" text="' + text + '"' + direct +']');
-            }
-            jQuery(document).ready(function ($) {
-                $('#select-edd-style').change(function () {
-                    if ($(this).val() === 'button') {
-                        $('#edd-color-choice').slideDown();
-                    } else {
-                        $('#edd-color-choice').slideUp();
-                    }
-                });
-            });
+				// Send the shortcode to the editor
+				window.send_to_editor('[purchase_link id="' + id + '" style="' + style + '" color="' + color + '" text="' + text + '"' + direct + ']');
+			}
+			jQuery(document).ready(function($) {
+				$('#select-edd-style').change(function() {
+					if ($(this).val() === 'button') {
+						$('#edd-color-choice').slideDown();
+					} else {
+						$('#edd-color-choice').slideUp();
+					}
+				});
+			});
 		</script>
 
 		<div id="choose-download" style="display: none;">
 			<div class="wrap" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
 				<p><?php echo sprintf( __( 'Use the form below to insert the short code for purchasing a %s', 'edd' ), edd_get_label_singular() ); ?></p>
 				<div>
-					<?php echo EDD()->html->product_dropdown( array( 'chosen' => true )); ?>
+					<?php echo EDD()->html->product_dropdown( array( 'chosen' => true ) ); ?>
 				</div>
-				<?php if( edd_shop_supports_buy_now() ) : ?>
+				<?php if ( edd_shop_supports_buy_now() ) : ?>
 					<div>
 						<select id="select-edd-direct" style="clear: both; display: block; margin-bottom: 1em; margin-top: 1em;">
 							<option value="0"><?php _e( 'Choose the button behavior', 'edd' ); ?></option>
@@ -106,29 +106,29 @@ function edd_admin_footer_for_thickbox() {
 					<select id="select-edd-style" style="clear: both; display: block; margin-bottom: 1em; margin-top: 1em;">
 						<option value=""><?php _e( 'Choose a style', 'edd' ); ?></option>
 						<?php
-							$styles = array( 'button', 'text link' );
-							foreach ( $styles as $style ) {
-								echo '<option value="' . $style . '">' . $style . '</option>';
-							}
+						$styles = array( 'button', 'text link' );
+						foreach ( $styles as $style ) {
+							echo '<option value="' . $style . '">' . $style . '</option>';
+						}
 						?>
 					</select>
 				</div>
 				<?php
 				$colors = edd_get_button_colors();
-				if( $colors ) { ?>
-				<div id="edd-color-choice" style="display: none;">
-					<select id="select-edd-color" style="clear: both; display: block; margin-bottom: 1em;">
-						<option value=""><?php _e('Choose a button color', 'edd'); ?></option>
-						<?php
+				if ( $colors ) { ?>
+					<div id="edd-color-choice" style="display: none;">
+						<select id="select-edd-color" style="clear: both; display: block; margin-bottom: 1em;">
+							<option value=""><?php _e( 'Choose a button color', 'edd' ); ?></option>
+							<?php
 							foreach ( $colors as $key => $color ) {
 								echo '<option value="' . str_replace( ' ', '_', $key ) . '">' . $color['label'] . '</option>';
 							}
-						?>
-					</select>
-				</div>
+							?>
+						</select>
+					</div>
 				<?php } ?>
 				<div>
-					<input type="text" class="regular-text" id="edd-text" value="" placeholder="<?php _e( 'Link text . . .', 'edd' ); ?>"/>
+					<input type="text" class="regular-text" id="edd-text" value="" placeholder="<?php _e( 'Link text . . .', 'edd' ); ?>" />
 				</div>
 				<p class="submit">
 					<input type="button" id="edd-insert-download" class="button-primary" value="<?php echo sprintf( __( 'Insert %s', 'edd' ), edd_get_label_singular() ); ?>" onclick="insertDownload();" />
@@ -136,7 +136,7 @@ function edd_admin_footer_for_thickbox() {
 				</p>
 			</div>
 		</div>
-	<?php
+		<?php
 	}
 }
 add_action( 'admin_footer', 'edd_admin_footer_for_thickbox' );

--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -30,7 +30,7 @@ function edd_media_button() {
 			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox" title="' . __( 'Insert Download', 'edd' ) . '">' . $img . '</a>';
 		} else {
 			$img    = '<span class="wp-media-buttons-icon" id="edd-media-button"></span>';
-			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox button edd-thickbox" title="' . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '">' . $img . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '</a>';
+			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox button edd-thickbox" title="' . sprintf( __( 'Insert %s', 'edd' ), edd_get_label_singular() ) . '">' . $img . sprintf( __( 'Insert %s', 'edd' ), edd_get_label_singular() ) . '</a>';
 		}
 	}
 	echo $output;

--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -88,7 +88,7 @@ function edd_admin_footer_for_thickbox() {
 		</script>
 
 		<div id="choose-download" style="display: none;">
-			<div class="wrap" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+			<div class="wrap">
 				<p><?php echo sprintf( __( 'Use the form below to insert the short code for purchasing a %s', 'edd' ), edd_get_label_singular() ); ?></p>
 				<div>
 					<?php echo EDD()->html->product_dropdown( array( 'chosen' => true ) ); ?>

--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -30,7 +30,7 @@ function edd_media_button() {
 			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox" title="' . __( 'Insert Download', 'edd' ) . '">' . $img . '</a>';
 		} else {
 			$img    = '<span class="wp-media-buttons-icon" id="edd-media-button"></span>';
-			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox button edd-thickbox" title="' . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '" style="padding-left: .4em;">' . $img . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '</a>';
+			$output = '<a href="#TB_inline?width=640&inlineId=choose-download" class="thickbox button edd-thickbox" title="' . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '">' . $img . sprintf( __( 'Insert %s', 'edd' ), strtolower( edd_get_label_singular() ) ) . '</a>';
 		}
 	}
 	echo $output;

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -234,57 +234,65 @@ function edd_admin_downloads_icon() {
 	$icon_2x_url     = $images_url . 'edd-icon-2x.png';
 	$icon_cpt_2x_url = $images_url . 'edd-cpt-2x.png';
 	?>
-	<style type="text/css" media="screen">
+	<style type="text/css">
 		<?php if ( version_compare( $wp_version, '3.8-RC', '>=' ) || version_compare( $wp_version, '3.8', '>=' ) ) { ?>
 			#adminmenu #menu-posts-download .wp-menu-image:before,
 			#dashboard_right_now .download-count:before {
 				content: '<?php echo $menu_icon; ?>';
+			}
+			#edd-media-button:before {
+				font: normal 18px/1 dashicons;
+				content: '<?php echo $menu_icon; ?>';
+				-moz-osx-font-smoothing: grayscale;
+				-webkit-font-smoothing: antialiased;
+				speak: none;
+			}
+			@media screen and (max-width: 782px) {
+				#edd-media-button:before {
+					font-size: 20px !important;
+				}
 			}
 		<?php } else { ?>
 			/** Fallback for outdated WP installations */
 			#adminmenu #menu-posts-download div.wp-menu-image {
 				background: url(<?php echo $icon_url; ?>) no-repeat 7px -17px;
 			}
-			#adminmenu #menu-posts-download:hover div.wp-menu-image,
-			#adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image {
+			#adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image,
+			#adminmenu #menu-posts-download:hover div.wp-menu-image {
 				background-position: 7px 6px;
 			}
-		<?php } ?>
-		#edd-media-button {
-			background: url(<?php echo $icon_url; ?>) 0 -16px no-repeat;
-			background-size: 12px 30px;
-		}
-		#icon-edit.icon32-posts-download {
-			background: url(<?php echo $icon_cpt_url; ?>) -7px -5px no-repeat;
-		}
-		.wp-media-buttons a.edd-thickbox {
-			padding-left: 5px;
-		}
-		@media
-		only screen and (-webkit-min-device-pixel-ratio: 1.5),
-		only screen and (   min--moz-device-pixel-ratio: 1.5),
-		only screen and (     -o-min-device-pixel-ratio: 3/2),
-		only screen and (        min-device-pixel-ratio: 1.5),
-		only screen and (                min-resolution: 1.5dppx) {
-			<?php if ( version_compare( $wp_version, '3.7', '<=' ) ) { ?>
+			#edd-media-button {
+				background: url(<?php echo $icon_url; ?>) 0 -16px no-repeat;
+				background-size: 12px 30px;
+			}
+			#icon-edit.icon32-posts-download {
+				background: url(<?php echo $icon_cpt_url; ?>) -7px -5px no-repeat;
+			}
+			@media print,
+				(-o-min-device-pixel-ratio: 5/4),
+				(-webkit-min-device-pixel-ratio: 1.25),
+				(min-resolution: 120dpi) {
 				#adminmenu #menu-posts-download div.wp-menu-image {
 					background-image: url(<?php echo $icon_2x_url; ?>);
 					background-position: 7px -18px;
 					background-size: 16px 40px;
 				}
-				#adminmenu #menu-posts-download:hover div.wp-menu-image,
-				#adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image {
+				#adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image,
+				#adminmenu #menu-posts-download:hover div.wp-menu-image {
 					background-position: 7px 6px;
 				}
-			<?php } ?>
-			#icon-edit.icon32-posts-download {
-				background: url(<?php echo $icon_cpt_2x_url; ?>) no-repeat -7px -5px !important;
-				background-size: 55px 45px !important;
+				#edd-media-button {
+					background-image: url(<?php echo $icon_2x_url; ?>);
+					background-position: 0 -17px;
+				}
+				#icon-edit.icon32-posts-download {
+					background: url(<?php echo $icon_cpt_2x_url; ?>) no-repeat -7px -5px !important;
+					background-size: 55px 45px !important;
+				}
 			}
-			#edd-media-button {
-				background-image: url(<?php echo $icon_2x_url; ?>);
-				background-position: 0 -17px;
-			}
+		<?php } ?>
+		.wp-media-buttons a.edd-thickbox {
+			padding-left: 5px;
 		}
 	</style>
 	<?php

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -41,20 +41,20 @@ function edd_load_scripts() {
 		}
 		wp_enqueue_script( 'edd-checkout-global', $js_dir . 'edd-checkout-global' . $suffix . '.js', array( 'jquery' ), EDD_VERSION );
 		wp_localize_script( 'edd-checkout-global', 'edd_global_vars', apply_filters( 'edd_global_checkout_script_vars', array(
-			'ajaxurl'            => edd_get_ajax_url(),
-			'checkout_nonce'     => wp_create_nonce( 'edd_checkout_nonce' ),
-			'currency_sign'      => edd_currency_filter(''),
-			'currency_pos'       => isset( $edd_options['currency_position'] ) ? $edd_options['currency_position'] : 'before',
-			'no_gateway'         => __( 'Please select a payment method', 'edd' ),
-			'no_discount'        => __( 'Please enter a discount code', 'edd' ), // Blank discount code message
-			'enter_discount'     => __( 'Enter discount', 'edd' ),
-			'discount_applied'   => __( 'Discount Applied', 'edd' ), // Discount verified message
-			'no_email'           => __( 'Please enter an email address before applying a discount code', 'edd' ),
-			'no_username'        => __( 'Please enter a username before applying a discount code', 'edd' ),
-			'purchase_loading'   => __( 'Please Wait...', 'edd' ),
-			'complete_purchase'  => __( 'Purchase', 'edd' ),
-			'taxes_enabled'      => edd_use_taxes() ? '1' : '0',
-			'edd_version'        => EDD_VERSION
+			'ajaxurl'           => edd_get_ajax_url(),
+			'checkout_nonce'    => wp_create_nonce( 'edd_checkout_nonce' ),
+			'currency_sign'     => edd_currency_filter( '' ),
+			'currency_pos'      => isset( $edd_options['currency_position'] ) ? $edd_options['currency_position'] : 'before',
+			'no_gateway'        => __( 'Please select a payment method', 'edd' ),
+			'no_discount'       => __( 'Please enter a discount code', 'edd' ), // Blank discount code message
+			'enter_discount'    => __( 'Enter discount', 'edd' ),
+			'discount_applied'  => __( 'Discount Applied', 'edd' ), // Discount verified message
+			'no_email'          => __( 'Please enter an email address before applying a discount code', 'edd' ),
+			'no_username'       => __( 'Please enter a username before applying a discount code', 'edd' ),
+			'purchase_loading'  => __( 'Please Wait...', 'edd' ),
+			'complete_purchase' => __( 'Purchase', 'edd' ),
+			'taxes_enabled'     => edd_use_taxes() ? '1' : '0',
+			'edd_version'       => EDD_VERSION
 		) ) );
 	}
 
@@ -63,11 +63,11 @@ function edd_load_scripts() {
 		wp_enqueue_script( 'edd-ajax', $js_dir . 'edd-ajax' . $suffix . '.js', array( 'jquery' ), EDD_VERSION );
 		wp_localize_script( 'edd-ajax', 'edd_scripts', apply_filters( 'edd_ajax_script_vars', array(
 			'ajaxurl'                 => edd_get_ajax_url(),
-			'position_in_cart'        => isset( $position ) ? $position : -1,
-			'already_in_cart_message' => __('You have already added this item to your cart', 'edd'), // Item already in the cart message
-			'empty_cart_message'      => __('Your cart is empty', 'edd'), // Item already in the cart message
-			'loading'                 => __('Loading', 'edd') , // General loading message
-			'select_option'           => __('Please select an option', 'edd') , // Variable pricing error with multi-purchase option enabled
+			'position_in_cart'        => isset( $position ) ? $position : - 1,
+			'already_in_cart_message' => __( 'You have already added this item to your cart', 'edd' ), // Item already in the cart message
+			'empty_cart_message'      => __( 'Your cart is empty', 'edd' ), // Item already in the cart message
+			'loading'                 => __( 'Loading', 'edd' ), // General loading message
+			'select_option'           => __( 'Please select an option', 'edd' ), // Variable pricing error with multi-purchase option enabled
 			'ajax_loader'             => set_url_scheme( EDD_PLUGIN_URL . 'assets/images/loading.gif', 'relative' ), // Ajax loading image
 			'is_checkout'             => edd_is_checkout() ? '1' : '0',
 			'default_gateway'         => edd_get_default_gateway(),
@@ -104,21 +104,21 @@ function edd_register_styles() {
 
 	$child_theme_style_sheet    = trailingslashit( get_stylesheet_directory() ) . $templates_dir . $file;
 	$child_theme_style_sheet_2  = trailingslashit( get_stylesheet_directory() ) . $templates_dir . 'edd.css';
-	$parent_theme_style_sheet   = trailingslashit( get_template_directory()   ) . $templates_dir . $file;
-	$parent_theme_style_sheet_2 = trailingslashit( get_template_directory()   ) . $templates_dir . 'edd.css';
-	$edd_plugin_style_sheet     = trailingslashit( edd_get_templates_dir()    ) . $file;
+	$parent_theme_style_sheet   = trailingslashit( get_template_directory() ) . $templates_dir . $file;
+	$parent_theme_style_sheet_2 = trailingslashit( get_template_directory() ) . $templates_dir . 'edd.css';
+	$edd_plugin_style_sheet     = trailingslashit( edd_get_templates_dir() ) . $file;
 
 	// Look in the child theme directory first, followed by the parent theme, followed by the EDD core templates directory
 	// Also look for the min version first, followed by non minified version, even if SCRIPT_DEBUG is not enabled.
 	// This allows users to copy just edd.css to their theme
 	if ( file_exists( $child_theme_style_sheet ) || ( ! empty( $suffix ) && ( $nonmin = file_exists( $child_theme_style_sheet_2 ) ) ) ) {
-		if( ! empty( $nonmin ) ) {
+		if ( ! empty( $nonmin ) ) {
 			$url = trailingslashit( get_stylesheet_directory_uri() ) . $templates_dir . 'edd.css';
 		} else {
 			$url = trailingslashit( get_stylesheet_directory_uri() ) . $templates_dir . $file;
 		}
 	} elseif ( file_exists( $parent_theme_style_sheet ) || ( ! empty( $suffix ) && ( $nonmin = file_exists( $parent_theme_style_sheet_2 ) ) ) ) {
-		if( ! empty( $nonmin ) ) {
+		if ( ! empty( $nonmin ) ) {
 			$url = trailingslashit( get_template_directory_uri() ) . $templates_dir . 'edd.css';
 		} else {
 			$url = trailingslashit( get_template_directory_uri() ) . $templates_dir . $file;
@@ -129,7 +129,7 @@ function edd_register_styles() {
 
 	wp_enqueue_style( 'edd-styles', $url, array(), EDD_VERSION );
 
-	if( edd_is_checkout() && is_ssl() ) {
+	if ( edd_is_checkout() && is_ssl() ) {
 		// Dashicons are used to show the padlock icon on the credit card form
 		wp_enqueue_style( 'dashicons' );
 	}
@@ -158,7 +158,7 @@ function edd_load_admin_scripts( $hook ) {
 	$css_dir = EDD_PLUGIN_URL . 'assets/css/';
 
 	// Use minified libraries if SCRIPT_DEBUG is turned off
-	$suffix  = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+	$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 	// These have to be global
 	wp_enqueue_style( 'jquery-chosen', $css_dir . 'chosen' . $suffix . '.css', array(), EDD_VERSION );
@@ -167,8 +167,8 @@ function edd_load_admin_scripts( $hook ) {
 	wp_localize_script( 'edd-admin-scripts', 'edd_vars', array(
 		'post_id'                 => isset( $post->ID ) ? $post->ID : null,
 		'edd_version'             => EDD_VERSION,
-		'add_new_download'        => __( 'Add New Download', 'edd' ), 									// Thickbox title
-		'use_this_file'           => __( 'Use This File','edd' ), 										// "use this file" button
+		'add_new_download'        => __( 'Add New Download', 'edd' ), // Thickbox title
+		'use_this_file'           => __( 'Use This File', 'edd' ), // "use this file" button
 		'quick_edit_warning'      => __( 'Sorry, not available for variable priced products.', 'edd' ),
 		'delete_payment'          => __( 'Are you sure you wish to delete this payment?', 'edd' ),
 		'delete_payment_note'     => __( 'Are you sure you wish to delete this note?', 'edd' ),
@@ -185,20 +185,20 @@ function edd_load_admin_scripts( $hook ) {
 		'one_or_more_option'      => sprintf( __( 'Choose one or more %s', 'edd' ), edd_get_label_plural() ),
 		'numeric_item_price'      => __( 'Item price must be numeric', 'edd' ),
 		'numeric_quantity'        => __( 'Quantity must be numeric', 'edd' ),
-		'currency_sign'           => edd_currency_filter(''),
+		'currency_sign'           => edd_currency_filter( '' ),
 		'currency_pos'            => isset( $edd_options['currency_position'] ) ? $edd_options['currency_position'] : 'before',
 		'currency_decimals'       => edd_currency_decimal_filter(),
 		'new_media_ui'            => apply_filters( 'edd_use_35_media_ui', 1 ),
 		'remove_text'             => __( 'Remove', 'edd' ),
 		'type_to_search'          => sprintf( __( 'Type to search %s', 'edd' ), edd_get_label_plural() ),
 		'quantities_enabled'      => edd_item_quantities_enabled()
-	));
+	) );
 
 	wp_enqueue_style( 'wp-color-picker' );
 	wp_enqueue_script( 'wp-color-picker' );
 	wp_enqueue_style( 'colorbox', $css_dir . 'colorbox' . $suffix . '.css', array(), '1.3.20' );
 	wp_enqueue_script( 'colorbox', $js_dir . 'jquery.colorbox-min.js', array( 'jquery' ), '1.3.20' );
-	if( function_exists( 'wp_enqueue_media' ) && version_compare( $wp_version, '3.5', '>=' ) ) {
+	if ( function_exists( 'wp_enqueue_media' ) && version_compare( $wp_version, '3.5', '>=' ) ) {
 		//call for new media manager
 		wp_enqueue_media();
 	}
@@ -223,33 +223,33 @@ add_action( 'admin_enqueue_scripts', 'edd_load_admin_scripts', 100 );
  * @global $post_type
  * @global $wp_version
  * @return void
-*/
+ */
 function edd_admin_downloads_icon() {
 	global $post_type, $wp_version;
 
-    $images_url      = EDD_PLUGIN_URL . 'assets/images/';
-    $menu_icon       = '\f316';
+	$images_url      = EDD_PLUGIN_URL . 'assets/images/';
+	$menu_icon       = '\f316';
 	$icon_url        = $images_url . 'edd-icon.png';
 	$icon_cpt_url    = $images_url . 'edd-cpt.png';
 	$icon_2x_url     = $images_url . 'edd-icon-2x.png';
 	$icon_cpt_2x_url = $images_url . 'edd-cpt-2x.png';
 	?>
-    <style type="text/css" media="screen">
-        <?php if( version_compare( $wp_version, '3.8-RC', '>=' ) || version_compare( $wp_version, '3.8', '>=' ) ) { ?>
-            #adminmenu #menu-posts-download .wp-menu-image:before,
-            #dashboard_right_now .download-count:before {
-                content: '<?php echo $menu_icon; ?>';
-            }
-        <?php } else { ?>
-            /** Fallback for outdated WP installations */
-		    #adminmenu #menu-posts-download div.wp-menu-image {
-			    background: url(<?php echo $icon_url; ?>) no-repeat 7px -17px;
-            }
-	    	#adminmenu #menu-posts-download:hover div.wp-menu-image,
-		    #adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image {
-			    background-position: 7px 6px;
-            }
-        <?php } ?>
+	<style type="text/css" media="screen">
+		<?php if ( version_compare( $wp_version, '3.8-RC', '>=' ) || version_compare( $wp_version, '3.8', '>=' ) ) { ?>
+			#adminmenu #menu-posts-download .wp-menu-image:before,
+			#dashboard_right_now .download-count:before {
+				content: '<?php echo $menu_icon; ?>';
+			}
+		<?php } else { ?>
+			/** Fallback for outdated WP installations */
+			#adminmenu #menu-posts-download div.wp-menu-image {
+				background: url(<?php echo $icon_url; ?>) no-repeat 7px -17px;
+			}
+			#adminmenu #menu-posts-download:hover div.wp-menu-image,
+			#adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image {
+				background-position: 7px 6px;
+			}
+		<?php } ?>
 		#icon-edit.icon32-posts-download {
 			background: url(<?php echo $icon_cpt_url; ?>) -7px -5px no-repeat;
 		}
@@ -262,18 +262,18 @@ function edd_admin_downloads_icon() {
 		only screen and (   min--moz-device-pixel-ratio: 1.5),
 		only screen and (     -o-min-device-pixel-ratio: 3/2),
 		only screen and (        min-device-pixel-ratio: 1.5),
-		only screen and (        		 min-resolution: 1.5dppx) {
-            <?php if( version_compare( $wp_version, '3.7', '<=' ) ) { ?>
-	    		#adminmenu #menu-posts-download div.wp-menu-image {
-		    		background-image: url(<?php echo $icon_2x_url; ?>);
-			    	background-position: 7px -18px;
-				    background-size: 16px 40px;
-    			}
-	    		#adminmenu #menu-posts-download:hover div.wp-menu-image,
-		    	#adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image {
-			    	background-position: 7px 6px;
-                }
-            <?php } ?>
+		only screen and (                min-resolution: 1.5dppx) {
+			<?php if ( version_compare( $wp_version, '3.7', '<=' ) ) { ?>
+				#adminmenu #menu-posts-download div.wp-menu-image {
+					background-image: url(<?php echo $icon_2x_url; ?>);
+					background-position: 7px -18px;
+					background-size: 16px 40px;
+				}
+				#adminmenu #menu-posts-download:hover div.wp-menu-image,
+				#adminmenu #menu-posts-download.wp-has-current-submenu div.wp-menu-image {
+					background-position: 7px 6px;
+				}
+			<?php } ?>
 			#icon-edit.icon32-posts-download {
 				background: url(<?php echo $icon_cpt_2x_url; ?>) no-repeat -7px -5px !important;
 				background-size: 55px 45px !important;
@@ -286,4 +286,4 @@ function edd_admin_downloads_icon() {
 	</style>
 	<?php
 }
-add_action( 'admin_head','edd_admin_downloads_icon' );
+add_action( 'admin_head', 'edd_admin_downloads_icon' );

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -250,12 +250,15 @@ function edd_admin_downloads_icon() {
 				background-position: 7px 6px;
 			}
 		<?php } ?>
-		#icon-edit.icon32-posts-download {
-			background: url(<?php echo $icon_cpt_url; ?>) -7px -5px no-repeat;
-		}
 		#edd-media-button {
 			background: url(<?php echo $icon_url; ?>) 0 -16px no-repeat;
 			background-size: 12px 30px;
+		}
+		#icon-edit.icon32-posts-download {
+			background: url(<?php echo $icon_cpt_url; ?>) -7px -5px no-repeat;
+		}
+		.wp-media-buttons a.edd-thickbox {
+			padding-left: 5px;
 		}
 		@media
 		only screen and (-webkit-min-device-pixel-ratio: 1.5),

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -54,7 +54,7 @@ function edd_load_scripts() {
 			'purchase_loading'  => __( 'Please Wait...', 'edd' ),
 			'complete_purchase' => __( 'Purchase', 'edd' ),
 			'taxes_enabled'     => edd_use_taxes() ? '1' : '0',
-			'edd_version'       => EDD_VERSION
+			'edd_version'       => EDD_VERSION,
 		) ) );
 	}
 
@@ -74,7 +74,7 @@ function edd_load_scripts() {
 			'redirect_to_checkout'    => ( edd_straight_to_checkout() || edd_is_checkout() ) ? '1' : '0',
 			'checkout_page'           => edd_get_checkout_uri(),
 			'permalinks'              => get_option( 'permalink_structure' ) ? '1' : '0',
-			'quantities_enabled'      => edd_item_quantities_enabled()
+			'quantities_enabled'      => edd_item_quantities_enabled(),
 		) ) );
 	}
 }


### PR DESCRIPTION
I originally just wanted to update the EDD media button to make use of the WP Dashicon font, but also came across some inline styles and spaces used as indentation.

I hope it's ok I've added these in the same request.

![38-new-post](https://cloud.githubusercontent.com/assets/1499293/6029083/76c869e0-abee-11e4-9369-7bfb95731045.png)

![38-new-post-mobile](https://cloud.githubusercontent.com/assets/1499293/6029088/7ca0e090-abee-11e4-88cf-46abb2d5514f.png)

I've tested the Add New Post, Add New Download and Downloads screen running WordPress 3.7 and 3.8 and 4.2 on Windows 7, Ubuntu 14.04.1 and iOS 8.