### PR TITLE
Fix Ajax Test Works Function

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -36,6 +36,10 @@ function edd_is_ajax_enabled() {
 function edd_test_ajax_works() {
 
 	add_filter( 'block_local_requests', '__return_false' );
+	
+	if ( get_transient( '_edd_ajax_works' ) ) {
+		return true;
+	}
 
 	$params = array(
 		'sslverify'  => false,


### PR DESCRIPTION
Right now, we save whether or not the ajax test works as a transient, but we never actually use it. So what happens is on every edd_notices call, which is done on every admin page, EDD related or not, we're running this (can be) performance harming remote_post. This pr uses the transient to return early, so we only check it once a day, not every single notices call