### PR TITLE
Allow taxonomy labels to be used elsewhere easily

### DIFF
--- a/includes/admin/downloads/dashboard-columns.php
+++ b/includes/admin/downloads/dashboard-columns.php
@@ -23,11 +23,14 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  *  Post Type List Table
  */
 function edd_download_columns( $download_columns ) {
+	$category_labels   = edd_get_taxonomy_labels( 'download_category' );
+	$tag_labels        = edd_get_taxonomy_labels( 'download_tag' );
+
 	$download_columns = array(
 		'cb'                => '<input type="checkbox"/>',
 		'title'             => __( 'Name', 'edd' ),
-		'download_category' => __( 'Categories', 'edd' ),
-		'download_tag'      => __( 'Tags', 'edd' ),
+		'download_category' => $category_labels['name'],
+		'download_tag'      => $tag_labels['name'],
 		'price'             => __( 'Price', 'edd' ),
 		'sales'             => __( 'Sales', 'edd' ),
 		'earnings'          => __( 'Earnings', 'edd' ),
@@ -220,7 +223,8 @@ function edd_add_download_filters() {
 		$terms = get_terms( 'download_category' );
 		if ( count( $terms ) > 0 ) {
 			echo "<select name='download_category' id='download_category' class='postform'>";
-				echo "<option value=''>" . __( 'Show all categories', 'edd' ) . "</option>";
+				$category_labels = edd_get_taxonomy_labels( 'download_category' );
+				echo "<option value=''>" . sprintf( __( 'Show all %s', 'edd' ), strtolower( $category_labels['name'] ) ) . "</option>";
 				foreach ( $terms as $term ) {
 					$selected = isset( $_GET['download_category'] ) && $_GET['download_category'] == $term->slug ? ' selected="selected"' : '';
 					echo '<option value="' . esc_attr( $term->slug ) . '"' . $selected . '>' . esc_html( $term->name ) .' (' . $term->count .')</option>';
@@ -231,7 +235,8 @@ function edd_add_download_filters() {
 		$terms = get_terms( 'download_tag' );
 		if ( count( $terms ) > 0) {
 			echo "<select name='download_tag' id='download_tag' class='postform'>";
-				echo "<option value=''>" . __( 'Show all tags', 'edd' ) . "</option>";
+				$tag_labels = edd_get_taxonomy_labels( 'download_tag' );
+				echo "<option value=''>" . sprintf( __( 'Show all %s', 'edd' ), strtolower( $tag_labels['name'] ) ) . "</option>";
 				foreach ( $terms as $term ) {
 					$selected = isset( $_GET['download_tag']) && $_GET['download_tag'] == $term->slug ? ' selected="selected"' : '';
 					echo '<option value="' . esc_attr( $term->slug ) . '"' . $selected . '>' . esc_html( $term->name ) .' (' . $term->count .')</option>';

--- a/includes/admin/reporting/pdf-reports.php
+++ b/includes/admin/reporting/pdf-reports.php
@@ -67,7 +67,8 @@ function edd_generate_pdf( $data ) {
 	$pdf->SetFillColor( 238, 238, 238 );
 	$pdf->Cell( 70, 6, utf8_decode( __( 'Product Name', 'edd' ) ), 1, 0, 'L', true );
 	$pdf->Cell( 30, 6, utf8_decode( __( 'Price', 'edd' ) ), 1, 0, 'L', true );
-	$pdf->Cell( 50, 6, utf8_decode( __( 'Categories', 'edd' ) ), 1, 0, 'L', true );
+	$category_labels = edd_get_taxonomy_labels( 'download_category' );
+	$pdf->Cell( 50, 6, utf8_decode( $category_labels['name'] ), 1, 0, 'L', true );
 	$pdf->Cell( 50, 6, utf8_decode( __( 'Tags', 'edd' ) ), 1, 0, 'L', true );
 	$pdf->Cell( 45, 6, utf8_decode( __( 'Number of Sales', 'edd' ) ), 1, 0, 'L', true );
 	$pdf->Cell( 35, 6, utf8_decode( __( 'Earnings to Date', 'edd' ) ), 1, 1, 'L', true );

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -231,11 +231,12 @@ class EDD_HTML_Elements {
 			$options[ absint( $category->term_id ) ] = esc_html( $category->name );
 		}
 
+		$category_labels = edd_get_taxonomy_labels( 'download_category' );
 		$output = $this->select( array(
 			'name'             => $name,
 			'selected'         => $selected,
 			'options'          => $options,
-			'show_option_all'  => __( 'All Categories', 'edd' ),
+			'show_option_all'  => sprintf( _x( 'All %s', 'plural: Example: "All Categories"', 'edd' ), $category_labels['name'] ),
 			'show_option_none' => false
 		) );
 

--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -25,19 +25,19 @@ function edd_setup_edd_post_types() {
 	$rewrite  = defined( 'EDD_DISABLE_REWRITE' ) && EDD_DISABLE_REWRITE ? false : array('slug' => $slug, 'with_front' => false);
 
 	$download_labels =  apply_filters( 'edd_download_labels', array(
-		'name' 				=> _x( '%2$s', 'download post type name', 'edd' ),
-		'singular_name' 	=> _x( '%1$s', 'singular download post type name', 'edd' ),
-		'add_new' 			=> __( 'Add New', 'edd' ),
-		'add_new_item' 		=> __( 'Add New %1$s', 'edd' ),
-		'edit_item' 		=> __( 'Edit %1$s', 'edd' ),
-		'new_item' 			=> __( 'New %1$s', 'edd' ),
-		'all_items' 		=> __( 'All %2$s', 'edd' ),
-		'view_item' 		=> __( 'View %1$s', 'edd' ),
-		'search_items' 		=> __( 'Search %2$s', 'edd' ),
-		'not_found' 		=> __( 'No %2$s found', 'edd' ),
-		'not_found_in_trash'=> __( 'No %2$s found in Trash', 'edd' ),
-		'parent_item_colon' => '',
-		'menu_name' 		=> _x( '%2$s', 'download post type menu name', 'edd' )
+		'name'               => _x( '%2$s', 'download post type name', 'edd' ),
+		'singular_name'      => _x( '%1$s', 'singular download post type name', 'edd' ),
+		'add_new'            => __( 'Add New', 'edd' ),
+		'add_new_item'       => __( 'Add New %1$s', 'edd' ),
+		'edit_item'          => __( 'Edit %1$s', 'edd' ),
+		'new_item'           => __( 'New %1$s', 'edd' ),
+		'all_items'          => __( 'All %2$s', 'edd' ),
+		'view_item'          => __( 'View %1$s', 'edd' ),
+		'search_items'       => __( 'Search %2$s', 'edd' ),
+		'not_found'          => __( 'No %2$s found', 'edd' ),
+		'not_found_in_trash' => __( 'No %2$s found in Trash', 'edd' ),
+		'parent_item_colon'  => '',
+		'menu_name'          => _x( '%2$s', 'download post type menu name', 'edd' )
 	) );
 
 	foreach ( $download_labels as $key => $value ) {
@@ -45,79 +45,79 @@ function edd_setup_edd_post_types() {
 	}
 
 	$download_args = array(
-		'labels' 			=> $download_labels,
-		'public' 			=> true,
-		'publicly_queryable'=> true,
-		'show_ui' 			=> true,
-		'show_in_menu' 		=> true,
-		'query_var' 		=> true,
-		'rewrite' 			=> $rewrite,
-		'capability_type' 	=> 'product',
-		'map_meta_cap'      => true,
-		'has_archive' 		=> $archives,
-		'hierarchical' 		=> false,
-		'supports' 			=> apply_filters( 'edd_download_supports', array( 'title', 'editor', 'thumbnail', 'excerpt', 'revisions', 'author' ) ),
+		'labels'             => $download_labels,
+		'public'             => true,
+		'publicly_queryable' => true,
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'query_var'          => true,
+		'rewrite'            => $rewrite,
+		'capability_type'    => 'product',
+		'map_meta_cap'       => true,
+		'has_archive'        => $archives,
+		'hierarchical'       => false,
+		'supports'           => apply_filters( 'edd_download_supports', array( 'title', 'editor', 'thumbnail', 'excerpt', 'revisions', 'author' ) ),
 	);
 	register_post_type( 'download', apply_filters( 'edd_download_post_type_args', $download_args ) );
 
 
 	/** Payment Post Type */
 	$payment_labels = array(
-		'name' 				=> _x( 'Payments', 'post type general name', 'edd' ),
-		'singular_name' 	=> _x( 'Payment', 'post type singular name', 'edd' ),
-		'add_new' 			=> __( 'Add New', 'edd' ),
-		'add_new_item' 		=> __( 'Add New Payment', 'edd' ),
-		'edit_item' 		=> __( 'Edit Payment', 'edd' ),
-		'new_item' 			=> __( 'New Payment', 'edd' ),
-		'all_items' 		=> __( 'All Payments', 'edd' ),
-		'view_item' 		=> __( 'View Payment', 'edd' ),
-		'search_items' 		=> __( 'Search Payments', 'edd' ),
-		'not_found' 		=> __( 'No Payments found', 'edd' ),
-		'not_found_in_trash'=> __( 'No Payments found in Trash', 'edd' ),
-		'parent_item_colon' => '',
-		'menu_name' 		=> __( 'Payment History', 'edd' )
+		'name'               => _x( 'Payments', 'post type general name', 'edd' ),
+		'singular_name'      => _x( 'Payment', 'post type singular name', 'edd' ),
+		'add_new'            => __( 'Add New', 'edd' ),
+		'add_new_item'       => __( 'Add New Payment', 'edd' ),
+		'edit_item'          => __( 'Edit Payment', 'edd' ),
+		'new_item'           => __( 'New Payment', 'edd' ),
+		'all_items'          => __( 'All Payments', 'edd' ),
+		'view_item'          => __( 'View Payment', 'edd' ),
+		'search_items'       => __( 'Search Payments', 'edd' ),
+		'not_found'          => __( 'No Payments found', 'edd' ),
+		'not_found_in_trash' => __( 'No Payments found in Trash', 'edd' ),
+		'parent_item_colon'  => '',
+		'menu_name'          => __( 'Payment History', 'edd' )
 	);
 
 	$payment_args = array(
-		'labels' 			=> apply_filters( 'edd_payment_labels', $payment_labels ),
-		'public' 			=> false,
-		'query_var' 		=> false,
-		'rewrite' 			=> false,
-		'capability_type' 	=> 'shop_payment',
-		'map_meta_cap'      => true,
-		'supports' 			=> array( 'title' ),
-		'can_export'		=> true
+		'labels'          => apply_filters( 'edd_payment_labels', $payment_labels ),
+		'public'          => false,
+		'query_var'       => false,
+		'rewrite'         => false,
+		'capability_type' => 'shop_payment',
+		'map_meta_cap'    => true,
+		'supports'        => array( 'title' ),
+		'can_export'      => true
 	);
 	register_post_type( 'edd_payment', $payment_args );
 
 
 	/** Discounts Post Type */
 	$discount_labels = array(
-		'name' 				=> _x( 'Discounts', 'post type general name', 'edd' ),
-		'singular_name' 	=> _x( 'Discount', 'post type singular name', 'edd' ),
-		'add_new' 			=> __( 'Add New', 'edd' ),
-		'add_new_item' 		=> __( 'Add New Discount', 'edd' ),
-		'edit_item' 		=> __( 'Edit Discount', 'edd' ),
-		'new_item' 			=> __( 'New Discount', 'edd' ),
-		'all_items' 		=> __( 'All Discounts', 'edd' ),
-		'view_item' 		=> __( 'View Discount', 'edd' ),
-		'search_items' 		=> __( 'Search Discounts', 'edd' ),
-		'not_found' 		=> __( 'No Discounts found', 'edd' ),
-		'not_found_in_trash'=> __( 'No Discounts found in Trash', 'edd' ),
-		'parent_item_colon' => '',
-		'menu_name' 		=> __( 'Discounts', 'edd' )
+		'name'               => _x( 'Discounts', 'post type general name', 'edd' ),
+		'singular_name'      => _x( 'Discount', 'post type singular name', 'edd' ),
+		'add_new'            => __( 'Add New', 'edd' ),
+		'add_new_item'       => __( 'Add New Discount', 'edd' ),
+		'edit_item'          => __( 'Edit Discount', 'edd' ),
+		'new_item'           => __( 'New Discount', 'edd' ),
+		'all_items'          => __( 'All Discounts', 'edd' ),
+		'view_item'          => __( 'View Discount', 'edd' ),
+		'search_items'       => __( 'Search Discounts', 'edd' ),
+		'not_found'          => __( 'No Discounts found', 'edd' ),
+		'not_found_in_trash' => __( 'No Discounts found in Trash', 'edd' ),
+		'parent_item_colon'  => '',
+		'menu_name'          => __( 'Discounts', 'edd' )
 	);
 
 	$discount_args = array(
-		'labels' 			=> apply_filters( 'edd_discount_labels', $discount_labels ),
-		'public' 			=> false,
-		'query_var' 		=> false,
-		'rewrite' 			=> false,
-		'show_ui'           => false,
-		'capability_type' 	=> 'shop_discount',
-		'map_meta_cap'      => true,
-		'supports' 			=> array( 'title' ),
-		'can_export'		=> true
+		'labels'          => apply_filters( 'edd_discount_labels', $discount_labels ),
+		'public'          => false,
+		'query_var'       => false,
+		'rewrite'         => false,
+		'show_ui'         => false,
+		'capability_type' => 'shop_discount',
+		'map_meta_cap'    => true,
+		'supports'        => array( 'title' ),
+		'can_export'      => true
 	);
 	register_post_type( 'edd_discount', $discount_args );
 }
@@ -169,21 +169,21 @@ function edd_get_label_plural( $lowercase = false ) {
  * @return string $title New placeholder text
  */
 function edd_change_default_title( $title ) {
-     // If a frontend plugin uses this filter (check extensions before changing this function)
-     if ( !is_admin() ) {
-     	$label = edd_get_label_singular();
-        $title = sprintf( __( 'Enter %s name here', 'edd' ), $label );
-     	return $title;
-     }
-     
-     $screen = get_current_screen();
+	 // If a frontend plugin uses this filter (check extensions before changing this function)
+	 if ( !is_admin() ) {
+		$label = edd_get_label_singular();
+		$title = sprintf( __( 'Enter %s name here', 'edd' ), $label );
+		return $title;
+	 }
 
-     if ( 'download' == $screen->post_type ) {
-     	$label = edd_get_label_singular();
-        $title = sprintf( __( 'Enter %s name here', 'edd' ), $label );
-     }
+	 $screen = get_current_screen();
 
-     return $title;
+	 if ( 'download' == $screen->post_type ) {
+		$label = edd_get_label_singular();
+		$title = sprintf( __( 'Enter %s name here', 'edd' ), $label );
+	 }
+
+	 return $title;
 }
 add_filter( 'enter_title_here', 'edd_change_default_title' );
 
@@ -199,26 +199,26 @@ function edd_setup_download_taxonomies() {
 
 	/** Categories */
 	$category_labels = array(
-		'name' 				=> sprintf( _x( '%s Categories', 'taxonomy general name', 'edd' ), edd_get_label_singular() ),
-		'singular_name' 	=> _x( 'Category', 'taxonomy singular name', 'edd' ),
-		'search_items' 		=> __( 'Search Categories', 'edd'  ),
-		'all_items' 		=> __( 'All Categories', 'edd'  ),
-		'parent_item' 		=> __( 'Parent Category', 'edd'  ),
+		'name'              => _x( 'Categories', 'taxonomy general name', 'edd' ),
+		'singular_name'     => _x( 'Category', 'taxonomy singular name', 'edd' ),
+		'search_items'      => __( 'Search Categories', 'edd'  ),
+		'all_items'         => __( 'All Categories', 'edd'  ),
+		'parent_item'       => __( 'Parent Category', 'edd'  ),
 		'parent_item_colon' => __( 'Parent Category:', 'edd'  ),
-		'edit_item' 		=> __( 'Edit Category', 'edd'  ),
-		'update_item' 		=> __( 'Update Category', 'edd'  ),
-		'add_new_item' 		=> sprintf( __( 'Add New %s Category', 'edd'  ), edd_get_label_singular() ),
-		'new_item_name' 	=> __( 'New Category Name', 'edd'  ),
-		'menu_name' 		=> __( 'Categories', 'edd'  ),
+		'edit_item'         => __( 'Edit Category', 'edd'  ),
+		'update_item'       => __( 'Update Category', 'edd'  ),
+		'add_new_item'      => sprintf( __( 'Add New %s Category', 'edd'  ), edd_get_label_singular() ),
+		'new_item_name'     => __( 'New Category Name', 'edd'  ),
+		'menu_name'         => __( 'Categories', 'edd'  ),
 	);
 
 	$category_args = apply_filters( 'edd_download_category_args', array(
-			'hierarchical' 	=> true,
-			'labels' 		=> apply_filters('edd_download_category_labels', $category_labels),
-			'show_ui' 		=> true,
-			'query_var' 	=> 'download_category',
-			'rewrite' 		=> array('slug' => $slug . '/category', 'with_front' => false, 'hierarchical' => true ),
-			'capabilities'  => array( 'manage_terms' => 'manage_product_terms','edit_terms' => 'edit_product_terms','assign_terms' => 'assign_product_terms','delete_terms' => 'delete_product_terms' )
+			'hierarchical' => true,
+			'labels'       => apply_filters('edd_download_category_labels', $category_labels),
+			'show_ui'      => true,
+			'query_var'    => 'download_category',
+			'rewrite'      => array('slug' => $slug . '/category', 'with_front' => false, 'hierarchical' => true ),
+			'capabilities' => array( 'manage_terms' => 'manage_product_terms','edit_terms' => 'edit_product_terms','assign_terms' => 'assign_product_terms','delete_terms' => 'delete_product_terms' )
 		)
 	);
 	register_taxonomy( 'download_category', array('download'), $category_args );
@@ -226,34 +226,65 @@ function edd_setup_download_taxonomies() {
 
 	/** Tags */
 	$tag_labels = array(
-		'name' 				=> sprintf( _x( '%s Tags', 'taxonomy general name', 'edd' ), edd_get_label_singular() ),
-		'singular_name' 	=> _x( 'Tag', 'taxonomy singular name', 'edd' ),
-		'search_items' 		=> __( 'Search Tags', 'edd'  ),
-		'all_items' 		=> __( 'All Tags', 'edd'  ),
-		'parent_item' 		=> __( 'Parent Tag', 'edd'  ),
-		'parent_item_colon' => __( 'Parent Tag:', 'edd'  ),
-		'edit_item' 		=> __( 'Edit Tag', 'edd'  ),
-		'update_item' 		=> __( 'Update Tag', 'edd'  ),
-		'add_new_item' 		=> __( 'Add New Tag', 'edd'  ),
-		'new_item_name' 	=> __( 'New Tag Name', 'edd'  ),
-		'menu_name' 		=> __( 'Tags', 'edd'  ),
+		'name'                  => _x( 'Tags', 'taxonomy general name', 'edd' ),
+		'singular_name'         => _x( 'Tag', 'taxonomy singular name', 'edd' ),
+		'search_items'          => __( 'Search Tags', 'edd'  ),
+		'all_items'             => __( 'All Tags', 'edd'  ),
+		'parent_item'           => __( 'Parent Tag', 'edd'  ),
+		'parent_item_colon'     => __( 'Parent Tag:', 'edd'  ),
+		'edit_item'             => __( 'Edit Tag', 'edd'  ),
+		'update_item'           => __( 'Update Tag', 'edd'  ),
+		'add_new_item'          => __( 'Add New Tag', 'edd'  ),
+		'new_item_name'         => __( 'New Tag Name', 'edd'  ),
+		'menu_name'             => __( 'Tags', 'edd'  ),
 		'choose_from_most_used' => sprintf( __( 'Choose from most used %s tags', 'edd'  ), edd_get_label_singular() ),
 	);
 
 	$tag_args = apply_filters( 'edd_download_tag_args', array(
-			'hierarchical' 	=> false,
-			'labels' 		=> apply_filters( 'edd_download_tag_labels', $tag_labels ),
-			'show_ui' 		=> true,
-			'query_var' 	=> 'download_tag',
-			'rewrite' 		=> array( 'slug' => $slug . '/tag', 'with_front' => false, 'hierarchical' => true  ),
-			'capabilities'  => array( 'manage_terms' => 'manage_product_terms','edit_terms' => 'edit_product_terms','assign_terms' => 'assign_product_terms','delete_terms' => 'delete_product_terms' )
-
+			'hierarchical' => false,
+			'labels'       => apply_filters( 'edd_download_tag_labels', $tag_labels ),
+			'show_ui'      => true,
+			'query_var'    => 'download_tag',
+			'rewrite'      => array( 'slug' => $slug . '/tag', 'with_front' => false, 'hierarchical' => true  ),
+			'capabilities' => array( 'manage_terms' => 'manage_product_terms','edit_terms' => 'edit_product_terms','assign_terms' => 'assign_product_terms','delete_terms' => 'delete_product_terms' )
 		)
 	);
 	register_taxonomy( 'download_tag', array( 'download' ), $tag_args );
 	register_taxonomy_for_object_type( 'download_tag', 'download' );
 }
 add_action( 'init', 'edd_setup_download_taxonomies', 0 );
+
+/**
+ * Get the singular and plural labels for a download taxonomy
+ *
+ * @since  2.4
+ * @param  string $taxonomy The Taxonomy to get labels for
+ * @return array            Associative array of labels (name = plural)
+ */
+function edd_get_taxonomy_labels( $taxonomy = 'download_category' ) {
+
+	$allowed_taxonomies = apply_filters( 'edd_allowed_download_taxonomies', array( 'download_category', 'download_tag' ) );
+
+	if ( ! in_array( $taxonomy, $allowed_taxonomies ) ) {
+		return false;
+	}
+
+	$labels   = array();
+	$taxonomy = get_taxonomy( $taxonomy );
+
+	if ( false !== $taxonomy ) {
+		$singular = $taxonomy->labels->singular_name;
+		$name     = $taxonomy->labels->name;
+
+		$labels = array(
+			'name'          => $name,
+			'singular_name' => $singular,
+		);
+	}
+
+	return apply_filters( 'edd_get_taxonomy_labels', $labels, $taxonomy );
+
+}
 
 /**
  * Registers Custom Post Statuses which are used by the Payments and Discount

--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -124,7 +124,7 @@ class edd_categories_tags_widget extends WP_Widget {
 		$hide_empty = isset( $instance['hide_empty'] ) && $instance['hide_empty'] == 'on' ? 1 : 0;
 
 		echo $args['before_widget'];
-		
+
 		if ( $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
@@ -136,7 +136,7 @@ class edd_categories_tags_widget extends WP_Widget {
 		echo "</ul>\n";
 
 		do_action( 'edd_after_taxonomy_widget' );
-		
+
 		echo $args['after_widget'];
 	}
 
@@ -168,8 +168,12 @@ class edd_categories_tags_widget extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'taxonomy' ) ); ?>"><?php _e( 'Taxonomy:', 'edd' ); ?></label>
 			<select name="<?php echo esc_attr( $this->get_field_name( 'taxonomy' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'taxonomy' ) ); ?>">
-				<option value="download_category" <?php selected( 'download_category', $instance['taxonomy'] ); ?>><?php _e( 'Categories', 'edd' ); ?></option>
-				<option value="download_tag" <?php selected( 'download_tag', $instance['taxonomy'] ); ?>><?php _e( 'Tags', 'edd' ); ?></option>
+				<?php
+				$category_labels = edd_get_taxonomy_labels( 'download_category' );
+				$tag_labels      = edd_get_taxonomy_labels( 'download_tag' );
+				?>
+				<option value="download_category" <?php selected( 'download_category', $instance['taxonomy'] ); ?>><?php echo $category_labels['name']; ?></option>
+				<option value="download_tag" <?php selected( 'download_tag', $instance['taxonomy'] ); ?>><?php echo $tag_labels['name']; ?></option>
 			</select>
 		</p>
 		<p>
@@ -187,7 +191,7 @@ class edd_categories_tags_widget extends WP_Widget {
 
 /**
  * Product Details Widget
- * 
+ *
  * Displays a product's details in a widget
  *
  * @since 1.9
@@ -195,165 +199,177 @@ class edd_categories_tags_widget extends WP_Widget {
  */
 class EDD_Product_Details_Widget extends WP_Widget {
 
-    /** Constructor */
+	/** Constructor */
 	public function __construct() {
 		parent::__construct(
 			'edd_product_details',
 			sprintf( __( '%s Details', 'edd' ), edd_get_label_singular() ),
-			array( 
+			array(
 				'description' => sprintf( __( 'Display the details of a specific %s', 'edd' ), edd_get_label_singular() ),
 			)
 		);
 	}
 
-    /** @see WP_Widget::widget */
-    public function widget( $args, $instance ) {
+	/** @see WP_Widget::widget */
+	public function widget( $args, $instance ) {
 		$args['id'] = ( isset( $args['id'] ) ) ? $args['id'] : 'edd_download_details_widget';
 
-        if ( ! isset( $instance['download_id'] ) || ( 'current' == $instance['download_id'] && ! is_singular( 'download' ) ) ) {
-        	return;
-        }
-
-       	// set correct download ID
-        if ( 'current' == $instance['download_id'] && is_singular( 'download' ) ) {
-        	$download_id = get_the_ID();
-        } else {
-        	$download_id = absint( $instance['download_id'] );
-        }
-
-        // Variables from widget settings
-		$title              = apply_filters( 'widget_title', $instance['title'], $instance, $args['id'] );
-      	$download_title 	= $instance['download_title'] ? apply_filters( 'edd_product_details_widget_download_title', '<h3>' . get_the_title( $download_id ) . '</h3>', $download_id ) : '';
-       	$purchase_button 	= $instance['purchase_button'] ? apply_filters( 'edd_product_details_widget_purchase_button', edd_get_purchase_link( array( 'download_id' => $download_id ) ), $download_id ) : '';
-    	$categories 		= $instance['categories'] ? $instance['categories'] : '';
-    	$tags 				= $instance['tags'] ? $instance['tags'] : '';
-	
-        // Used by themes. Opens the widget
-        echo $args['before_widget'];
-
-        // Display the widget title
-        if( $title ) {
-            echo $args['before_title'] . $title . $args['after_title'];
+		if ( ! isset( $instance['download_id'] ) || ( 'current' == $instance['download_id'] && ! is_singular( 'download' ) ) ) {
+			return;
 		}
 
-        do_action( 'edd_product_details_widget_before_title' , $instance , $download_id );
+		// set correct download ID
+		if ( 'current' == $instance['download_id'] && is_singular( 'download' ) ) {
+			$download_id = get_the_ID();
+		} else {
+			$download_id = absint( $instance['download_id'] );
+		}
 
-     	// download title
-        echo $download_title;
+		// Variables from widget settings
+		$title              = apply_filters( 'widget_title', $instance['title'], $instance, $args['id'] );
+		$download_title 	= $instance['download_title'] ? apply_filters( 'edd_product_details_widget_download_title', '<h3>' . get_the_title( $download_id ) . '</h3>', $download_id ) : '';
+		$purchase_button 	= $instance['purchase_button'] ? apply_filters( 'edd_product_details_widget_purchase_button', edd_get_purchase_link( array( 'download_id' => $download_id ) ), $download_id ) : '';
+		$categories 		= $instance['categories'] ? $instance['categories'] : '';
+		$tags 				= $instance['tags'] ? $instance['tags'] : '';
 
-        do_action( 'edd_product_details_widget_before_purchase_button' , $instance , $download_id );
-        // purchase button
-        echo $purchase_button;
+		// Used by themes. Opens the widget
+		echo $args['before_widget'];
 
-      	// categories and tags
-    	$category_list = $categories ? get_the_term_list( $download_id, 'download_category', '', ', ' ) : '';
-    	$tag_list = $tags ? get_the_term_list( $download_id, 'download_tag', '', ', ' ) : '';
+		// Display the widget title
+		if( $title ) {
+			echo $args['before_title'] . $title . $args['after_title'];
+		}
 
-        $text = '';
+		do_action( 'edd_product_details_widget_before_title' , $instance , $download_id );
 
-        if( $category_list || $tag_list ) {
-        	$text .= '<p class="edd-meta">';
+		// download title
+		echo $download_title;
 
-        	if( $category_list )
-	        	$text .= '<span class="categories">' . __( 'Categories: %1$s', 'edd' ). '</span><br/>';
+		do_action( 'edd_product_details_widget_before_purchase_button' , $instance , $download_id );
+		// purchase button
+		echo $purchase_button;
 
-	        if ( $tag_list )
-	            $text .= '<span class="tags">' . __( 'Tags: %2$s', 'edd' ) . '</span>';
+		// categories and tags
+		$category_list     = $categories ? get_the_term_list( $download_id, 'download_category', '', ', ' ) : '';
+		$category_count    = count( get_the_terms( $download_id, 'download_category' ) );
+		$category_labels   = edd_get_taxonomy_labels( 'download_category' );
+		$category_label    = $category_count > 1 ? $category_labels['name'] : $category_labels['singular_name'];
 
-        	$text .= '</p>';
-        }
-        
-        do_action( 'edd_product_details_widget_before_categories_and_tags', $instance, $download_id );
+		$tag_list     = $tags ? get_the_term_list( $download_id, 'download_tag', '', ', ' ) : '';
+		$tag_count    = count( get_the_terms( $download_id, 'download_tag' ) );
+		$tag_taxonomy = edd_get_taxonomy_labels( 'download_tag' );
+		$tag_label    = $tag_count > 1 ? $tag_taxonomy['name'] : $tag_taxonomy['singular_name'];
 
-        printf( $text, $category_list, $tag_list );
-        
-        do_action( 'edd_product_details_widget_before_end', $instance, $download_id );
+		$text = '';
 
-        // Used by themes. Closes the widget
-        echo $args['after_widget'];
-    }
+		if( $category_list || $tag_list ) {
+			$text .= '<p class="edd-meta">';
 
-   	/** @see WP_Widget::form */
-    public function form( $instance ) {
-        // Set up some default widget settings.
-        $defaults = array(
-            'title' 			=> sprintf( __( '%s Details', 'edd' ), edd_get_label_singular() ),
-            'download_id' 		=> 'current',
-            'download_title' 	=> 'on',
-            'purchase_button' 	=> 'on',
-            'categories' 		=> 'on',
-            'tags' 				=> 'on'
-        );
+			if( $category_list ) {
 
-        $instance = wp_parse_args( (array) $instance, $defaults ); ?>
-        
-        <!-- Title -->
-        <p>
-            <label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php _e( 'Title:', 'edd' ) ?></label>
-            <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo $instance['title']; ?>" />
-        </p>
+				$text .= '<span class="categories">%1$s: %2$s</span><br/>';
+			}
+
+			if ( $tag_list ) {
+				$text .= '<span class="tags">%3$s: %4$s</span>';
+			}
+
+			$text .= '</p>';
+		}
+
+		do_action( 'edd_product_details_widget_before_categories_and_tags', $instance, $download_id );
+
+		printf( $text, $category_label, $category_list, $tag_label, $tag_list );
+
+		do_action( 'edd_product_details_widget_before_end', $instance, $download_id );
+
+		// Used by themes. Closes the widget
+		echo $args['after_widget'];
+	}
+
+	/** @see WP_Widget::form */
+	public function form( $instance ) {
+		// Set up some default widget settings.
+		$defaults = array(
+			'title' 			=> sprintf( __( '%s Details', 'edd' ), edd_get_label_singular() ),
+			'download_id' 		=> 'current',
+			'download_title' 	=> 'on',
+			'purchase_button' 	=> 'on',
+			'categories' 		=> 'on',
+			'tags' 				=> 'on'
+		);
+
+		$instance = wp_parse_args( (array) $instance, $defaults ); ?>
+
+		<!-- Title -->
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php _e( 'Title:', 'edd' ) ?></label>
+			<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo $instance['title']; ?>" />
+		</p>
 
 			<!-- Download -->
-         <?php 
-            $args = array( 
-	            'post_type'      => 'download', 
-	            'posts_per_page' => -1, 
-	            'post_status'    => 'publish', 
-	        );
-	        $downloads = get_posts( $args );
-        ?>
-        <p>
-            <label for="<?php echo esc_attr( $this->get_field_id( 'download_id' ) ); ?>"><?php printf( __( '%s', 'edd' ), edd_get_label_singular() ); ?></label>
-            <select class="widefat" name="<?php echo esc_attr( $this->get_field_name( 'download_id' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'download_id' ) ); ?>">
-            	<option value="current"><?php _e( 'Use current', 'edd' ); ?></option>
-            <?php foreach ( $downloads as $download ) { ?>
-                <option <?php selected( absint( $instance['download_id'] ), $download->ID ); ?> value="<?php echo esc_attr( $download->ID ); ?>"><?php echo $download->post_title; ?></option>
-            <?php } ?>
-            </select>
-        </p>
+		 <?php
+			$args = array(
+				'post_type'      => 'download',
+				'posts_per_page' => -1,
+				'post_status'    => 'publish',
+			);
+			$downloads = get_posts( $args );
+		?>
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'download_id' ) ); ?>"><?php printf( __( '%s', 'edd' ), edd_get_label_singular() ); ?></label>
+			<select class="widefat" name="<?php echo esc_attr( $this->get_field_name( 'download_id' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'download_id' ) ); ?>">
+				<option value="current"><?php _e( 'Use current', 'edd' ); ?></option>
+			<?php foreach ( $downloads as $download ) { ?>
+				<option <?php selected( absint( $instance['download_id'] ), $download->ID ); ?> value="<?php echo esc_attr( $download->ID ); ?>"><?php echo $download->post_title; ?></option>
+			<?php } ?>
+			</select>
+		</p>
 
-        <!-- Download title -->
-        <p>
-            <input <?php checked( $instance['download_title'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'download_title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'download_title' ) ); ?>" type="checkbox" />
-            <label for="<?php echo esc_attr( $this->get_field_id( 'download_title' ) ); ?>"><?php _e( 'Show Title', 'edd' ); ?></label>
-        </p>
+		<!-- Download title -->
+		<p>
+			<input <?php checked( $instance['download_title'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'download_title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'download_title' ) ); ?>" type="checkbox" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'download_title' ) ); ?>"><?php _e( 'Show Title', 'edd' ); ?></label>
+		</p>
 
-        <!-- Show purchase button -->
-        <p>
-            <input <?php checked( $instance['purchase_button'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'purchase_button' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'purchase_button' ) ); ?>" type="checkbox" />
-            <label for="<?php echo esc_attr( $this->get_field_id( 'purchase_button' ) ); ?>"><?php _e( 'Show Purchase Button', 'edd' ); ?></label>
-        </p>
+		<!-- Show purchase button -->
+		<p>
+			<input <?php checked( $instance['purchase_button'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'purchase_button' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'purchase_button' ) ); ?>" type="checkbox" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'purchase_button' ) ); ?>"><?php _e( 'Show Purchase Button', 'edd' ); ?></label>
+		</p>
 
-        <!-- Show download categories -->
-        <p>
-            <input <?php checked( $instance['categories'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'categories' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'categories' ) ); ?>" type="checkbox" />
-            <label for="<?php echo esc_attr( $this->get_field_id( 'categories' ) ); ?>"><?php _e( 'Show Categories', 'edd' ); ?></label>
-        </p>
+		<!-- Show download categories -->
+		<p>
+			<?php $category_labels = edd_get_taxonomy_labels( 'download_category' ); ?>
+			<input <?php checked( $instance['categories'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'categories' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'categories' ) ); ?>" type="checkbox" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'categories' ) ); ?>"><?php printf( __( 'Show %s', 'edd' ), $category_labels['name'] ); ?></label>
+		</p>
 
-        <!-- Show download tags -->
-        <p>
-            <input <?php checked( $instance['tags'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'tags' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'tags' ) ); ?>" type="checkbox" />
-            <label for="<?php echo esc_attr( $this->get_field_id( 'tags' ) ); ?>"><?php _e( 'Show Tags', 'edd' ); ?></label>
-        </p>
-        
-        <?php do_action( 'edd_product_details_widget_form' , $instance ); ?>
-    <?php }
+		<!-- Show download tags -->
+		<p>
+			<?php $tag_labels = edd_get_taxonomy_labels( 'download_tag' ); ?>
+			<input <?php checked( $instance['tags'], 'on' ); ?> id="<?php echo esc_attr( $this->get_field_id( 'tags' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'tags' ) ); ?>" type="checkbox" />
+			<label for="<?php echo esc_attr( $this->get_field_id( 'tags' ) ); ?>"><?php printf( __( 'Show %s', 'edd' ), $tag_labels['name'] ); ?></label>
+		</p>
 
-    /** @see WP_Widget::update */
-    public function update( $new_instance, $old_instance ) {
-        $instance = $old_instance;
+		<?php do_action( 'edd_product_details_widget_form' , $instance ); ?>
+	<?php }
 
-        $instance['title']           = strip_tags( $new_instance['title'] );
-        $instance['download_id']     = strip_tags( $new_instance['download_id'] );
-        $instance['download_title']  = isset( $new_instance['download_title'] )  ? $new_instance['download_title']  : '';
-        $instance['purchase_button'] = isset( $new_instance['purchase_button'] ) ? $new_instance['purchase_button'] : '';
-        $instance['categories']      = isset( $new_instance['categories'] )      ? $new_instance['categories']      : '';
-        $instance['tags']            = isset( $new_instance['tags'] )            ? $new_instance['tags']            : '';
+	/** @see WP_Widget::update */
+	public function update( $new_instance, $old_instance ) {
+		$instance = $old_instance;
 
-        do_action( 'edd_product_details_widget_update', $instance );
-        
-        return $instance;
-    } 
+		$instance['title']           = strip_tags( $new_instance['title'] );
+		$instance['download_id']     = strip_tags( $new_instance['download_id'] );
+		$instance['download_title']  = isset( $new_instance['download_title'] )  ? $new_instance['download_title']  : '';
+		$instance['purchase_button'] = isset( $new_instance['purchase_button'] ) ? $new_instance['purchase_button'] : '';
+		$instance['categories']      = isset( $new_instance['categories'] )      ? $new_instance['categories']      : '';
+		$instance['tags']            = isset( $new_instance['tags'] )            ? $new_instance['tags']            : '';
+
+		do_action( 'edd_product_details_widget_update', $instance );
+
+		return $instance;
+	}
 
 }
 

--- a/tests/tests-post-type-labels.php
+++ b/tests/tests-post-type-labels.php
@@ -31,4 +31,34 @@ class Tests_Post_Type_Labels extends WP_UnitTestCase {
 		$this->assertEquals( 'Downloads', edd_get_label_plural() );
 		$this->assertEquals( 'downloads', edd_get_label_plural( true ) );
 	}
+
+	public function test_taxonomy_labels() {
+
+		$category_labels = edd_get_taxonomy_labels();
+		$this->assertInternalType( 'array', $category_labels );
+		$this->assertArrayHasKey( 'name', $category_labels );
+		$this->assertArrayHasKey( 'singular_name', $category_labels );
+		$this->assertTrue( in_array( 'Category', $category_labels ) );
+		$this->assertTrue( in_array( 'Categories', $category_labels ) );
+		// Negative test for our change to exclude singular post type label in #3212
+		$this->assertFalse( in_array( 'Download Categories', $category_labels ) );
+
+		$this->assertInternalType( 'array', $category_labels );
+		$this->assertArrayHasKey( 'name', $category_labels );
+		$this->assertArrayHasKey( 'singular_name', $category_labels );
+		$this->assertTrue( in_array( 'Category', $category_labels ) );
+		$this->assertTrue( in_array( 'Categories', $category_labels ) );
+		// Negative test for our change to exclude singular post type label in #3212
+		$this->assertFalse( in_array( 'Download Categories', $category_labels ) );
+
+		$tag_labels = edd_get_taxonomy_labels( 'download_tag' );
+		$this->assertInternalType( 'array', $tag_labels );
+		$this->assertArrayHasKey( 'name', $tag_labels );
+		$this->assertArrayHasKey( 'singular_name', $tag_labels );
+		$this->assertTrue( in_array( 'Tag', $tag_labels ) );
+		$this->assertTrue( in_array( 'Tags', $tag_labels ) );
+		// Negative test for our change to exclude singular post type label in #3212
+		$this->assertFalse( in_array( 'Download Tags', $tag_labels ) );
+
+	}
 }


### PR DESCRIPTION
Addresses the issue raised in #3212 but also makes a consistent usage of our taxonomy labels.