### PR TITLE
Use $download->get_price() function instead of property

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -141,7 +141,7 @@ function edd_get_download_price( $download_id = 0 ) {
 	}
 
 	$download = new EDD_Download( $download_id );
-	return $download->price;
+	return $download->get_price();
 }
 
 /**
@@ -232,7 +232,7 @@ function edd_get_variable_prices( $download_id = 0 ) {
 	}
 
 	$download = new EDD_Download( $download_id );
-	return $download->prices;
+	return $download->get_prices();
 }
 
 /**


### PR DESCRIPTION
Hey,

Just noticed this and made a quick PR inside GH.

Use the sanitized and filtered `$download->get_price()` and `$download->get_prices()` values for the old backward compatible functions instead of the EDD_Download property.