### PR TITLE
Introduce create() method for EDD_Download

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -139,6 +139,19 @@ class EDD_Download {
 
 		$download = WP_Post::get_instance( $_id );
 
+		return $this->setup_download( $download );
+
+	}
+
+	/**
+	 * Given the download data, let's set the variables
+	 *
+	 * @since  2.3
+	 * @param  object $download The Download Object
+	 * @return bool             If the setup was successful or not
+	 */
+	private function setup_download( $download ) {
+
 		if( ! is_object( $download ) ) {
 			return false;
 		}
@@ -153,9 +166,17 @@ class EDD_Download {
 
 		foreach ( $download as $key => $value ) {
 
-			$this->$key = $value;
+			switch ( $key ) {
+
+				default:
+					$this->$key = $value;
+					break;
+
+			}
 
 		}
+
+		return true;
 
 	}
 
@@ -203,9 +224,11 @@ class EDD_Download {
 
 		$id = wp_insert_post( $args, true );
 
+		$download = WP_Post::get_instance( $id );
+
 		do_action( 'edd_download_post_create', $id, $args );
 
-		return $id;
+		return $this->setup_download( $download );
 
 	}
 

--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -146,7 +146,7 @@ class EDD_Download {
 	/**
 	 * Given the download data, let's set the variables
 	 *
-	 * @since  2.3
+	 * @since  2.3.6
 	 * @param  object $download The Download Object
 	 * @return bool             If the setup was successful or not
 	 */
@@ -202,13 +202,13 @@ class EDD_Download {
 	/**
 	 * Creates a download
 	 *
-	 * @since  future
+	 * @since  2.3.6
 	 * @param  array  $data Array of attributes for a download
 	 * @return mixed  false if data isn't passed and class not instantiated for creation, or New Download ID
 	 */
 	public function create( $data = array() ) {
 
-		if ( $this->id != 0 || empty( $data ) ) {
+		if ( $this->id != 0 ) {
 			return false;
 		}
 

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -915,7 +915,7 @@ function edd_update_payment_meta( $payment_id = 0, $meta_key = '', $meta_value =
 
 	}
 
-	$meta_value = apply_filters( 'edd_edd_update_payment_meta_' . $meta_key, $meta_value, $payment_id );
+	$meta_value = apply_filters( 'edd_update_payment_meta_' . $meta_key, $meta_value, $payment_id );
 
 	return update_post_meta( $payment_id, $meta_key, $meta_value, $prev_value );
 }

--- a/tests/tests-downloads.php
+++ b/tests/tests-downloads.php
@@ -53,20 +53,20 @@ class Tests_Downloads extends WP_UnitTestCase {
 
 	public function test_edd_download() {
 
-		// Create a new download
+		// Verify passing nothing gives us an empty download
 		$download = new EDD_Download;
-		$this->assertNotEmpty( $download->ID );
-		$this->assertEquals( 'download', $download->post_type );
-		$this->assertEquals( 'draft', $download->post_status );
-		$this->assertEquals( 0, $download->sales );
-		$this->assertEquals( 0.00, $download->earnings );
-		$this->assertFalse( $download->has_variable_prices() );
-		$this->assertEmpty( $download->prices );
+		$this->assertEquals( 0, $download->ID );
 
-		// Retrieve the one we just created
-		$download2 = new EDD_Download( $download->ID );
+		// Create a Download
+		$args = array(
+			'post_title'  => 'Test Create Download'
+		);
+		$download2 = new EDD_Download;
+		$this->assertEquals( 0, $download2->ID );
+
+		$download2->create( $args );
+
 		$this->assertNotEmpty( $download2->ID );
-		$this->assertEquals( $download->ID, $download2->ID );
 		$this->assertEquals( 'download', $download2->post_type );
 		$this->assertEquals( 'draft', $download2->post_status );
 		$this->assertEquals( 0, $download2->sales );


### PR DESCRIPTION
Moves to a explicit `create` method for the `EDD_Download` class, and addresses the issues in #3312