### PR TITLE
Ignore vendor directory & temporary files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ tests/clover.xml
 
 # Grunt
 node_modules
+
+# Vendor
+vendor
+
+# Temporary files
+*~


### PR DESCRIPTION
I noticed this while making another recent PR. Git isn't configured to ignore the `vendor` folder or the temporary files (`*~`).