### PR TITLE
Fix Airplane mode

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -39,6 +39,7 @@ function edd_test_ajax_works() {
 	if ( class_exists( 'Airplane_Mode_Core' ) ) {
 
 		global $Airplane_Mode_Core;
+		$Airplane_Mode_Core = new Airplane_Mode_Core::getInstance();
 
 		if ( method_exists( $Airplane_Mode_Core, 'enabled' ) ) {
 


### PR DESCRIPTION
Depending on the load order of files, the global might not contain an instance of the Airplane Mode. Let's ensure it does