### PR TITLE
Cache busting cookies: edd_items_in_cart

### DIFF
--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -198,7 +198,9 @@ class EDD_Session {
 			if( $set ) {
 				@setcookie( 'edd_items_in_cart', '1', time() + 30 * 60, COOKIEPATH, COOKIE_DOMAIN, false );
 			} else {
-				@setcookie( 'edd_items_in_cart', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
+				if ( isset($_COOKIE['edd_items_in_cart']) ) {
+					@setcookie( 'edd_items_in_cart', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );	
+				}				
 			}
 		}
 	}


### PR DESCRIPTION
Resubmit against `release/2.4` of PR #3172 

I've started using fastcgi caching with Nginx over caching plugins.  The down downside of this is that Nginx will not cache any page or serve a cached page for any request with a Set-Cookie, and unlike Varnish, you can't exclude cookies from the cache.

I've noticed that every page request on sites with EDD includes a Set-Cookie header from EDD in the form of `edd_items_in_cart`.  It defaults to `deleted`, but if any items are in the cart it is set to that number.

I can't figure out why it would be necessary to set this cookie on every single request, especially when a user hasn't initiated any shopping actions.  Nor does it feel like the kind of data that needs to be in a cookie. 

With EDD's strong AJAX coverage, I'd think there would be plenty of ways to avoid this entirely. 

(I'm not sure if EDD uses PHP sessions, but if so the same would apply for first page requests that cause a new session. That's harder to solve though.)