### PR TITLE
Reverse how we handled #2794 by reimplementing the download attribute

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1097,3 +1097,36 @@ function edd_get_random_downloads( $num = 3, $post_ids = true ) {
 	$args  = apply_filters( 'edd_get_random_downloads', $args );
 	return get_posts( $args );
 }
+
+/**
+ * Returns if a user can access a download of a purchase
+ *
+ * @since 2.2
+ * @author Chris Christoff
+ * @param bool $bool Default for has_access
+ * @param mixed $purchase_data Array of purchase data 
+ * @param mixed $args Array of arguments
+ * @return nool If a user can access the file
+ */
+function edd_can_access_download( $bool = true, $purchase_data = array(), $args = array() ) {
+	return apply_filters( 'edd_file_download_has_access', $bool, $purchase_data, $args );
+}
+
+/**
+ * Returns `download` attribute for download link if user can access download 
+ *
+ * @since 2.2
+ * @author Chris Christoff
+ * @param bool $bool Default for has_access for edd_can_access_download()
+ * @param mixed $purchase_data Array of purchase data  for edd_can_access_download()
+ * @param mixed $args Array of arguments for edd_can_access_download()
+ * @param mixed $args The file array
+ * @return nool If a user can access the file
+ */
+function edd_get_html5_download_attribute( $bool = true, $purchase_data = array(), $args = array(), $file = array ) {
+	$string = '';
+	if ( edd_can_access_download( $bool, $purchase_data, $arg ){
+		$string = 'download="'  .edd_get_file_name( $file ) . '"';	
+	}
+	return apply_filters( 'edd_get_html5_download_attribute', $string, $bool, $purchase_data, $args, $file );
+}

--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -425,8 +425,9 @@ function edd_email_tag_download_list( $payment_id ) {
 
 					if ( $show_links ) {
 						$download_list .= '<div>';
+							$attribute = edd_get_html5_download_attribute( true, $payment_data, array(), $file );
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $item['id'], $price_id );
-							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
+							$download_list .= '<a href="' . esc_url( $file_url ) . '"' . $attribute . '>' . edd_get_file_name( $file ) . '</a>';
 							$download_list .= '</div>';
 					} else {
 						$download_list .= '<div>';
@@ -449,8 +450,9 @@ function edd_email_tag_download_list( $payment_id ) {
 					foreach ( $files as $filekey => $file ) {
 						if ( $show_links ) {
 							$download_list .= '<div>';
+							$attribute = edd_get_html5_download_attribute( true, $payment_data, array(), $file );
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $price_id );
-							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . $file['name'] . '</a>';
+							$download_list .= '<a href="' . esc_url( $file_url ) . '"' . $attribute . '>' . $file['name'] . '</a>';
 							$download_list .= '</div>';
 						} else {
 							$download_list .= '<div>';

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -47,7 +47,7 @@ function edd_process_download() {
 	$method  = edd_get_file_download_method();
 
 	// Defaulting this to true for now because the method below doesn't work well
-	$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $args );
+	$has_access = edd_can_access_download( true, $payment, $args );
 
 	//$has_access = ( edd_logged_in_only() && is_user_logged_in() ) || !edd_logged_in_only() ? true : false;
 	if ( $payment && $has_access ) {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -478,6 +478,7 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 	$payment_key = edd_get_payment_key( $payment_id );
 	$email       = edd_get_payment_user_email( $payment_id );
 	$links       = '<ul class="edd_download_links">';
+	$purchase    = edd_get_payment_meta( $payment_id );
 
 	foreach ( $downloads as $download ) {
 		$links .= '<li>';
@@ -487,7 +488,8 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 			if ( is_array( $files ) ) {
 				foreach ( $files as $filekey => $file ) {
 					$links .= '<div class="edd_download_link_file">';
-						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '">';
+						$attribute = edd_get_html5_download_attribute( true, $purchase, array(), $file );
+						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '" ' . $attribute . '> ';
 							if ( isset( $file['name'] ) )
 								$links .= esc_html( $file['name'] );
 							else

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -53,11 +53,12 @@ if ( $purchases ) :
 
 										foreach ( $download_files as $filekey => $file ) :
 
-											$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $download['id'], $price_id );
+											$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $download['id'], $price_id );																		$has_access = apply_filters( 'edd_file_download_has_access', true, $payment, $edd_receipt_args );
+											$attribute = edd_get_html5_download_attribute( true, $purchase_data, array(), $file );
 											?>
 
 											<div class="edd_download_file">
-												<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link">
+												<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link">
 													<?php echo isset( $file['name'] ) ? esc_html( $file['name'] ) : esc_html( $name ); ?>
 												</a>
 											</div>

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -167,9 +167,10 @@ $status    = edd_get_payment_status( $payment, true );
 								foreach ( $download_files as $filekey => $file ) :
 
 									$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $item['id'], $price_id );
+									$attribute = edd_get_html5_download_attribute( true, $payment, $edd_receipt_args, $file );
 									?>
 									<li class="edd_download_file">
-										<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
+										<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
 									</li>
 									<?php
 									do_action( 'edd_receipt_files', $filekey, $file, $item['id'], $payment->ID, $meta );
@@ -187,12 +188,11 @@ $status    = edd_get_payment_status( $payment, true );
 											$download_files = edd_get_download_files( $bundle_item );
 
 											if( $download_files && is_array( $download_files ) ) :
-
 												foreach ( $download_files as $filekey => $file ) :
-
+													$attribute = edd_get_html5_download_attribute( true, $payment, $edd_receipt_args, $file );
 													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); ?>
 													<li class="edd_download_file">
-														<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
+														<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
 													</li>
 													<?php
 													do_action( 'edd_receipt_bundle_files', $filekey, $file, $item['id'], $bundle_item, $payment->ID, $meta );


### PR DESCRIPTION
The `download` attribute is useful in several cases. It completely put an end to the "my file opened in my browser instead of downloading" tickets. Instead of removing the attribute, and all of its benefits, instead lets only show it when the file can be downloaded. This pr also adds the attribute to bundled products on the receipts page (where it wasn't before) as wells as the download history page