### PR TITLE
All add to cart buttons for same product changed to checkout when one is clicked  (#3275)

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -206,7 +206,7 @@ jQuery(document).ready(function ($) {
 					}
 
 					// Update all buttons for same download
-					if( $( '.edd_download_purchase_form' ).length ) {
+					if( $( '.edd_download_purchase_form' ).length && ( variable_price == 'no' || ! form.find('.edd_price_option_' + download).is('input:hidden') ) ) {
 						var parent_form = $('.edd_download_purchase_form *[data-download-id="' + download + '"]').parents('form');
 						$( 'a.edd-add-to-cart', parent_form ).hide();
 						if( price_mode != 'multi' ) {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -84,6 +84,7 @@ function edd_get_purchase_link( $args = array() ) {
 	// Override color if color == inherit
 	$args['color'] = ( $args['color'] == 'inherit' ) ? '' : $args['color'];
 
+	$options          = array();
 	$variable_pricing = $download->has_variable_prices();
 	$data_variable    = $variable_pricing ? ' data-variable-price="yes"' : 'data-variable-price="no"';
 	$type             = $download->is_single_price_mode() ? 'data-price-mode=multi' : 'data-price-mode=single';
@@ -92,10 +93,10 @@ function edd_get_purchase_link( $args = array() ) {
 
 		if ( $variable_pricing && false !== $args['price_id'] ) {
 
-			$price_id = $args['price_id'];
-			$prices   = $download->prices;
-
-			$price = isset( $prices[$price_id] ) ? $prices[$price_id]['amount'] : false;
+			$price_id            = $args['price_id'];
+			$prices              = $download->prices;
+			$options['price_id'] = $args['price_id'];
+			$price               = isset( $prices[$price_id] ) ? $prices[$price_id]['amount'] : false;
 
 		} elseif ( ! $variable_pricing ) {
 
@@ -104,7 +105,7 @@ function edd_get_purchase_link( $args = array() ) {
 		}
 	}
 
-	$data_price       = isset( $price ) && false !== $price ? 'data-price="' . $price . '"' : 'data-price="' . 0 . '"';
+	$data_price  = isset( $price ) && false !== $price ? 'data-price="' . $price . '"' : 'data-price="' . 0 . '"';
 
 	$button_text = ! empty( $args['text'] ) ? '&nbsp;&ndash;&nbsp;' . $args['text'] : '';
 
@@ -118,7 +119,7 @@ function edd_get_purchase_link( $args = array() ) {
 
 	}
 
-	if ( edd_item_in_cart( $download->ID ) && ( ! $variable_pricing || ! $download->is_single_price_mode() ) ) {
+	if ( edd_item_in_cart( $download->ID, $options ) && ( ! $variable_pricing || ! $download->is_single_price_mode() ) ) {
 		$button_display   = 'style="display:none;"';
 		$checkout_display = '';
 	} else {


### PR DESCRIPTION
Solves #3275

If you have multiple [purchase_link] short codes for a product on the same page, they all get changed to Checkout when one is clicked.

When the buttons are all for the same price ID, it is the expected behavior but when each button has a different price ID, this should not happen.