### PR TITLE
Use the new customer count in EDD_DB_Customers for >= 2.3 installs

### DIFF
--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -1103,17 +1103,17 @@ class EDD_API {
 
 			return $earnings;
 		} elseif ( $args['type'] == 'customers' ) {
-	        if ( version_compare( $edd_version, '2.3', '<' ) || ! edd_has_upgrade_completed( 'upgrade_customer_payments_association' ) ) {
-	            global $wpdb;
-	            $stats = array();
-	            $count = $wpdb->get_col( "SELECT COUNT(DISTINCT meta_value) FROM $wpdb->postmeta WHERE meta_key = '_edd_payment_user_email'" );
-	            $stats['customers']['total_customers'] = $count[0];
-	            return $stats;
-	        } else {
-	            $customers = new EDD_DB_Customers();
-	            $stats['customers']['total_customers'] = $customers->count();
-	            return $stats;
-	        }
+			if ( version_compare( $edd_version, '2.3', '<' ) || ! edd_has_upgrade_completed( 'upgrade_customer_payments_association' ) ) {
+				global $wpdb;
+				$stats = array();
+				$count = $wpdb->get_col( "SELECT COUNT(DISTINCT meta_value) FROM $wpdb->postmeta WHERE meta_key = '_edd_payment_user_email'" );
+				$stats['customers']['total_customers'] = $count[0];
+				return $stats;
+			} else {
+				$customers = new EDD_DB_Customers();
+				$stats['customers']['total_customers'] = $customers->count();
+				return $stats;
+			}
 		} elseif ( empty( $args['type'] ) ) {
 			$stats = array_merge( $stats, $this->get_default_sales_stats() );
 			$stats = array_merge ( $stats, $this->get_default_earnings_stats() );

--- a/includes/class-edd-api.php
+++ b/includes/class-edd-api.php
@@ -1103,15 +1103,17 @@ class EDD_API {
 
 			return $earnings;
 		} elseif ( $args['type'] == 'customers' ) {
-			global $wpdb;
-
-			$stats = array();
-
-			$count = $wpdb->get_col( "SELECT COUNT(DISTINCT meta_value) FROM $wpdb->postmeta WHERE meta_key = '_edd_payment_user_email'" );
-
-			$stats['customers']['total_customers'] = $count[0];
-
-			return $stats;
+	        if ( version_compare( $edd_version, '2.3', '<' ) || ! edd_has_upgrade_completed( 'upgrade_customer_payments_association' ) ) {
+	            global $wpdb;
+	            $stats = array();
+	            $count = $wpdb->get_col( "SELECT COUNT(DISTINCT meta_value) FROM $wpdb->postmeta WHERE meta_key = '_edd_payment_user_email'" );
+	            $stats['customers']['total_customers'] = $count[0];
+	            return $stats;
+	        } else {
+	            $customers = new EDD_DB_Customers();
+	            $stats['customers']['total_customers'] = $customers->count();
+	            return $stats;
+	        }
 		} elseif ( empty( $args['type'] ) ) {
 			$stats = array_merge( $stats, $this->get_default_sales_stats() );
 			$stats = array_merge ( $stats, $this->get_default_earnings_stats() );


### PR DESCRIPTION
Right now, the stats API uses the following query to get the customer
count:
```$count = $wpdb->get_col( "SELECT COUNT(DISTINCT meta_value) FROM
$wpdb->postmeta WHERE meta_key = '_edd_payment_user_email'" );```

https://github.com/easydigitaldownloads/Easy-Digital-Downloads/blob/49bba4499763ed571e7a9fa336e24ddd902663ba/includes/class-edd-api.php#L1110

This is great in that it works for everyone even if they didn't run the
EDD 2.3 updates.

On the downside, there's 2 significant issues with it:
- It's not cached
- Its a huge set of data (we ask MySQL to find all records, then limit
it)

Instead, what we should do is for the 99.999% who did the update routine
use the customer count from EDD_DB_Customers, which is both cached and
far more efficient (we don't need to sort out duplicates)

So our code will be something like:

```php
if ( version_compare( $edd_version, '2.3', '<' ) || !
edd_has_upgrade_completed( 'upgrade_customer_payments_association' ) ) {
global $wpdb;
$stats = array();
$count = $wpdb->get_col( "SELECT COUNT(DISTINCT meta_value) FROM
$wpdb->postmeta WHERE meta_key = '_edd_payment_user_email'" );
$stats['customers']['total_customers'] = $count[0];
return $stats;
} else {
$customers = new EDD_DB_Customers();
$stats['customers']['total_customers'] =  $customers->count();
return $stats;
}
```

Solves #3284