### PR TITLE
Rename "Cyprus Island" to just "Cyprus".

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -199,7 +199,7 @@ function edd_get_country_list() {
 		'HR' => 'Croatia/Hrvatska',
 		'CU' => 'Cuba',
 		'CW' => 'Cura&Ccedil;ao',
-		'CY' => 'Cyprus Island',
+		'CY' => 'Cyprus',
 		'CZ' => 'Czech Republic',
 		'DK' => 'Denmark',
 		'DJ' => 'Djibouti',


### PR DESCRIPTION
There's no "Cyprus Island", just "Cyprus". :)