### PR TITLE
fixed edd_listen_for_failed_payments()

### DIFF
--- a/includes/checkout/functions.php
+++ b/includes/checkout/functions.php
@@ -229,7 +229,8 @@ function edd_listen_for_failed_payments() {
 	if( ! empty( $failed_page ) && is_page( $failed_page ) && ! empty( $_GET['payment-id'] ) ) {
 
 		$payment_id = absint( $_GET['payment-id'] );
-		$status     = edd_get_payment_status( $payment_id );
+		$payment    = get_post( $payment_id );
+		$status     = edd_get_payment_status( $payment );
 
 		if( $status && 'pending' === strtolower( $status ) ) {
 


### PR DESCRIPTION
The `edd_get_payment_status()` function only accepts a `WP_Post` object. However the current version of `edd_listen_for_failed_payments()` passes a payment ID (post ID) to the function, causing it to return false instead of the actual payment status so that the payment status is never actually changed to 'failed'.

This commit fixes that behavior.