### PR TITLE
Don't check if ajax calls work if Airplane Mode plugin is active (#3215)

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -35,6 +35,16 @@ function edd_is_ajax_enabled() {
  */
 function edd_test_ajax_works() {
 
+	// Check if the Airplane Mode plugin is installed
+	if ( class_exists( 'Airplane_Mode_Core' ) ) {
+
+		global $Airplane_Mode_Core;
+
+		if ( $Airplane_Mode_Core->enabled() ) {
+			return true;
+		}
+	}
+
 	add_filter( 'block_local_requests', '__return_false' );
 	
 	if ( get_transient( '_edd_ajax_works' ) ) {
@@ -78,14 +88,6 @@ function edd_test_ajax_works() {
 
 	if( $works ) {
 		set_transient( '_edd_ajax_works', '1', DAY_IN_SECONDS );
-	} else {
-		if ( class_exists( 'Airplane_Mode_Core' ) ) { // the Airplane Mode plugin is installed
-			global $Airplane_Mode_Core;
-			if ( $Airplane_Mode_Core->enabled() ) { // and it's enabled
-				$works = true; // the checks will fail if its active, so set works to true to avoid outputting error message
-				set_transient( '_edd_ajax_works', '1', DAY_IN_SECONDS ); // ignore for a day
-			}
-		}		
 	}
 
 	return $works;

--- a/tests/ajax.php
+++ b/tests/ajax.php
@@ -217,4 +217,28 @@ class Tests_AJAX extends WP_UnitTestCase {
 		$expected = '<select class="edd_price_options_select edd-select edd-select"><option value="0">Simple</option><option value="1">Advanced</option></select>';
 		//$this->assertEquals( $expected, $this->_last_response );
 	}
+
+	public function test_edd_test_ajax_works() {
+		
+		$this->assertTrue( edd_test_ajax_works() );
+
+		$this->assertNotEmpty( get_transient( '_edd_ajax_works' ) );
+
+		// Now test for Airplane Mode plugin
+
+		delete_transient( '_edd_ajax_works' );
+
+		class Airplane_Mode_Core {
+			function __construct() {}
+			public function enabled() { return true }
+		}
+
+		global $Airplane_Mode_Core;
+		$Airplane_Mode_Core = new Airplane_Mode_Core;
+
+		// Should return true but should not set a transient
+		$this->assertTrue( edd_test_ajax_works() );
+		$this->assertEmpty( get_transient( '_edd_ajax_works' ) );
+
+	}
 }


### PR DESCRIPTION
Solves #3215

If the Airplane mode plugin is installed and enabled we should ignore the test. It's kind of annoying to see the error all the time.