### PR TITLE
Disable Buy Now buttons when Taxes are enabled (#3235)

### DIFF
--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -158,7 +158,7 @@ function edd_shop_supports_buy_now() {
 	$gateways = edd_get_enabled_payment_gateways();
 	$ret      = false;
 
-	if( $gateways ) {
+	if( ! edd_use_taxes()  && $gateways ) {
 		foreach( $gateways as $gateway_id => $gateway ) {
 			if( edd_gateway_supports_buy_now( $gateway_id ) ) {
 				$ret = true;

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -71,6 +71,11 @@ function edd_get_purchase_link( $args = array() ) {
 
 	$args = wp_parse_args( $args, $defaults );
 
+	// Override the stright_to_gateway if the shop doesn't support it
+	if ( ! edd_shop_supports_buy_now() ) {
+		$args['direct'] = false;
+	}
+
 	$download = new EDD_Download( $args['download_id'] );
 
 	if( empty( $download->ID ) ) {


### PR DESCRIPTION
Solves #3235

We gets users every now and then that encounter issues with trying to use Buy Now buttons and taxes but then not seeing taxes get calculated. This is because the general Checkout process is required for calculating the taxed amount.

I'm proposing that we automatically disable the buy now options if taxes are enabled. In the future, once we have introduced a way to calculate taxes and use buy now buttons, we can remove this.