### PR TITLE
Add more info to tax rate response

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -408,10 +408,10 @@ function edd_ajax_recalculate_taxes() {
 	$cart = ob_get_clean();
 	$response = array(
 		'html'  => $cart,
-		'tax' => edd_get_cart_tax(),
-		'tax_formatted' => html_entity_decode( edd_cart_tax( false ), ENT_COMPAT, 'UTF-8' ),
-		'tax_rate' => edd_get_tax_rate(),
-		'tax_rate_formatted' => html_entity_decode( edd_get_formatted_tax_rate(), ENT_COMPAT, 'UTF-8' ),
+		'tax_raw' => edd_get_cart_tax(),
+		'tax' => html_entity_decode( edd_cart_tax( false ), ENT_COMPAT, 'UTF-8' ),
+		'tax_rate_raw' => edd_get_tax_rate(),
+		'tax_rate' => html_entity_decode( edd_get_formatted_tax_rate(), ENT_COMPAT, 'UTF-8' ),
 		'total' => html_entity_decode( edd_cart_total( false ), ENT_COMPAT, 'UTF-8' ),
 	);
 

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -408,6 +408,10 @@ function edd_ajax_recalculate_taxes() {
 	$cart = ob_get_clean();
 	$response = array(
 		'html'  => $cart,
+		'tax' => edd_get_cart_tax(),
+		'tax_formatted' => html_entity_decode( edd_cart_tax( false ), ENT_COMPAT, 'UTF-8' ),
+		'tax_rate' => edd_get_tax_rate(),
+		'tax_rate_formatted' => html_entity_decode( edd_get_formatted_tax_rate(), ENT_COMPAT, 'UTF-8' ),
 		'total' => html_entity_decode( edd_cart_total( false ), ENT_COMPAT, 'UTF-8' ),
 	);
 


### PR DESCRIPTION
This is useful (necessary) for VAT plugins to update the displayed tax rate everytime `edd_recalculate_taxes` is called, without having to perform an unnecessary additional AJAX request.