### PR TITLE
Only delete edd_items_in_cart cookie if it is already set.

### DIFF
--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -198,7 +198,9 @@ class EDD_Session {
 			if( $set ) {
 				@setcookie( 'edd_items_in_cart', '1', time() + 30 * 60, COOKIEPATH, COOKIE_DOMAIN, false );
 			} else {
-				@setcookie( 'edd_items_in_cart', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+				if ( isset($_COOKIE['edd_items_in_cart']) ) {
+					@setcookie( 'edd_items_in_cart', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );	
+				}				
 			}
 		}
 	}


### PR DESCRIPTION
This fixes issue where every page load includes a wasteful Set-Cookie request to clear out the `edd_items_in_cart` cookie.

I've tested in my install, and it works as expected.