### PR TITLE
Add filter on cart item quantity ajax event.

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -306,6 +306,10 @@ function edd_ajax_update_cart_item_quantity() {
 			'subtotal'    => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_subtotal() ) ), ENT_COMPAT, 'UTF-8' ),
 			'total'       => html_entity_decode( edd_currency_filter( edd_format_amount( $total ) ), ENT_COMPAT, 'UTF-8' )
 		);
+
+		// Allow for custom cart item quantity handling
+		$return = apply_filters( 'edd_ajax_cart_item_quantity_response', $return );
+
 		echo json_encode($return);
 	}
 	edd_die();


### PR DESCRIPTION
Just adding a filter that is useful if you're doing anything in the checkout that needs to respond to changes in the cart. I'm working on an application that could really benefit from this. My current workaround is to fire off a second AJAX request after this one returns, which results in an odd delay and is certainly far from ideal.

Happy to explain in further detail if you want a better understanding of the use case. 