### PR TITLE
Ensure meta data contains tax key. Fixes #3324. 

### DIFF
--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -295,7 +295,12 @@ function edd_update_payment_backwards_compat( $meta_id, $object_id, $meta_key, $
 
 		case '_edd_payment_meta':
 			$meta_value   = maybe_unserialize( $meta_value );
-			$tax_value    = ! empty( $meta_value['tax'] ) ? $meta_value['tax'] : 0;
+			
+			if( !isset( $meta_value['tax'] ) ){
+				return;
+			}
+			
+			$tax_value    = $meta_value['tax'];
 
 			$data         = array( 'meta_value' => $tax_value );
 			$where        = array( 'post_id'  => $object_id, 'meta_key' => '_edd_payment_tax' );

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -161,7 +161,8 @@ function edd_insert_payment( $payment_data = array() ) {
 			'currency'     => $payment_data['currency'],
 			'downloads'    => $payment_data['downloads'],
 			'user_info'    => $payment_data['user_info'],
-			'cart_details' => $payment_data['cart_details']
+			'cart_details' => $payment_data['cart_details'],
+			'tax'          => $cart_tax,
 		);
 
 		$mode    = edd_is_test_mode() ? 'test' : 'live';

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -162,7 +162,6 @@ function edd_insert_payment( $payment_data = array() ) {
 			'downloads'    => $payment_data['downloads'],
 			'user_info'    => $payment_data['user_info'],
 			'cart_details' => $payment_data['cart_details'],
-			'tax'          => $cart_tax,
 		);
 
 		$mode    = edd_is_test_mode() ? 'test' : 'live';

--- a/tests/tests-tax.php
+++ b/tests/tests-tax.php
@@ -265,5 +265,18 @@ class Tests_Taxes extends WP_UnitTestCase {
 	public function test_get_payment_tax() {
 		$this->assertEquals( '0.36', edd_get_payment_tax( $this->_payment_id ) );
 	}
+	
+	/**
+	 * @see https://github.com/easydigitaldownloads/Easy-Digital-Downloads/issues/3324
+	 */
+	public function test_backwards_compat_bug(){
+		
+		$this->assertEquals( '0.36', edd_get_payment_tax( $this->_payment_id ) );
+		
+		$current_meta = edd_get_payment_meta( $this->_payment_id );
+		edd_update_payment_meta( $this->_payment_id, '_edd_payment_meta', $current_meta );
+		
+		$this->assertEquals( '0.36', edd_get_payment_tax( $this->_payment_id ) );
+	}
 
 }


### PR DESCRIPTION
Fixes bug with payment meta/tax backwards compatability code. Adds unit test. Fixes #3324.

Passes all tax unit tests. However I was only able to test 60% of all unit tests before I encountered an error (unrelated to this pull request):

 > PHP Fatal error:  Call to undefined method Tests_Activation::assertNotFalse() in /var/www/html/plugins/edd/tests/tests-install.php on line 76

(Seems the phpunit version set by `composer.json` is out of date? I think it requires 4.4+)