### PR TITLE
[purchase_link] direct to gateway option doesn't work on variable products

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -120,25 +120,20 @@ jQuery(document).ready(function ($) {
 
 				form.find('.edd_price_option_' + download + ':checked', form).each(function( index ) {
 					item_price_ids[ index ] = $(this).val();
-
-					// If we're still only at free items, check if this one is free also
-					if ( true === free_items ) {
-						var item_price = $(this).data('price');
-						if ( item_price && item_price > 0 ) {
-							// We now have a paid item, we can't use add_to_cart
-							free_items = false;
-						}
-					}
-
 				});
 			}
-
 		} else {
 			item_price_ids[0] = download;
-			if ( $this.data('price') && $this.data('price') > 0 ) {
-				free_items = false;
-			}
 		}
+
+        // If we're still only at free items, check if this one is free also
+        if ( true === free_items ) {
+            var item_price = $(this).data('price');
+            if ( item_price && item_price > 0 ) {
+                // We now have a paid item, we can't use add_to_cart
+                free_items = false;
+            }
+        }
 
 		// If we've got nothing but free items being added, change to add_to_cart
 		if ( free_items ) {

--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -126,14 +126,14 @@ jQuery(document).ready(function ($) {
 			item_price_ids[0] = download;
 		}
 
-        // If we're still only at free items, check if this one is free also
-        if ( true === free_items ) {
-            var item_price = $(this).data('price');
-            if ( item_price && item_price > 0 ) {
-                // We now have a paid item, we can't use add_to_cart
-                free_items = false;
-            }
-        }
+	        // If we're still only at free items, check if this one is free also
+	        if ( true === free_items ) {
+	            var item_price = $(this).data('price');
+	            if ( item_price && item_price > 0 ) {
+	                // We now have a paid item, we can't use add_to_cart
+	                free_items = false;
+	            }
+	        }
 
 		// If we've got nothing but free items being added, change to add_to_cart
 		if ( free_items ) {


### PR DESCRIPTION
 `free_items` flag was persist unchanged(`true`) for variable products with direct link. Resolved #3592