### PR TITLE
Item quantity fields not showing with [purchase_link] shortcode (#3230)

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -308,7 +308,7 @@ function edd_variable_price_quantity_field( $key, $price, $download_id ) {
 		return;
 	}
 
-	if( ! edd_single_price_option_mode() ) {
+	if( ! edd_single_price_option_mode( $download_id ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Solves #3230

Make sure Item Quantities are enabled in the EDD settings. Set up a variable pricing product with multi-purchase mode enabled. View the single download page to confirm that the item quantity fields display for each variable pricing option. Once confirmed, use that product's [purchase_link] shortcode in a separate Post/Page. The item quantity fields don't seem to show.