### PR TITLE
Script tests

### DIFF
--- a/includes/plugin-compatibility.php
+++ b/includes/plugin-compatibility.php
@@ -126,7 +126,7 @@ add_action( 'edd_email_send_before', 'edd_disable_mandrill_nl2br');
  * @return void
  */
 function edd_disable_404_redirected_redirect() {
-	
+
 	if( ! defined( 'WBZ404_VERSION' ) ) {
 		return;
 	}
@@ -135,4 +135,4 @@ function edd_disable_404_redirected_redirect() {
 		remove_action( 'template_redirect', 'wbz404_process404', 10 );
 	}
 }
-add_action( 'parse_query', 'edd_disable_404_redirected_redirect' );
+add_action( 'template_redirect', 'edd_disable_404_redirected_redirect', 9 );

--- a/tests/tests-plugin-compatibility.php
+++ b/tests/tests-plugin-compatibility.php
@@ -19,7 +19,7 @@ class Tests_Plugin_Compatibility extends WP_UnitTestCase {
 		$this->assertNotFalse( has_filter( 'edd_downloads_excerpt', 'edd_qtranslate_content' ) );
 		$this->assertNotFalse( has_action( 'template_redirect', 'edd_disable_woo_ssl_on_checkout' ) );
 		$this->assertNotFalse( has_action( 'edd_email_send_before', 'edd_disable_mandrill_nl2br' ) );
-		$this->assertNotFalse( has_action( 'parse_query', 'edd_disable_404_redirected_redirect' ) );
+		$this->assertNotFalse( has_action( 'template_redirect', 'edd_disable_404_redirected_redirect' ) );
 
 	}
 

--- a/tests/tests-scripts.php
+++ b/tests/tests-scripts.php
@@ -25,7 +25,7 @@ class Tests_Scripts extends WP_UnitTestCase {
 	 * @since 2.3.6
 	 */
 	public function test_load_scripts_checkout() {
-$this->markTestIncomplete( 'Getting weird errors' );
+
 		// Prepare test
 		$this->go_to( get_permalink( edd_get_option( 'purchase_page' ) ) );
 		edd_load_scripts();
@@ -79,7 +79,7 @@ $this->markTestIncomplete( 'Getting weird errors' );
 	 * @since 2.3.6
 	 */
 	public function test_register_styles_checkout_ssl() {
-$this->markTestIncomplete( 'Getting weird' );
+
 		// Prepare test
 		$_SERVER['HTTPS'] = 'ON'; // Fake SSL
 		$this->go_to( get_permalink( edd_get_option( 'purchase_page' ) ) );

--- a/tests/tests-scripts.php
+++ b/tests/tests-scripts.php
@@ -25,10 +25,9 @@ class Tests_Scripts extends WP_UnitTestCase {
 	 * @since 2.3.6
 	 */
 	public function test_load_scripts_checkout() {
-return;
+$this->markTestIncomplete( 'Getting weird errors' );
 		// Prepare test
-		$this->go_to( edd_get_option( 'purchase_page' ) );
-		$this->go_to( get_permalink( 3 ) );
+		$this->go_to( get_permalink( edd_get_option( 'purchase_page' ) ) );
 		edd_load_scripts();
 
 		$this->assertTrue( wp_script_is( 'creditCardValidator', 'enqueued' ) );
@@ -80,7 +79,7 @@ return;
 	 * @since 2.3.6
 	 */
 	public function test_register_styles_checkout_ssl() {
-
+$this->markTestIncomplete( 'Getting weird' );
 		// Prepare test
 		$_SERVER['HTTPS'] = 'ON'; // Fake SSL
 		$this->go_to( get_permalink( edd_get_option( 'purchase_page' ) ) );

--- a/tests/tests-scripts.php
+++ b/tests/tests-scripts.php
@@ -1,0 +1,169 @@
+<?php
+
+/**
+ * @group scripts
+ */
+class Tests_Scripts extends WP_UnitTestCase {
+
+	/**
+	 * Test if all the file hooks are working.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_file_hooks() {
+
+		$this->assertNotFalse( has_action( 'wp_enqueue_scripts', 'edd_load_scripts' ) );
+		$this->assertNotFalse( has_action( 'wp_enqueue_scripts', 'edd_register_styles' ) );
+		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', 'edd_load_admin_scripts' ) );
+		$this->assertNotFalse( has_action( 'admin_head', 'edd_admin_downloads_icon' ) );
+
+	}
+
+	/**
+	 * Test that all the scripts are loaded at the checkout page.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_load_scripts_checkout() {
+return;
+		// Prepare test
+		$this->go_to( edd_get_option( 'purchase_page' ) );
+		$this->go_to( get_permalink( 3 ) );
+		edd_load_scripts();
+
+		$this->assertTrue( wp_script_is( 'creditCardValidator', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'edd-checkout-global', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'edd-ajax', 'enqueued' ) );
+
+		$this->go_to( '/' );
+
+	}
+
+	/**
+	 * Test that the edd_register_styles() function will bail when the 'disable_styles'
+	 * option is set to true.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_register_styles_bail_option() {
+
+		// Prepare test
+		$origin_disable_styles = edd_get_option( 'disable_styles', false );
+		edd_update_option( 'disable_styles', true );
+
+		// Assert
+		$this->assertNull( edd_register_styles() );
+
+		// Reset to origin
+		edd_update_option( 'disable_styles', $origin_disable_styles );
+
+	}
+
+	/**
+	 * Test that the edd_register_styles() function will enqueue the styles.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_register_styles() {
+
+		edd_update_option( 'disable_styles', false );
+		edd_register_styles();
+
+		$this->assertTrue( wp_style_is( 'edd-styles', 'enqueued' ) );
+
+	}
+
+	/**
+	 * Test that the edd_register_styles() function will enqueue the proper styles
+	 * when page is checkout + ssl.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_register_styles_checkout_ssl() {
+
+		// Prepare test
+		$_SERVER['HTTPS'] = 'ON'; // Fake SSL
+		$this->go_to( get_permalink( edd_get_option( 'purchase_page' ) ) );
+		edd_update_option( 'disable_styles', false );
+		edd_register_styles();
+
+		$this->assertTrue( wp_style_is( 'dashicons', 'enqueued' ) );
+
+		$this->go_to( '/' );
+		unset( $_SERVER['HTTPS'] );
+
+	}
+
+	/**
+	 * Test that the edd_load_admin_scripts() function will bail when not a EDD admin page.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_load_admin_scripts_bail() {
+
+		// Prepare test
+		global $pagenow;
+		$origin_pagenow = $pagenow;
+		$pagenow = 'dashboard';
+
+		if ( ! function_exists( 'edd_is_admin_page' ) ) {
+			include EDD_PLUGIN_DIR . 'includes/admin/admin-pages.php';
+		}
+
+		// Assert
+		$this->assertNull( edd_load_admin_scripts( 'dashboard' ) );
+
+		// Reset to origin
+		$pagenow = $origin_pagenow;
+
+	}
+
+	/**
+	 * Test that the edd_load_admin_scripts() function will enqueue the proper styles.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_load_admin_scripts() {
+
+		if ( ! function_exists( 'edd_is_admin_page' ) ) {
+			include EDD_PLUGIN_DIR . 'includes/admin/admin-pages.php';
+		}
+
+		edd_load_admin_scripts( 'settings.php' );
+
+		$this->assertTrue( wp_style_is( 'jquery-chosen', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'wp-color-picker', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'colorbox', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'jquery-ui-css', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'thickbox', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'edd-admin', 'enqueued' ) );
+
+		$this->assertTrue( wp_script_is( 'jquery-chosen', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'edd-admin-scripts', 'enqueued' ) );
+// 		$this->assertTrue( wp_script_is( 'wp-color-picker', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'colorbox', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jquery-ui-datepicker', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jquery-ui-dialog', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jquery-flot', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'media-upload', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'thickbox', 'enqueued' ) );
+
+	}
+
+	/**
+	 * Test that the edd_admin_downloads_icon() function will display the proper styles.
+	 *
+	 * @since 2.3.6
+	 */
+	public function test_admin_downloads_icon() {
+
+		ob_start();
+			edd_admin_downloads_icon();
+		$return = ob_get_clean();
+
+		$this->assertContains( '#edd-media-button', $return );
+
+	}
+
+
+}

--- a/tests/tests-shortcodes.php
+++ b/tests/tests-shortcodes.php
@@ -204,8 +204,9 @@ class Tests_Shortcode extends WP_UnitTestCase {
 	}
 
 	public function test_purchase_collection_shortcode() {
+		$this->go_to( '/' );
 		$this->assertInternalType( 'string', edd_purchase_collection_shortcode( array() ) );
-		$this->assertEquals( '<a href="?edd_action=purchase_collection&taxonomy&terms" class="button blue edd-submit">Purchase All Items</a>', edd_purchase_collection_shortcode( array() ) );
+		$this->assertEquals( '<a href="/?edd_action=purchase_collection&taxonomy&terms" class="button blue edd-submit">Purchase All Items</a>', edd_purchase_collection_shortcode( array() ) );
 	}
 
 	public function test_downloads_query_with_schema() {


### PR DESCRIPTION
Wow, I've been lacking in doing commits lately!

Gonna try picking it up again :smile: 

This script has two `markTestIncomplete`, as it is generating some errors;
The error only occur when testing the full suite, not when only testing the tests-scripts.php file.

Maybe you got an idea why its happening (happens on the lines with `$this->go_to( get_permalink(..) );`

```
There were 2 errors:

1) Tests_Scripts::test_load_scripts_checkout
Trying to get property of non-object

/private/tmp/wordpress/wp-includes/query.php:4349
/private/tmp/wordpress/wp-includes/query.php:496
/Applications/MAMP/htdocs/edd/wp-content/plugins/Easy-Digital-Downloads/includes/checkout/functions.php:78
/Applications/MAMP/htdocs/edd/wp-content/plugins/Easy-Digital-Downloads/includes/plugin-compatibility.php:134
/private/tmp/wordpress/wp-includes/plugin.php:571
/private/tmp/wordpress/wp-includes/query.php:1817
/private/tmp/wordpress/wp-includes/query.php:2364
/private/tmp/wordpress/wp-includes/query.php:3836
/private/tmp/wordpress/wp-includes/class-wp.php:540
/private/tmp/wordpress/wp-includes/class-wp.php:611
/private/tmp/wordpress-tests-lib/includes/testcase.php:359
/Applications/MAMP/htdocs/edd/wp-content/plugins/Easy-Digital-Downloads/tests/tests-scripts.php:30

2) Tests_Scripts::test_register_styles_checkout_ssl
Trying to get property of non-object

/private/tmp/wordpress/wp-includes/query.php:4349
/private/tmp/wordpress/wp-includes/query.php:496
/Applications/MAMP/htdocs/edd/wp-content/plugins/Easy-Digital-Downloads/includes/checkout/functions.php:78
/Applications/MAMP/htdocs/edd/wp-content/plugins/Easy-Digital-Downloads/includes/plugin-compatibility.php:134
/private/tmp/wordpress/wp-includes/plugin.php:571
/private/tmp/wordpress/wp-includes/query.php:1817
/private/tmp/wordpress/wp-includes/query.php:2364
/private/tmp/wordpress/wp-includes/query.php:3836
/private/tmp/wordpress/wp-includes/class-wp.php:540
/private/tmp/wordpress/wp-includes/class-wp.php:611
/private/tmp/wordpress-tests-lib/includes/testcase.php:359
/Applications/MAMP/htdocs/edd/wp-content/plugins/Easy-Digital-Downloads/tests/tests-scripts.php:85
```