### PR TITLE
Better Customer Links for the Payments Table

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -355,7 +355,7 @@ class EDD_Payment_History_Table extends WP_List_Table {
 		$customer_id = edd_get_payment_customer_id( $payment->ID );
 		$customer    = new EDD_Customer( $customer_id );
 
-		$value = '<a href="' . esc_url( add_query_arg( array( 'user' => urlencode( $customer->email ), 'paged' => false ) ) ) . '">' . $customer->name . '</a>';
+		$value = '<a href="' . esc_url( admin_url( "edit.php?post_type=download&page=edd-customers&view=overview&id=$customer_id" ) ) . '">' . $customer->name . '</a>';
 		return apply_filters( 'edd_payments_table_column', $value, $payment->ID, 'user' );
 	}
 


### PR DESCRIPTION
Right now the links here just bring you to a filtered view of the customers payments. 99% of the time, when on the page, I sort of expect this link to bring you to the customers's profile, which after all contains all of their orders anyways.

![image](https://cloud.githubusercontent.com/assets/1324637/9842327/bd82f374-5a7a-11e5-8a2e-d96b7071043f.png)

This pr fixes it so it does that
Makes for a much better user experience and lets you more easily cross reference data for a customer