### PR TITLE
Add filters to modify the quantity input fields in purchase forms.

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -352,7 +352,7 @@ function edd_variable_price_quantity_field( $key, $price, $download_id ) {
 <?php 
 	$quantity_input = ob_get_clean();
 
-	echo apply_filters( 'edd_purchase_form_variation_quantity_input', $quantity_input, $key, $price, $download_id );	
+	echo apply_filters( 'edd_purchase_form_variation_quantity_input', $quantity_input, $download_id, $key, $price );
 }
 add_action( 'edd_after_price_option', 'edd_variable_price_quantity_field', 10, 3 );
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -312,10 +312,15 @@ function edd_download_purchase_form_quantity_field( $download_id = 0, $args = ar
 		return;
 	}
 
-	echo '<div class="edd_download_quantity_wrapper">';
-		echo '<input type="number" min="1" step="1" name="edd_download_quantity" class="edd-input edd-item-quantity" value="1" />';
-	echo '</div>';
+	ob_start();
+?>
+	<div class="edd_download_quantity_wrapper">
+		<input type="number" min="1" step="1" name="edd_download_quantity" class="edd-input edd-item-quantity" value="1" />
+	</div>
+<?php 
+	$quantity_input = ob_get_clean();
 
+	echo apply_filters( 'edd_purchase_form_quantity_input', $quantity_input, $download_id, $args );
 }
 add_action( 'edd_purchase_link_top', 'edd_download_purchase_form_quantity_field', 10, 2 );
 
@@ -338,10 +343,16 @@ function edd_variable_price_quantity_field( $key, $price, $download_id ) {
 		return;
 	}
 
-	echo '<div class="edd_download_quantity_wrapper edd_download_quantity_price_option_' . sanitize_key( $price['name'] ) . '">';
-		echo '<span class="edd_price_option_sep">&nbsp;x&nbsp;</span>';
-		echo '<input type="number" min="1" step="1" name="edd_download_quantity_' . esc_attr( $key ) . '" class="edd-input edd-item-quantity" value="1" />';
-	echo '</div>';
+	ob_start();
+?>
+	<div class="edd_download_quantity_wrapper edd_download_quantity_price_option_<?php echo sanitize_key( $price['name'] ) ?>">
+		<span class="edd_price_option_sep">&nbsp;x&nbsp;</span>
+		<input type="number" min="1" step="1" name="edd_download_quantity_<?php echo esc_attr( $key ) ?>" class="edd-input edd-item-quantity" value="1" />
+	</div>
+<?php 
+	$quantity_input = ob_get_clean();
+
+	echo apply_filters( 'edd_purchase_form_variation_quantity_input', $quantity_input, $key, $price, $download_id );	
 }
 add_action( 'edd_after_price_option', 'edd_variable_price_quantity_field', 10, 3 );
 


### PR DESCRIPTION
It would be nice to have filters on these HTML snippets. You can get around this now by unhooking the action callback, but then you have to run all the same checks that `edd_download_purchase_form_quantity_field()` and `edd_variable_price_quantity_field()` run. 

As an aside, would it make sense to bake an optional label into the HTML output here? As it stands, the quantity input just feels like a random input field without a clear context. 