### PR TITLE
Update widget-cart-item.php

### DIFF
--- a/templates/widget-cart-item.php
+++ b/templates/widget-cart-item.php
@@ -1,5 +1,5 @@
 <li class="edd-cart-item">
 	<span class="edd-cart-item-title">{item_title}</span>
-	<span class="edd-cart-item-separator">-</span><span class="edd-cart-item-quantity">&nbsp;{item_quantity}&nbsp;@&nbsp;<span class="edd-cart-item-price">&nbsp;{item_amount}&nbsp;</span><span class="edd-cart-item-separator">-</span>
+	<span class="edd-cart-item-separator">-</span><span class="edd-cart-item-quantity">&nbsp;{item_quantity}&nbsp;@&nbsp;</span><span class="edd-cart-item-price">&nbsp;{item_amount}&nbsp;</span><span class="edd-cart-item-separator">-</span>
 	<a href="{remove_url}" data-cart-item="{cart_item_id}" data-download-id="{item_id}" data-action="edd_remove_from_cart" class="edd-remove-from-cart"><?php _e( 'remove', 'edd' ); ?></a>
 </li>


### PR DESCRIPTION
Closing `<span>` tag needed for `edd-cart-item-quantity` element. Discovered by a customer in HS ticket #7754.