### PR TITLE
Switch from $_SERVER["HTTPS"] check to is_ssl(). #3740.

### DIFF
--- a/includes/checkout/functions.php
+++ b/includes/checkout/functions.php
@@ -323,10 +323,6 @@ function edd_enforced_ssl_redirect_handler() {
 		return;
 	}
 
-	if ( isset( $_SERVER["HTTPS"] ) && $_SERVER["HTTPS"] == "on" ) {
-		return;
-	}
-
 	$uri = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 
 	wp_safe_redirect( $uri );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -436,8 +436,9 @@ function edd_get_current_page_url() {
 	else :
 		$page_url = 'http';
 
-	if ( isset( $_SERVER["HTTPS"] ) && $_SERVER["HTTPS"] == "on" )
+	if ( is_ssl() ) {
 		$page_url .= "s";
+	}
 
 	$page_url .= "://";
 


### PR DESCRIPTION
is_ssl() handles the same check and an additional port check for when servers fail to set the HTTPS var. This removes the check from edd_enforced_ssl_redirect_handler() since it's already checked with is_ssl above, and it swaps the check in edd_get_current_page_url() to is_ssl().