### PR TITLE
Checks for download limit for new urls #3259

### DIFF
--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -693,7 +693,7 @@ function edd_process_signed_download_url( $args ) {
 	$order_parts = explode( ':', rawurldecode( $_GET['eddfile'] ) );
 	
 	// Check to make sure not at download limit
-	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $order_parts[3] ) ){
+	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $order_parts[3] ) ) {
 		wp_die( apply_filters( 'edd_download_limit_reached_text', __( 'Sorry but you have hit your download limit for this file.', 'edd' ) ), __( 'Error', 'edd' ), array( 'response' => 403 ) );	
 	}
 	

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -697,15 +697,6 @@ function edd_process_signed_download_url( $args ) {
 		wp_die( apply_filters( 'edd_download_limit_reached_text', __( 'Sorry but you have hit your download limit for this file.', 'edd' ) ), __( 'Error', 'edd' ), array( 'response' => 403 ) );	
 	}
 	
-	// Make sure the link hasn't expired
-	$expire = $_GET['ttl'];
-	if ( base64_encode( base64_decode( $expire, true ) ) === $expire ) {
-		$expire = base64_decode( $expire ); // If it is a base64 string, decode it. Old expiration dates were in base64
-	}
-	if ( current_time( 'timestamp' ) > $expire ) {
-		wp_die( apply_filters( 'edd_download_link_expired_text', __( 'Sorry but your download link has expired.', 'edd' ) ), __( 'Error', 'edd' ), array( 'response' => 403 ) );
-	}
-	
 	$args['expire']      = $_GET['ttl'];
 	$args['download']    = $order_parts[1];
 	$args['payment']     = $order_parts[0];

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -693,7 +693,7 @@ function edd_process_signed_download_url( $args ) {
 	$order_parts = explode( ':', rawurldecode( $_GET['eddfile'] ) );
 	
 	// Check to make sure not at download limit
-	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $order_parts[3] ) )
+	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $order_parts[3] ) ){
 		wp_die( apply_filters( 'edd_download_limit_reached_text', __( 'Sorry but you have hit your download limit for this file.', 'edd' ) ), __( 'Error', 'edd' ), array( 'response' => 403 ) );	
 	}
 	

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -691,7 +691,21 @@ function edd_process_signed_download_url( $args ) {
 	}
 
 	$order_parts = explode( ':', rawurldecode( $_GET['eddfile'] ) );
-
+	
+	// Check to make sure not at download limit
+	if ( edd_is_file_at_download_limit( $order_parts[1], $order_parts[0], $order_parts[2], $order_parts[3] ) )
+		wp_die( apply_filters( 'edd_download_limit_reached_text', __( 'Sorry but you have hit your download limit for this file.', 'edd' ) ), __( 'Error', 'edd' ), array( 'response' => 403 ) );	
+	}
+	
+	// Make sure the link hasn't expired
+	$expire = $_GET['ttl'];
+	if ( base64_encode( base64_decode( $expire, true ) ) === $expire ) {
+		$expire = base64_decode( $expire ); // If it is a base64 string, decode it. Old expiration dates were in base64
+	}
+	if ( current_time( 'timestamp' ) > $expire ) {
+		wp_die( apply_filters( 'edd_download_link_expired_text', __( 'Sorry but your download link has expired.', 'edd' ) ), __( 'Error', 'edd' ), array( 'response' => 403 ) );
+	}
+	
 	$args['expire']      = $_GET['ttl'];
 	$args['download']    = $order_parts[1];
 	$args['payment']     = $order_parts[0];


### PR DESCRIPTION
The file download count check which for legacy links are done in the deprecated edd_verify_download_link function are not done for the new download links. This pr solves that issue.

Solves #3259

This needs to be tested