### PR TITLE
Allow ordering of gateways with default first

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -526,7 +526,7 @@ add_action( 'edd_purchase_form_login_fields', 'edd_get_login_fields' );
  * @return void
  */
 function edd_payment_mode_select() {
-	$gateways = edd_get_enabled_payment_gateways();
+	$gateways = edd_get_enabled_payment_gateways( true );
 	$page_URL = edd_get_current_page_url();
 	do_action('edd_payment_mode_top'); ?>
 	<?php if( edd_is_ajax_disabled() ) { ?>
@@ -858,7 +858,7 @@ function edd_filter_success_page_content( $content ) {
 			$content = apply_filters( 'edd_payment_confirm_' . $_GET['payment-confirmation'], $content );
 		}
 	}
-	
+
 	return $content;
 }
 add_filter( 'the_content', 'edd_filter_success_page_content' );

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -39,9 +39,10 @@ function edd_get_payment_gateways() {
  * Returns a list of all enabled gateways.
  *
  * @since 1.0
+ * @param  bool $sort If true, the default gateway will be first
  * @return array $gateway_list All the available gateways
 */
-function edd_get_enabled_payment_gateways() {
+function edd_get_enabled_payment_gateways( $sort = false ) {
 	$gateways = edd_get_payment_gateways();
 	$enabled  = edd_get_option( 'gateways', false );
 
@@ -51,6 +52,15 @@ function edd_get_enabled_payment_gateways() {
 		if ( isset( $enabled[ $key ] ) && $enabled[ $key ] == 1 ) {
 			$gateway_list[ $key ] = $gateway;
 		}
+	}
+
+	if ( true === $sort ) {
+		// Reorder our gateways so the default is first
+		$default_gateway_id = edd_get_default_gateway();
+		$default_gateway    = array( $default_gateway_id => $gateway_list[ $default_gateway_id ] );
+		unset( $gateway_list[ $default_gateway_id ] );
+
+		$gateway_list = array_merge( $default_gateway, $gateway_list );
 	}
 
 	return apply_filters( 'edd_enabled_payment_gateways', $gateway_list );

--- a/tests/tests-gateways.php
+++ b/tests/tests-gateways.php
@@ -27,6 +27,37 @@ class Test_Gateways extends WP_UnitTestCase {
 
 	public function test_enabled_gateways() {
 		$this->assertEmpty( edd_get_enabled_payment_gateways() );
+
+		global $edd_options;
+		$edd_options['gateways']['paypal'] = '1';
+		$edd_options['gateways']['manual'] = '1';
+
+		// Verify PayPal comes back as default/first when none is set
+		$this->assertTrue( empty( $edd_options['default_gateway'] ) );
+
+		$enabled_gateway_list = edd_get_enabled_payment_gateways( true );
+		$first_gateway_id     = current( array_keys( $enabled_gateway_list ) );
+		$this->assertEquals( 'paypal', $first_gateway_id );
+
+		// Test when default is set to paypal
+		$edd_options['default_gateway'] = 'paypal';
+		$enabled_gateway_list = edd_get_enabled_payment_gateways( true );
+		$first_gateway_id     = current( array_keys( $enabled_gateway_list ) );
+		$this->assertEquals( 'paypal', $first_gateway_id );
+
+		// Test default is set to manual and we ask for it sorted
+		$edd_options['default_gateway'] = 'manual';
+		$enabled_gateway_list = edd_get_enabled_payment_gateways( true );
+		$first_gateway_id     = current( array_keys( $enabled_gateway_list ) );
+		$this->assertEquals( 'manual', $first_gateway_id );
+
+		// Test the call does not return it sorted when manual is default
+		$enabled_gateway_list = edd_get_enabled_payment_gateways();
+		$first_gateway_id     = current( array_keys( $enabled_gateway_list ) );
+		$this->assertEquals( 'paypal', $first_gateway_id );
+
+		// Reset these so the rest of the tests don't fail
+		unset( $edd_options['default_gateway'], $edd_options['gateways']['paypal'], $edd_options['gateways']['manual'] );
 	}
 
 	public function test_is_gateway_active() {


### PR DESCRIPTION
Addresses the concern in #3297 by allowing the list of enabled gateways to be returned with the default one first. It also implements it on the checkout template.