### PR TITLE
Removing calls for edd_test_ajax_works for now

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -75,6 +75,7 @@ class EDD_Notices {
 			echo '</div>';
 		}
 
+		/* Commented out per https://github.com/easydigitaldownloads/Easy-Digital-Downloads/issues/3475
 		if( ! edd_test_ajax_works() && ! get_user_meta( get_current_user_id(), '_edd_admin_ajax_inaccessible_dismissed', true ) && current_user_can( 'manage_shop_settings' ) ) {
 			echo '<div class="error">';
 				echo '<p>' . __( 'Your site appears to be blocking the WordPress ajax interface. This may causes issues with your store.', 'edd' ) . '</p>';
@@ -82,6 +83,7 @@ class EDD_Notices {
 				echo '<p><a href="' . add_query_arg( array( 'edd_action' => 'dismiss_notices', 'edd_notice' => 'admin_ajax_inaccessible' ) ) . '">' . __( 'Dismiss Notice', 'edd' ) . '</a></p>';
 			echo '</div>';
 		}
+		*/
 
 		if ( isset( $_GET['edd-message'] ) ) {
 			// Shop discounts errors

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -478,7 +478,8 @@ function edd_tools_sysinfo_get() {
 
 	$return .= 'Remote Post:              ' . $WP_REMOTE_POST . "\n";
 	$return .= 'Table Prefix:             ' . 'Length: ' . strlen( $wpdb->prefix ) . '   Status: ' . ( strlen( $wpdb->prefix ) > 16 ? 'ERROR: Too long' : 'Acceptable' ) . "\n";
-	$return .= 'Admin AJAX:               ' . ( edd_test_ajax_works() ? 'Accessible' : 'Inaccessible' ) . "\n";
+	// Commented out per https://github.com/easydigitaldownloads/Easy-Digital-Downloads/issues/3475
+	//$return .= 'Admin AJAX:               ' . ( edd_test_ajax_works() ? 'Accessible' : 'Inaccessible' ) . "\n";
 	$return .= 'WP_DEBUG:                 ' . ( defined( 'WP_DEBUG' ) ? WP_DEBUG ? 'Enabled' : 'Disabled' : 'Not set' ) . "\n";
 	$return .= 'Memory Limit:             ' . WP_MEMORY_LIMIT . "\n";
 	$return .= 'Registered Post Stati:    ' . implode( ', ', get_post_stati() ) . "\n";

--- a/tests/ajax.php
+++ b/tests/ajax.php
@@ -219,7 +219,7 @@ class Tests_AJAX extends WP_UnitTestCase {
 	}
 
 	public function test_edd_test_ajax_works() {
-		
+		$this->markTestIncomplete( 'Needs to be reworked per #3475' );
 		$this->assertTrue( edd_test_ajax_works() );
 
 		$this->assertNotEmpty( get_transient( '_edd_ajax_works' ) );


### PR DESCRIPTION
Addresses concerns in #3475 & #3387