### PR TITLE
First pass at plugins_loaded transition

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -48,6 +48,14 @@ final class Easy_Digital_Downloads {
 	private static $instance;
 
 	/**
+	 * EDD Loader Object
+	 *
+	 * @var object
+	 * @since 2.5
+	 */
+	public $loader;
+
+	/**
 	 * EDD Roles Object
 	 *
 	 * @var object
@@ -132,19 +140,21 @@ final class Easy_Digital_Downloads {
 	public static function instance() {
 		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof Easy_Digital_Downloads ) ) {
 			self::$instance = new Easy_Digital_Downloads;
-			self::$instance->setup_constants();
 
 			add_action( 'plugins_loaded', array( self::$instance, 'load_textdomain' ) );
 
+			require_once 'includes/class-edd-loader.php';
+			self::$instance->loader     = new EDD_Loader( __FILE__ );
+
 			self::$instance->includes();
-			self::$instance->roles      = new EDD_Roles();
+			self::$instance->roles      = self::$instance->loader->roles;
+			self::$instance->api        = self::$instance->loader->api;
+			self::$instance->session    = self::$instance->loader->session;
+			self::$instance->customers  = self::$instance->loader->customers;
 			self::$instance->fees       = new EDD_Fees();
-			self::$instance->api        = new EDD_API();
-			self::$instance->session    = new EDD_Session();
 			self::$instance->html       = new EDD_HTML_Elements();
 			self::$instance->emails     = new EDD_Emails();
 			self::$instance->email_tags = new EDD_Email_Template_Tags();
-			self::$instance->customers  = new EDD_DB_Customers();
 		}
 		return self::$instance;
 	}
@@ -177,41 +187,6 @@ final class Easy_Digital_Downloads {
 	}
 
 	/**
-	 * Setup plugin constants
-	 *
-	 * @access private
-	 * @since 1.4
-	 * @return void
-	 */
-	private function setup_constants() {
-
-		// Plugin version
-		if ( ! defined( 'EDD_VERSION' ) ) {
-			define( 'EDD_VERSION', '2.4.3' );
-		}
-
-		// Plugin Folder Path
-		if ( ! defined( 'EDD_PLUGIN_DIR' ) ) {
-			define( 'EDD_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
-		}
-
-		// Plugin Folder URL
-		if ( ! defined( 'EDD_PLUGIN_URL' ) ) {
-			define( 'EDD_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
-		}
-
-		// Plugin Root File
-		if ( ! defined( 'EDD_PLUGIN_FILE' ) ) {
-			define( 'EDD_PLUGIN_FILE', __FILE__ );
-		}
-
-		// Make sure CAL_GREGORIAN is defined
-		if ( ! defined( 'CAL_GREGORIAN' ) ) {
-			define( 'CAL_GREGORIAN', 1 );
-		}
-	}
-
-	/**
 	 * Include required files
 	 *
 	 * @access private
@@ -219,26 +194,17 @@ final class Easy_Digital_Downloads {
 	 * @return void
 	 */
 	private function includes() {
-		global $edd_options;
-
-		require_once EDD_PLUGIN_DIR . 'includes/admin/settings/register-settings.php';
-		$edd_options = edd_get_settings();
-
 		require_once EDD_PLUGIN_DIR . 'includes/actions.php';
 		if( file_exists( EDD_PLUGIN_DIR . 'includes/deprecated-functions.php' ) ) {
 			require_once EDD_PLUGIN_DIR . 'includes/deprecated-functions.php';
 		}
 		require_once EDD_PLUGIN_DIR . 'includes/ajax-functions.php';
-		require_once EDD_PLUGIN_DIR . 'includes/api/class-edd-api.php';
 		require_once EDD_PLUGIN_DIR . 'includes/template-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/checkout/template.php';
 		require_once EDD_PLUGIN_DIR . 'includes/checkout/functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/cart/functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/cart/template.php';
 		require_once EDD_PLUGIN_DIR . 'includes/cart/actions.php';
-		require_once EDD_PLUGIN_DIR . 'includes/class-edd-db.php';
-		require_once EDD_PLUGIN_DIR . 'includes/class-edd-db-customers.php';
-		require_once EDD_PLUGIN_DIR . 'includes/class-edd-customer.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-download.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-cache-helper.php';
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
@@ -249,16 +215,10 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-html-elements.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-license-handler.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-logging.php';
-		require_once EDD_PLUGIN_DIR . 'includes/class-edd-session.php';
-		require_once EDD_PLUGIN_DIR . 'includes/class-edd-stats.php';
-		require_once EDD_PLUGIN_DIR . 'includes/class-edd-roles.php';
-		require_once EDD_PLUGIN_DIR . 'includes/country-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/formatting.php';
 		require_once EDD_PLUGIN_DIR . 'includes/widgets.php';
-		require_once EDD_PLUGIN_DIR . 'includes/misc-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/mime-types.php';
 		require_once EDD_PLUGIN_DIR . 'includes/gateways/actions.php';
-		require_once EDD_PLUGIN_DIR . 'includes/gateways/functions.php';
 		if ( version_compare( phpversion(), 5.3, '>' ) ) {
 			require_once EDD_PLUGIN_DIR . 'includes/gateways/amazon-payments.php';
 		}
@@ -267,16 +227,12 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/discount-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/payments/functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/payments/actions.php';
-		require_once EDD_PLUGIN_DIR . 'includes/payments/class-payment-stats.php';
 		require_once EDD_PLUGIN_DIR . 'includes/payments/class-payments-query.php';
 		require_once EDD_PLUGIN_DIR . 'includes/download-functions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/scripts.php';
-		require_once EDD_PLUGIN_DIR . 'includes/post-types.php';
 		require_once EDD_PLUGIN_DIR . 'includes/plugin-compatibility.php';
-		require_once EDD_PLUGIN_DIR . 'includes/emails/class-edd-emails.php';
 		require_once EDD_PLUGIN_DIR . 'includes/emails/class-edd-email-tags.php';
 		require_once EDD_PLUGIN_DIR . 'includes/emails/functions.php';
-		require_once EDD_PLUGIN_DIR . 'includes/emails/template.php';
 		require_once EDD_PLUGIN_DIR . 'includes/emails/actions.php';
 		require_once EDD_PLUGIN_DIR . 'includes/error-tracking.php';
 		require_once EDD_PLUGIN_DIR . 'includes/user-functions.php';
@@ -294,7 +250,6 @@ final class Easy_Digital_Downloads {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/admin-pages.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/dashboard-widgets.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/thickbox.php';
-			require_once EDD_PLUGIN_DIR . 'includes/admin/upload-functions.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/downloads/dashboard-columns.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/customers/customers.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/customers/customer-functions.php';
@@ -319,16 +274,11 @@ final class Easy_Digital_Downloads {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/tracking.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/tools.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/plugins.php';
-			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';
-			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrades.php';
-			require_once EDD_PLUGIN_DIR . 'includes/admin/welcome.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/class-edd-heartbeat.php';
 		} else {
 			require_once EDD_PLUGIN_DIR . 'includes/process-download.php';
 			require_once EDD_PLUGIN_DIR . 'includes/theme-compatibility.php';
 		}
-
-		require_once EDD_PLUGIN_DIR . 'includes/install.php';
 	}
 
 	/**
@@ -382,6 +332,28 @@ endif; // End if class_exists check
 function EDD() {
 	return Easy_Digital_Downloads::instance();
 }
+add_action( 'plugins_loaded', 'EDD', 9 );
 
-// Get EDD Running
-EDD();
+
+/**
+ * Install
+ *
+ * Runs on plugin installation and sets up the post types, custom taxonomies,
+ * flushes rewrite rules to initiate the new 'downloads' slug and also creates
+ * the plugin and populates the settings fields for those plugin pages. After
+ * successful install, the use is redirected to the EDD Welcome screen.
+ *
+ * @since 2.5
+ * @return void
+ */
+function edd_load_installer() {
+	// Load required files
+	require_once 'includes/install.php';
+	require_once 'includes/class-edd-loader.php';
+
+	new EDD_Loader( __FILE__ );
+
+	// Run the install script
+	edd_install();
+}
+register_activation_hook( __FILE__, 'edd_load_installer' );

--- a/includes/class-edd-loader.php
+++ b/includes/class-edd-loader.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * EDD Loader
+ *
+ * The Loader class bootstraps components that are required
+ * during both the install process and instantiation of the
+ * main Easy_Digital_Downloads class. This allows us to
+ * load EDD on plugins_loaded and still access required
+ * components from the register_plugin_activation hook.
+ *
+ * @package		EDD
+ * @subpackage	Classes/Loader
+ * @copyright	Copyright (c) 2015, Pippin Williamson
+ * @license		http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since		2.5
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * EDD_Loader Class
+ *
+ * A general use class for bootstrapping components required during load and install.
+ *
+ * @since 2.5
+ */
+class EDD_Loader {
+
+	/**
+	 * EDD plugin file
+	 *
+	 * @var string
+	 * @since 2.5
+	 */
+	public $plugin_file;
+
+	/**
+	 * EDD Roles Object
+	 *
+	 * @var object
+	 * @since 2.5
+	 */
+	public $roles;
+
+	/**
+	 * EDD API Object
+	 *
+	 * @var object
+	 * @since 1.5
+	 */
+	public $api;
+
+	/**
+	 * EDD Session Object
+	 *
+	 * @var object
+	 * @since 2.5
+	 */
+	public $session;
+	
+	/**
+	 * EDD Customers DB Object
+	 *
+	 * @var object
+	 * @since 2.5
+	 */
+	public $customers;
+
+	/**
+	 * Set up the EDD Loader Class
+	 *
+	 * @since 2.5
+	 * @param string $plugin_file The plugin file
+	 */
+	public function __construct( $plugin_file ) {
+		// We need the main plugin file reference
+		$this->plugin_file = $plugin_file;
+
+		$this->setup_constants();
+		$this->includes();
+
+		$this->roles     = new EDD_Roles();
+		$this->api       = new EDD_API();
+		$this->session   = new EDD_Session();
+		$this->customers = new EDD_DB_Customers();
+	}
+
+
+	/**
+	 * Setup plugin constants
+	 *
+	 * @access private
+	 * @since 2.5
+	 * @return void
+	 */
+	private function setup_constants() {
+
+		// Plugin version
+		define( 'EDD_VERSION', '2.4.3' );
+
+		// Plugin folder path
+		define( 'EDD_PLUGIN_DIR', plugin_dir_path( $this->plugin_file ) );
+
+		// Plugin folder URL
+		define( 'EDD_PLUGIN_URL', plugin_dir_url( $this->plugin_file ) );
+
+		// Plugin root file
+		define( 'EDD_PLUGIN_FILE', $this->plugin_file );
+
+		// Make sure CAL_GREGORIAN is defined
+		if ( ! defined( 'CAL_GREGORIAN' ) ) {
+			define( 'CAL_GREGORIAN', 1 );
+		}
+	}
+
+	/**
+	 * Include required files
+	 *
+	 * @access private
+	 * @since 2.5
+	 * @return void
+	 */
+	private function includes() {
+		global $edd_options;
+		
+		require_once EDD_PLUGIN_DIR . 'includes/admin/settings/register-settings.php';
+		$edd_options = edd_get_settings();
+
+		require_once EDD_PLUGIN_DIR . 'includes/api/class-edd-api.php';
+		require_once EDD_PLUGIN_DIR . 'includes/post-types.php';
+		require_once EDD_PLUGIN_DIR . 'includes/class-edd-db.php';
+		require_once EDD_PLUGIN_DIR . 'includes/class-edd-db-customers.php';
+		require_once EDD_PLUGIN_DIR . 'includes/class-edd-customer.php';
+		require_once EDD_PLUGIN_DIR . 'includes/class-edd-session.php';
+		require_once EDD_PLUGIN_DIR . 'includes/class-edd-roles.php';
+		require_once EDD_PLUGIN_DIR . 'includes/class-edd-stats.php';
+		require_once EDD_PLUGIN_DIR . 'includes/payments/class-payment-stats.php';
+		require_once EDD_PLUGIN_DIR . 'includes/country-functions.php';
+		require_once EDD_PLUGIN_DIR . 'includes/misc-functions.php';
+		require_once EDD_PLUGIN_DIR . 'includes/gateways/functions.php';
+		require_once EDD_PLUGIN_DIR . 'includes/emails/template.php';
+		require_once EDD_PLUGIN_DIR . 'includes/emails/class-edd-emails.php';
+		require_once EDD_PLUGIN_DIR . 'includes/emails/class-edd-email-tags.php';
+
+		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+			require_once EDD_PLUGIN_DIR . 'includes/admin/upload-functions.php';
+			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';
+			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrades.php';
+			require_once EDD_PLUGIN_DIR . 'includes/admin/welcome.php';
+		}
+	}
+}

--- a/includes/install.php
+++ b/includes/install.php
@@ -141,10 +141,10 @@ function edd_install() {
 	update_option( 'edd_default_api_version', 'v' . $api->get_version() );
 
 	// Create the customers database
-	@EDD()->customers->create_table();
+	@EDD_Loader()->customers->create_table();
 
 	// Check for PHP Session support, and enable if available
-	EDD()->session->use_php_sessions();
+	EDD_Loader()->session->use_php_sessions();
 
 	// Add a temporary option to note that EDD pages have been created
 	set_transient( '_edd_installed', $options, 30 );
@@ -197,7 +197,7 @@ function edd_after_install() {
 	}
 
 	// Create the customers database (this ensures it creates it on multisite instances where it is network activated)
-	@EDD()->customers->create_table();
+	@EDD_Loader()->customers->create_table();
 
 	// Delete the transient
 	delete_transient( '_edd_installed' );

--- a/includes/install.php
+++ b/includes/install.php
@@ -173,7 +173,6 @@ function edd_install() {
 	// Add the transient to redirect
 	set_transient( '_edd_activation_redirect', true, 30 );
 }
-register_activation_hook( EDD_PLUGIN_FILE, 'edd_install' );
 
 /**
  * Post-installation


### PR DESCRIPTION
This is a quick run-through of the cleanest way I can think of to migrate EDD to load on `plugins_loaded` without breaking anything. Short version:

Anything that is required during the installation process is moved to a new class `EDD_Loader`. This class is instantiated during the `register_activation_hook` function and in the main `Easy_Digital_Downloads` class. At present, the loader doesn't do much but instantiate the required classes (`EDD_Roles()`, `EDD_API()`, `EDD_Session()` and `EDD_DB_Customers()`), and define the plugin constants.

During the instantiation of the main `Easy_Digital_Downloads` class, the already instantiated classes are passed to the EDD vars rather than re-instantiating them. This allows backward compatibility with anything currently referencing them through `EDD()->whatever->method()`.

The activation hook has been moved from the install.php file into the main plugin file, and now calls a new function, `edd_load_installer` which instantiates the main loader, then runs the existing `edd_install` function.

In my tests, it works flawlessly.

This is a pass at resolving the issue brought up in #2189.