### PR TITLE
Codestyling and remove html from translations

### DIFF
--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -29,7 +29,7 @@ class EDD_SL_Plugin_Updater {
      * @param string  $_plugin_file Path to the plugin file.
      * @param array   $_api_data    Optional data to send with API calls.
      */
-    function __construct( $_api_url, $_plugin_file, $_api_data = null ) {
+    public function __construct( $_api_url, $_plugin_file, $_api_data = null ) {
         $this->api_url  = trailingslashit( $_api_url );
         $this->api_data = $_api_data;
         $this->name     = plugin_basename( $_plugin_file );
@@ -73,11 +73,11 @@ class EDD_SL_Plugin_Updater {
 
         global $pagenow;
 
-        if( ! is_object( $_transient_data ) ) {
+        if ( ! is_object( $_transient_data ) ) {
             $_transient_data = new stdClass;
         }
 
-        if( 'plugins.php' == $pagenow && is_multisite() ) {
+        if ( 'plugins.php' == $pagenow && is_multisite() ) {
             return $_transient_data;
         }
 
@@ -87,7 +87,7 @@ class EDD_SL_Plugin_Updater {
 
             if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
 
-                if( version_compare( $this->version, $version_info->new_version, '<' ) ) {
+                if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
 
 					if ( empty( $version_info->plugin ) ) {
 						$version_info->plugin = $this->name;
@@ -101,7 +101,6 @@ class EDD_SL_Plugin_Updater {
                 $_transient_data->checked[ $this->name ] = $this->version;
 
             }
-
         }
 
         return $_transient_data;
@@ -115,11 +114,11 @@ class EDD_SL_Plugin_Updater {
      */
     public function show_update_notification( $file, $plugin ) {
 
-        if( ! current_user_can( 'update_plugins' ) ) {
+        if ( ! current_user_can( 'update_plugins' ) ) {
             return;
         }
 
-        if( ! is_multisite() ) {
+        if ( ! is_multisite() ) {
             return;
         }
 
@@ -137,7 +136,7 @@ class EDD_SL_Plugin_Updater {
             $cache_key    = md5( 'edd_plugin_' .sanitize_key( $this->name ) . '_version_info' );
             $version_info = get_transient( $cache_key );
 
-            if( false === $version_info ) {
+            if ( false === $version_info ) {
 
                 $version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug ) );
 
@@ -145,11 +144,11 @@ class EDD_SL_Plugin_Updater {
             }
 
 
-            if( ! is_object( $version_info ) ) {
+            if ( ! is_object( $version_info ) ) {
                 return;
             }
 
-            if( version_compare( $this->version, $version_info->new_version, '<' ) ) {
+            if ( version_compare( $this->version, $version_info->new_version, '<' ) ) {
 
                 $update_cache->response[ $this->name ] = $version_info;
 
@@ -179,18 +178,21 @@ class EDD_SL_Plugin_Updater {
 
             if ( empty( $version_info->download_link ) ) {
                 printf(
-                    __( 'There is a new version of %1$s available. <a target="_blank" class="thickbox" href="%2$s">View version %3$s details</a>.', 'easy-digital-downloads' ),
+                    __( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s.', 'easy-digital-downloads' ),
                     esc_html( $version_info->name ),
-                    esc_url( $changelog_link ),
-                    esc_html( $version_info->new_version )
+                    '<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
+                    esc_html( $version_info->new_version ),
+                    '</a>',
                 );
             } else {
                 printf(
-                    __( 'There is a new version of %1$s available. <a target="_blank" class="thickbox" href="%2$s">View version %3$s details</a> or <a href="%4$s">update now</a>.', 'easy-digital-downloads' ),
+                    __( 'There is a new version of %1$s available. %2$sView version %3$s details%4$s or %5$supdate now%6$s.', 'easy-digital-downloads' ),
                     esc_html( $version_info->name ),
-                    esc_url( $changelog_link ),
+                    '<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
                     esc_html( $version_info->new_version ),
-                    esc_url( wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $this->name, 'upgrade-plugin_' . $this->name ) )
+                    '</a>',
+                    '<a href="' . esc_url( wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $this->name, 'upgrade-plugin_' . $this->name ) ) .'">',
+                    '</a>',
                 );
             }
 
@@ -211,7 +213,6 @@ class EDD_SL_Plugin_Updater {
      */
     function plugins_api_filter( $_data, $_action = '', $_args = null ) {
 
-
         if ( $_action != 'plugin_information' ) {
 
             return $_data;
@@ -229,8 +230,8 @@ class EDD_SL_Plugin_Updater {
             'is_ssl' => is_ssl(),
             'fields' => array(
                 'banners' => false, // These will be supported soon hopefully
-                'reviews' => false
-            )
+                'reviews' => false,
+            ),
         );
 
         $api_response = $this->api_request( 'plugin_information', $to_send );
@@ -275,13 +276,15 @@ class EDD_SL_Plugin_Updater {
 
         $data = array_merge( $this->api_data, $_data );
 
-        if ( $data['slug'] != $this->slug )
+        if ( $data['slug'] != $this->slug ) {
             return;
+        }
 
-        if ( empty( $data['license'] ) )
+        if ( empty( $data['license'] ) ) {
             return;
+        }
 
-        if( $this->api_url == home_url() ) {
+        if ( $this->api_url == home_url() ) {
             return false; // Don't allow a plugin to ping itself
         }
 
@@ -292,7 +295,7 @@ class EDD_SL_Plugin_Updater {
             'item_id'    => isset( $data['item_id'] ) ? $data['item_id'] : false,
             'slug'       => $data['slug'],
             'author'     => $data['author'],
-            'url'        => home_url()
+            'url'        => home_url(),
         );
 
         $request = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );
@@ -312,31 +315,28 @@ class EDD_SL_Plugin_Updater {
 
     public function show_changelog() {
 
-
-        if( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
+        if ( empty( $_REQUEST['edd_sl_action'] ) || 'view_plugin_changelog' != $_REQUEST['edd_sl_action'] ) {
             return;
         }
 
-        if( empty( $_REQUEST['plugin'] ) ) {
+        if ( empty( $_REQUEST['plugin'] ) ) {
             return;
         }
 
-        if( empty( $_REQUEST['slug'] ) ) {
+        if ( empty( $_REQUEST['slug'] ) ) {
             return;
         }
 
-        if( ! current_user_can( 'update_plugins' ) ) {
+        if ( ! current_user_can( 'update_plugins' ) ) {
             wp_die( __( 'You do not have permission to install plugin updates', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
         }
 
         $response = $this->api_request( 'plugin_latest_version', array( 'slug' => $_REQUEST['slug'] ) );
 
-        if( $response && isset( $response->sections['changelog'] ) ) {
+        if ( $response && isset( $response->sections['changelog'] ) ) {
             echo '<div style="background:#fff;padding:10px;">' . $response->sections['changelog'] . '</div>';
         }
 
-
         exit;
     }
-
 }

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -182,7 +182,7 @@ class EDD_SL_Plugin_Updater {
                     esc_html( $version_info->name ),
                     '<a target="_blank" class="thickbox" href="' . esc_url( $changelog_link ) . '">',
                     esc_html( $version_info->new_version ),
-                    '</a>',
+                    '</a>'
                 );
             } else {
                 printf(
@@ -192,7 +192,7 @@ class EDD_SL_Plugin_Updater {
                     esc_html( $version_info->new_version ),
                     '</a>',
                     '<a href="' . esc_url( wp_nonce_url( self_admin_url( 'update.php?action=upgrade-plugin&plugin=' ) . $this->name, 'upgrade-plugin_' . $this->name ) ) .'">',
-                    '</a>',
+                    '</a>'
                 );
             }
 


### PR DESCRIPTION
- Some of the codestyling isn't passing my PHPlint filters
- Moved the HTML for the links out of the translatable string