### PR TITLE
Introduce upgrade completion functions and tests

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -443,6 +443,7 @@ function edd_tools_sysinfo_get() {
 	$return .= 'Currency Position:        ' . edd_get_option( 'currency_position', 'before' ) . "\n";
 	$return .= 'Decimal Separator:        ' . edd_get_option( 'decimal_separator', '.' ) . "\n";
 	$return .= 'Thousands Separator:      ' . edd_get_option( 'thousands_separator', ',' ) . "\n";
+	$return .= 'Upgrades Completed:       ' . implode( ',', edd_get_completed_upgrades() ) . "\n";
 
 	$return  = apply_filters( 'edd_sysinfo_after_edd_config', $return );
 
@@ -638,7 +639,7 @@ function edd_tools_sysinfo_download() {
 	if( ! current_user_can( 'manage_shop_settings' ) ) {
 		return;
 	}
-	
+
 	nocache_headers();
 
 	header( 'Content-Type: text/plain' );

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -240,6 +240,8 @@ function edd_upgrade_has_completed( $upgrade_action = '' ) {
 
 /**
  * Get's the array of completed upgrade actions
+ *
+ * @since  2.3
  * @return array The array of completed upgrades
  */
 function edd_get_completed_upgrades() {

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -223,7 +223,7 @@ function edd_has_upgrade_completed( $upgrade_action = '' ) {
  * @param  string $upgrade_action The action to add to the copmleted upgrades array
  * @return bool                   If the function was successfully added
  */
-function edd_upgrade_has_completed( $upgrade_action = '' ) {
+function edd_set_upgrade_complete( $upgrade_action = '' ) {
 
 	if ( empty( $upgrade_action ) ) {
 		return false;
@@ -804,7 +804,7 @@ function edd_v23_upgrade_payment_taxes() {
 		if( empty( $has_payments ) ) {
 			// We had no payments, just complete
 			update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
-			edd_upgrade_has_completed( 'upgrade_payment_taxes' );
+			edd_set_upgrade_complete( 'upgrade_payment_taxes' );
 			delete_option( 'edd_doing_upgrade' );
 			wp_redirect( admin_url() ); exit;
 		}
@@ -846,7 +846,7 @@ function edd_v23_upgrade_payment_taxes() {
 	} else {
 		// No more payments found, finish up
 		update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
-		edd_upgrade_has_completed( 'upgrade_payment_taxes' );
+		edd_set_upgrade_complete( 'upgrade_payment_taxes' );
 		delete_option( 'edd_doing_upgrade' );
 		wp_redirect( admin_url() ); exit;
 	}
@@ -884,7 +884,7 @@ function edd_v23_upgrade_customer_purchases() {
 		if( empty( $has_payments ) ) {
 			// We had no payments, just complete
 			update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
-			edd_upgrade_has_completed( 'upgrade_customer_payments_association' );
+			edd_set_upgrade_complete( 'upgrade_customer_payments_association' );
 			delete_option( 'edd_doing_upgrade' );
 			wp_redirect( admin_url() ); exit;
 		}
@@ -973,7 +973,7 @@ function edd_v23_upgrade_customer_purchases() {
 		// No more customers found, finish up
 
 		update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
-		edd_upgrade_has_completed( 'upgrade_customer_payments_association' );
+		edd_set_upgrade_complete( 'upgrade_customer_payments_association' );
 		delete_option( 'edd_doing_upgrade' );
 
 		wp_redirect( admin_url() ); exit;

--- a/tests/tests-upgrades.php
+++ b/tests/tests-upgrades.php
@@ -1,0 +1,30 @@
+<?php
+
+
+/**
+ * @group edd_upgrades
+ */
+class Tests_Upgrades extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function test_upgrade_completion() {
+
+		$current_upgrades = edd_get_completed_upgrades();
+		$this->assertTrue( empty( $current_upgrades ) );
+		$this->assertInternalType( 'array', $current_upgrades );
+
+		$this->assertTrue( edd_upgrade_has_completed( 'test-upgrade-action' ) );
+		$this->assertTrue( edd_has_upgrade_completed( 'test-upgrade-action' ) );
+		$this->assertFalse( edd_has_upgrade_completed( 'test-upgrade-action-false' ) );
+
+	}
+
+}

--- a/tests/tests-upgrades.php
+++ b/tests/tests-upgrades.php
@@ -21,7 +21,7 @@ class Tests_Upgrades extends WP_UnitTestCase {
 		$this->assertTrue( empty( $current_upgrades ) );
 		$this->assertInternalType( 'array', $current_upgrades );
 
-		$this->assertTrue( edd_upgrade_has_completed( 'test-upgrade-action' ) );
+		$this->assertTrue( edd_set_upgrade_complete( 'test-upgrade-action' ) );
 		$this->assertTrue( edd_has_upgrade_completed( 'test-upgrade-action' ) );
 		$this->assertFalse( edd_has_upgrade_completed( 'test-upgrade-action-false' ) );
 


### PR DESCRIPTION
Should address issues when we have multiple upgrades for a user who either jumps versions or a version has 2 upgrades in it's release. #2835