### PR TITLE
Only make payments for products who are published

### DIFF
--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -555,6 +555,7 @@ class EDD_CLI extends WP_CLI_Command {
 					'post_type'     => 'download',
 					'orderby'       => 'rand',
 					'order'         => 'ASC',
+					'post_status'   => 'publish',
 					'posts_per_page'=> 1
 				) );
 
@@ -564,6 +565,11 @@ class EDD_CLI extends WP_CLI_Command {
 
 				if( $product->post_type != 'download' ) {
 					WP_CLI::error( __( 'Specified ID is not a product', 'edd' ) );
+					return;
+				}
+
+				if( $product->post_status != 'publish' ) {
+					WP_CLI::error( __( 'Specified ID is not a published', 'edd' ) );
 					return;
 				}
 

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -569,7 +569,7 @@ class EDD_CLI extends WP_CLI_Command {
 				}
 
 				if( $product->post_status != 'publish' ) {
-					WP_CLI::error( __( 'Specified ID is not a published', 'edd' ) );
+					WP_CLI::error( __( 'Specified ID is not published', 'edd' ) );
 					return;
 				}
 


### PR DESCRIPTION
Right now, since there isn't a check for it, running the create payments cli command can make sales of products that aren't published yet. Found while testing 2.5