### PR TITLE
Reverse how we handled #2794 by reimplementing the download attribute

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1022,13 +1022,13 @@ function edd_get_file_download_method() {
  *
  * @since 2.4
  * @author Chris Christoff
- * @param bool $bool Default for has_access
+ * @param bool $has_access Default for has_access
  * @param mixed $purchase_data Array of purchase data 
  * @param mixed $args Array of arguments
  * @return nool If a user can access the file
  */
-function edd_can_access_download( $bool = true, $purchase_data = array(), $args = array() ) {
-	return apply_filters( 'edd_file_download_has_access', $bool, $purchase_data, $args );
+function edd_has_file_download_access( $has_access = true, $purchase_data = array(), $args = array() ) {
+	return apply_filters( 'edd_file_download_has_access', $has_access, $purchase_data, $args );
 }
 
 /**
@@ -1036,18 +1036,18 @@ function edd_can_access_download( $bool = true, $purchase_data = array(), $args 
  *
  * @since 2.4
  * @author Chris Christoff
- * @param bool $bool Default for has_access for edd_can_access_download()
- * @param mixed $purchase_data Array of purchase data  for edd_can_access_download()
- * @param mixed $args Array of arguments for edd_can_access_download()
+ * @param bool $has_access Default for has_access for edd_has_file_download_access()
+ * @param mixed $purchase_data Array of purchase data  for edd_has_file_download_access()
+ * @param mixed $args Array of arguments for edd_has_file_download_access()
  * @param mixed $args The file array
  * @return nool If a user can access the file
  */
-function edd_get_html5_download_attribute( $bool = true, $purchase_data = array(), $args = array(), $file = array() ) {
+function edd_get_html5_download_attribute( $has_access = true, $purchase_data = array(), $args = array(), $file = array() ) {
 	$string = '';
-	if ( edd_can_access_download( $bool, $purchase_data, $args ) ){
+	if ( edd_has_file_download_access( $has_access, $purchase_data, $args ) ){
 		$string = 'download="'  .edd_get_file_name( $file ) . '"';	
 	}
-	return apply_filters( 'edd_get_html5_download_attribute', $string, $bool, $purchase_data, $args, $file );
+	return apply_filters( 'edd_get_html5_download_attribute', $string, $has_access, $purchase_data, $args, $file );
 }
 
 

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1025,7 +1025,7 @@ function edd_get_file_download_method() {
  * @param bool $has_access Default for has_access
  * @param mixed $purchase_data Array of purchase data 
  * @param mixed $args Array of arguments
- * @return nool If a user can access the file
+ * @return bool If a user can access the file
  */
 function edd_has_file_download_access( $has_access = true, $purchase_data = array(), $args = array() ) {
 	return apply_filters( 'edd_file_download_has_access', $has_access, $purchase_data, $args );
@@ -1040,7 +1040,7 @@ function edd_has_file_download_access( $has_access = true, $purchase_data = arra
  * @param mixed $purchase_data Array of purchase data  for edd_has_file_download_access()
  * @param mixed $args Array of arguments for edd_has_file_download_access()
  * @param mixed $args The file array
- * @return nool If a user can access the file
+ * @return bool If a user can access the file
  */
 function edd_get_html5_download_attribute( $has_access = true, $purchase_data = array(), $args = array(), $file = array() ) {
 	$string = '';

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -1018,6 +1018,40 @@ function edd_get_file_download_method() {
 }
 
 /**
+ * Returns if a user can access a download of a purchase
+ *
+ * @since 2.4
+ * @author Chris Christoff
+ * @param bool $bool Default for has_access
+ * @param mixed $purchase_data Array of purchase data 
+ * @param mixed $args Array of arguments
+ * @return nool If a user can access the file
+ */
+function edd_can_access_download( $bool = true, $purchase_data = array(), $args = array() ) {
+	return apply_filters( 'edd_file_download_has_access', $bool, $purchase_data, $args );
+}
+
+/**
+ * Returns `download` attribute for download link if user can access download 
+ *
+ * @since 2.4
+ * @author Chris Christoff
+ * @param bool $bool Default for has_access for edd_can_access_download()
+ * @param mixed $purchase_data Array of purchase data  for edd_can_access_download()
+ * @param mixed $args Array of arguments for edd_can_access_download()
+ * @param mixed $args The file array
+ * @return nool If a user can access the file
+ */
+function edd_get_html5_download_attribute( $bool = true, $purchase_data = array(), $args = array(), $file = array() ) {
+	$string = '';
+	if ( edd_can_access_download( $bool, $purchase_data, $args ) ){
+		$string = 'download="'  .edd_get_file_name( $file ) . '"';	
+	}
+	return apply_filters( 'edd_get_html5_download_attribute', $string, $bool, $purchase_data, $args, $file );
+}
+
+
+/**
  * Returns a random download
  *
  * @since 1.7

--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -425,8 +425,9 @@ function edd_email_tag_download_list( $payment_id ) {
 
 					if ( $show_links ) {
 						$download_list .= '<div>';
+							$attribute = edd_get_html5_download_attribute( true, $payment_data, array(), $file );
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $item['id'], $price_id );
-							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
+							$download_list .= '<a href="' . esc_url( $file_url ) . '"' . $attribute . '>' . edd_get_file_name( $file ) . '</a>';
 							$download_list .= '</div>';
 					} else {
 						$download_list .= '<div>';
@@ -449,8 +450,9 @@ function edd_email_tag_download_list( $payment_id ) {
 					foreach ( $files as $filekey => $file ) {
 						if ( $show_links ) {
 							$download_list .= '<div>';
+							$attribute = edd_get_html5_download_attribute( true, $payment_data, array(), $file );
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $price_id );
-							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . $file['name'] . '</a>';
+							$download_list .= '<a href="' . esc_url( $file_url ) . '"' . $attribute . '>' . $file['name'] . '</a>';
 							$download_list .= '</div>';
 						} else {
 							$download_list .= '<div>';

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -62,7 +62,7 @@ function edd_process_download() {
 
 	}
 
-	$args['has_access'] = apply_filters( 'edd_file_download_has_access', $args['has_access'], $args['payment'], $args );
+	$args['has_access'] = edd_can_access_download( $args['has_access'], $args['payment'], $args );
 
 	//$args['has_access'] = ( edd_logged_in_only() && is_user_logged_in() ) || !edd_logged_in_only() ? true : false;
 	if ( $args['payment'] && $args['has_access'] ) {

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -62,7 +62,7 @@ function edd_process_download() {
 
 	}
 
-	$args['has_access'] = edd_can_access_download( $args['has_access'], $args['payment'], $args );
+	$args['has_access'] = edd_has_file_download_access( $args['has_access'], $args['payment'], $args );
 
 	//$args['has_access'] = ( edd_logged_in_only() && is_user_logged_in() ) || !edd_logged_in_only() ? true : false;
 	if ( $args['payment'] && $args['has_access'] ) {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -509,6 +509,7 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 	$downloads   = edd_get_payment_meta_cart_details( $payment_id, true );
 	$payment_key = edd_get_payment_key( $payment_id );
 	$email       = edd_get_payment_user_email( $payment_id );
+	$purchase    = edd_get_payment_meta( $payment_id );
 	$links       = '<ul class="edd_download_links">';
 
 	foreach ( $downloads as $download ) {
@@ -519,7 +520,8 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 			if ( is_array( $files ) ) {
 				foreach ( $files as $filekey => $file ) {
 					$links .= '<div class="edd_download_link_file">';
-						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '">';
+						$attribute = edd_get_html5_download_attribute( true, $purchase, array(), $file );
+						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '" ' . $attribute . '> ';
 							if ( isset( $file['name'] ) )
 								$links .= esc_html( $file['name'] );
 							else

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -54,10 +54,11 @@ if ( $purchases ) :
 										foreach ( $download_files as $filekey => $file ) :
 
 											$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $download['id'], $price_id );
+											$attribute = edd_get_html5_download_attribute( true, $purchase_data, array(), $file );
 											?>
 
 											<div class="edd_download_file">
-												<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link">
+												<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link">
 													<?php echo isset( $file['name'] ) ? esc_html( $file['name'] ) : esc_html( $name ); ?>
 												</a>
 											</div>

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -167,9 +167,10 @@ $status    = edd_get_payment_status( $payment, true );
 								foreach ( $download_files as $filekey => $file ) :
 
 									$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $item['id'], $price_id );
+									$attribute = edd_get_html5_download_attribute( true, $payment, $edd_receipt_args, $file );
 									?>
 									<li class="edd_download_file">
-										<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
+										<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
 									</li>
 									<?php
 									do_action( 'edd_receipt_files', $filekey, $file, $item['id'], $payment->ID, $meta );
@@ -190,9 +191,10 @@ $status    = edd_get_payment_status( $payment, true );
 
 												foreach ( $download_files as $filekey => $file ) :
 
-													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); ?>
+													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); 
+													$attribute    = edd_get_html5_download_attribute( true, $payment, $edd_receipt_args, $file ); ?>
 													<li class="edd_download_file">
-														<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
+														<a href="<?php echo esc_url( $download_url ); ?>" <?php echo $attribute; ?> class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
 													</li>
 													<?php
 													do_action( 'edd_receipt_bundle_files', $filekey, $file, $item['id'], $bundle_item, $payment->ID, $meta );


### PR DESCRIPTION
YAR of + resolves #2794 and #2798

The `download` attribute is useful in several cases. It completely put an end to the "my file opened in my browser instead of downloading" tickets. Instead of removing the attribute, and all of its benefits, instead lets only show it when the file can be downloaded. This pr also adds the attribute to bundled products on the receipts page (where it wasn't before) as wells as the download history page

Refs:
#2393
#2794
#2795
#2798
#3091
#3255
#3512
