### PR TITLE
Set post date GMT for EDD Log

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -546,7 +546,7 @@ function edd_record_sale_in_log( $download_id = 0, $payment_id, $price_id = fals
 		'post_parent'   => $download_id,
 		'log_type'      => 'sale',
 		'post_date'     => isset( $sale_date ) ? $sale_date : null,
-		'post_date_gmt' => isset( $sale_date ) ? $sale_date : null
+		'post_date_gmt' => isset( $sale_date ) ? get_gmt_from_date( $sale_date ) : null
 	);
 
 	$log_meta = array(


### PR DESCRIPTION
#3416 

Correctly sets the GMT for the edd log. See below record of test payment:

![screen shot 2015-05-18 at 1 01 59 pm](https://cloud.githubusercontent.com/assets/676582/7674044/2cb9a4f6-fd5e-11e4-97e5-106b815a262a.png)
