### PR TITLE
Update class-edd-html-elements.php

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -38,7 +38,7 @@ class EDD_HTML_Elements {
 			'multiple'    => false,
 			'selected'    => 0,
 			'chosen'      => false,
-			'number'      => 30,
+			'number'      => -1,
 			'bundles'     => true,
 			'placeholder' => sprintf( __( 'Select a %s', 'edd' ), edd_get_label_singular() )
 		);


### PR DESCRIPTION
When I have more than 30 downloads, I cannot see all the downloads in the bundled downloads selectbox. The number of posts should be changed from 30 to -1 to fetch all.