### PR TITLE
allow for the heading in purchase receipt to be set overridden

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -448,6 +448,13 @@ function edd_get_registered_settings() {
 					'type' => 'text',
 					'std'  => __( 'Purchase Receipt', 'edd' )
 				),
+				'purchase_heading' => array(
+					'id' => 'purchase_heading',
+					'name' => __( 'Purchase Email Heading', 'edd' ),
+					'desc' => __( 'Enter the heading for the purchase receipt email', 'edd' ),
+					'type' => 'text',
+					'std'  => __( 'Purchase Receipt', 'edd' )
+				),
 				'purchase_receipt' => array(
 					'id' => 'purchase_receipt',
 					'name' => __( 'Purchase Receipt', 'edd' ),

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -37,7 +37,7 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true ) {
 	$subject      = apply_filters( 'edd_purchase_subject', wp_strip_all_tags( $subject ), $payment_id );
 	$subject      = edd_do_email_tags( $subject, $payment_id );
 
-	$heading     = edd_get_option( 'purchase_heading', __( 'Purchase Reciept', 'edd' ) );
+	$heading     = edd_get_option( 'purchase_heading', __( 'Purchase Receipt', 'edd' ) );
 	$heading     = apply_filters( 'edd_purchase_heading', $heading, $payment_id, $payment_data );
 
 	$attachments  = apply_filters( 'edd_receipt_attachments', array(), $payment_id, $payment_data );
@@ -78,7 +78,7 @@ function edd_email_test_purchase_receipt() {
 	$subject     = apply_filters( 'edd_purchase_subject', wp_strip_all_tags( $subject ), 0 );
 	$subject     = edd_do_email_tags( $subject, 0 );
 
-	$heading     = edd_get_option( 'purchase_heading', __( 'Purchase Reciept', 'edd' ) );
+	$heading     = edd_get_option( 'purchase_heading', __( 'Purchase Receipt', 'edd' ) );
 	$heading     = apply_filters( 'edd_purchase_heading', $heading, $payment_id, $payment_data );
 
 	$attachments = apply_filters( 'edd_receipt_attachments', array(), 0, array() );

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -78,6 +78,9 @@ function edd_email_test_purchase_receipt() {
 	$subject     = apply_filters( 'edd_purchase_subject', wp_strip_all_tags( $subject ), 0 );
 	$subject     = edd_do_email_tags( $subject, 0 );
 
+	$heading     = edd_get_option( 'purchase_heading', __( 'Purchase Reciept', 'edd' ) );
+	$heading     = apply_filters( 'edd_purchase_heading', $heading, $payment_id, $payment_data );
+
 	$attachments = apply_filters( 'edd_receipt_attachments', array(), 0, array() );
 
 	$message     = edd_do_email_tags( edd_get_email_body_content( 0, array() ), 0 );
@@ -85,7 +88,7 @@ function edd_email_test_purchase_receipt() {
 	$emails = EDD()->emails;
 	$emails->__set( 'from_name', $from_name );
 	$emails->__set( 'from_email', $from_email );
-	$emails->__set( 'heading', __( 'Purchase Receipt', 'edd' ) );
+	$emails->__set( 'heading', $heading );
 
 	$headers = apply_filters( 'edd_receipt_headers', $emails->get_headers(), 0, array() );
 	$emails->__set( 'headers', $headers );

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -37,6 +37,9 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true ) {
 	$subject      = apply_filters( 'edd_purchase_subject', wp_strip_all_tags( $subject ), $payment_id );
 	$subject      = edd_do_email_tags( $subject, $payment_id );
 
+	$heading     = edd_get_option( 'purchase_heading', __( 'Purchase Reciept', 'edd' ) );
+	$heading     = apply_filters( 'edd_purchase_heading', $heading, $payment_id, $payment_data );
+
 	$attachments  = apply_filters( 'edd_receipt_attachments', array(), $payment_id, $payment_data );
 	$message      = edd_do_email_tags( edd_get_email_body_content( $payment_id, $payment_data ), $payment_id );
 
@@ -44,7 +47,7 @@ function edd_email_purchase_receipt( $payment_id, $admin_notice = true ) {
 
 	$emails->__set( 'from_name', $from_name );
 	$emails->__set( 'from_email', $from_email );
-	$emails->__set( 'heading', __( 'Purchase Receipt', 'edd' ) );
+	$emails->__set( 'heading', $heading );
 
 
 	$headers = apply_filters( 'edd_receipt_headers', $emails->get_headers(), $payment_id, $payment_data );
@@ -166,7 +169,7 @@ function edd_get_admin_notice_emails() {
  * @return mixed
  */
 function edd_admin_notices_disabled( $payment_id = 0 ) {
-	$ret = edd_get_option( 'disable_admin_notices', false );	
+	$ret = edd_get_option( 'disable_admin_notices', false );
 	return (bool) apply_filters( 'edd_admin_notices_disabled', $ret, $payment_id );
 }
 


### PR DESCRIPTION
I need to change the title of the "Purchase Receipt" but realized that the output is not filterable or able to be set as an option. This PR makes it possible to override as a filter, and enables a new setting in EDD settings to make it user controlled.