### PR TITLE
Don't use fast_finish for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
       env: WP_VERSION=3.9.2 WP_MULTISITE=0
     - php: hhvm
       env: WP_VERSION=4.0 WP_MULTISITE=0
-  fast_finish: true
 
 before_script:
 - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
Travis CI has a bug where when fast_finish is enabled, it doesn't let you cancel the builds:
https://github.com/travis-ci/travis-ci/issues/2658