### PR TITLE
Add ability for admins to download files

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -45,7 +45,7 @@ function edd_add_download_meta_box() {
 
 		if ( current_user_can( 'edit_others_posts' ) ) {
 			/** File download metabox */
-			add_meta_box( 'edd_attached_files', sprintf( __( 'Attached Files', 'edd' ), edd_get_label_singular(), edd_get_label_plural() ), 'edd_render_attached_files_meta_box', $post_type, 'normal', 'high' );
+			add_meta_box( 'edd_attached_files', __( 'Attached Files', 'edd' ), 'edd_render_attached_files_meta_box', $post_type, 'normal', 'high' );
 		}
 	}
 }

--- a/includes/admin/reporting/class-file-downloads-logs-list-table.php
+++ b/includes/admin/reporting/class-file-downloads-logs-list-table.php
@@ -114,7 +114,11 @@ class EDD_File_Downloads_Log_Table extends WP_List_Table {
 			case 'user_id' :
 				return $item[ $column_name ] ? '<a href="' . add_query_arg( 'user', $item[ $column_name ] ) . '">' . $item['user_name'] . '</a>' : $item['user_name'];
 			case 'payment_id' :
-				return $item['payment_id'] !== false ? '<a href="' . admin_url( 'edit.php?post_type=download&page=edd-payment-history&view=view-order-details&id=' . $item['payment_id'] ) . '">' . edd_get_payment_number( $item['payment_id'] ) . '</a>' : '';
+				if ( is_numeric( $item['payment_id'] ) ) {
+					return $item['payment_id'] !== false ? '<a href="' . admin_url( 'edit.php?post_type=download&page=edd-payment-history&view=view-order-details&id=' . $item['payment_id'] ) . '">' . edd_get_payment_number( $item['payment_id'] ) . '</a>' : '';
+				} else {
+					return $item['payment_id'];
+				}
 			default:
 				return $item[ $column_name ];
 		}

--- a/includes/admin/upload-functions.php
+++ b/includes/admin/upload-functions.php
@@ -52,7 +52,7 @@ add_action( 'admin_init', 'edd_change_downloads_upload_dir', 999 );
  */
 
 function edd_create_protection_files( $force = false, $method = false ) {
-	if ( false === get_transient( 'edd_check_protection_files' ) || $force ) {
+	//if ( false === get_transient( 'edd_check_protection_files' ) || $force ) {
 
 		$upload_path = edd_get_upload_dir();
 
@@ -61,6 +61,7 @@ function edd_create_protection_files( $force = false, $method = false ) {
 
 		// Top level .htaccess file
 		$rules = edd_get_htaccess_rules( $method );
+
 		if ( edd_htaccess_exists() ) {
 			$contents = @file_get_contents( $upload_path . '/.htaccess' );
 			if ( $contents !== $rules || ! $contents ) {
@@ -86,8 +87,8 @@ function edd_create_protection_files( $force = false, $method = false ) {
 			}
 		}
 		// Check for the files once per day
-		set_transient( 'edd_check_protection_files', true, 3600 * 24 );
-	}
+		//set_transient( 'edd_check_protection_files', true, 3600 * 24 );
+	//}
 }
 add_action( 'admin_init', 'edd_create_protection_files' );
 
@@ -159,6 +160,7 @@ function edd_get_htaccess_rules( $method = false ) {
 			break;
 
 	endswitch;
+
 	$rules = apply_filters( 'edd_protected_directory_htaccess_rules', $rules, $method );
 	return $rules;
 }

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -570,26 +570,31 @@ function edd_record_sale_in_log( $download_id = 0, $payment_id, $price_id = fals
  * @param string $ip IP Address
  * @param int $payment_id Payment ID
  * @param int $price_id Price ID, if any
+ * @param bool $is_admin If the download is an admin procssed download from issue #3002
  * @return void
  */
-function edd_record_download_in_log( $download_id = 0, $file_id, $user_info, $ip, $payment_id, $price_id = false ) {
+function edd_record_download_in_log( $download_id = 0, $file_id, $user_info, $ip, $payment_id, $price_id = false, $is_admin = false ) {
 	global $edd_logs;
 
 	$log_data = array(
-		'post_parent'	=> $download_id,
-		'log_type'		=> 'file_download'
+		'post_parent' => $download_id,
+		'log_type'    => 'file_download'
 	);
 
 	$user_id = isset( $user_info['id'] ) ? $user_info['id'] : (int) -1;
 
 	$log_meta = array(
-		'user_info'	=> $user_info,
-		'user_id'	=> $user_id,
-		'file_id'	=> (int) $file_id,
-		'ip'		=> $ip,
-		'payment_id'=> $payment_id,
-		'price_id'  => (int) $price_id
+		'user_info'  => $user_info,
+		'user_id'    => $user_id,
+		'file_id'    => (int) $file_id,
+		'ip'         => $ip,
+		'payment_id' => $payment_id,
+		'price_id'   => (int) $price_id
 	);
+
+	if ( $is_admin ) {
+		$log_meta['admin_download'] = 1;
+	}
 
 	$edd_logs->insert_log( $log_data, $log_meta );
 }

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -738,10 +738,11 @@ function edd_process_admin_download() {
 	// Verify the attachment belongs to the download
 	$files               = edd_get_download_files( $download_id );
 	$attachment_verified = false;
-	foreach ( $files as $file ) {
+	foreach ( $files as $file_id => $file ) {
 		if ( $file['attachment_id'] == $attachment_id ) {
 			$attachment_verified = true;
 			$requested_file      = $file['file'];
+			$file_id             = $file_id;
 			break;
 		}
 	}
@@ -749,6 +750,15 @@ function edd_process_admin_download() {
 	if ( false === $attachment_verified ) {
 		wp_die( apply_filters( 'edd_deny_admin_message', $error_message, __( 'Download Attachment Mismatch', 'edd' ) ), __( 'Error', 'edd' ), array( 'response' => 403 ) );
 	}
+
+	// Record this file download in the log
+	$user_info = array();
+	$user_data          = get_userdata( get_current_user_id() );
+	$user_info['id']    = get_current_user_id();
+	$user_info['name']  = $user_data->display_name;
+	$user_info['email'] = $user_data->user_email;
+
+	edd_record_download_in_log( $download_id, $file_id, $user_info, edd_get_ip(), __( 'Admin' ), true );
 
 	$file_extension = edd_get_file_extension( $requested_file );
 	$ctype          = edd_get_file_ctype( $file_extension );


### PR DESCRIPTION
Adds a metabox for anyone who can 'edit_others_posts' that allows them to see all items attached to a download, and then offers some information regarding size and mime type, as well as a download link.

It addresses the concerns in #3002 
