### PR TITLE
Add edd_download_supports to EDD_Download class w/ helpers

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -101,6 +101,17 @@ class EDD_Download {
 	private $button_behavior;
 
 	/**
+	 * Default download support options
+	 *
+	 * @since 2.4
+	 */
+	private $supports = array(
+		'quantities' => false,
+		'taxes'      => false,
+		'shipping'   => false,
+	);
+
+	/**
 	 * Get things going
 	 *
 	 * @since 2.2
@@ -628,6 +639,33 @@ class EDD_Download {
 
 		return (bool) apply_filters( 'edd_is_free_download', $is_free, $this->ID, $price_id );
 
+	}
+
+	/**
+	 * Determine if the download supports a feature
+	 * 
+	 * @since  2.4
+	 * @param  string $feature   The feature being checked for support
+	 * @return bool              Whether the download supports the feature.
+	 */
+	public function supports( $features = '' ) {
+		$supports = apply_filters( 'edd_download_supports', $this->supports, $this->ID );
+
+		if( empty( $features ) ) {
+			return false;
+		}
+
+		if ( ! is_array( $features ) ) {
+			return ! empty( $supports[ $features ] ) && $supports[ $features ];
+		}
+
+		$support_check = true;
+		foreach ( $features as $feature ) {
+			if ( empty( $supports[ $feature ] ) || ! $supports[ $feature ] ) {
+				$support_check = false;
+			}
+		}
+		return $support_check;
 	}
 
 }

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1097,3 +1097,22 @@ function edd_get_random_downloads( $num = 3, $post_ids = true ) {
 	$args  = apply_filters( 'edd_get_random_downloads', $args );
 	return get_posts( $args );
 }
+
+/**
+ * Checks whether or not a download supports a specific feature
+ *
+ * @since 2.4
+ * @author Daniel Iser
+ * @param int $download_id ID number of the download to check
+ * @param string $feature The feature being checked.
+ * @return bool $supports True if the product supports the feature, false if the product does not or no ID is passed
+ */
+function edd_download_supports( $download_id = 0, $feature ) {
+
+	if( empty( $download_id ) ) {
+		return false;
+	}
+
+	$download = new EDD_Download( $download_id );
+	return $download->supports( $feature );
+}

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -831,3 +831,23 @@ function edd_add_download_post_classes( $classes, $class = '', $post_id = false 
 	return $classes;
 }
 add_filter( 'post_class', 'edd_add_download_post_classes', 20, 3 );
+
+/**
+ * Checks if download supports specific feature in the loop
+ *
+ * @since 2.4
+ * @author Daniel Iser
+ * @param string $feature The feature being checked.
+ * @return bool $supports True if the product supports the feature, false if the product does not or no ID is passed
+ */
+function edd_item_supports( $feature ) {
+	global $post;
+
+	$post_id = is_object( $post ) ? $post->ID : 0;
+
+	if( empty( $post_id ) ) {
+		return false;
+	}
+
+	return edd_download_supports( $post_id, $feature );
+}


### PR DESCRIPTION
Feature #2955
Added private $supports array to EDD_Download class.
Added public supports() method to the EDD_Download class, accepts a string or array of features to check against $supports array.
Added 'edd_download_supports' filter allowing addition and setting of features to the $supports array.
Added edd_download_supports function for usage outside the loop.
Added edd_item_supports for use inside the loop.