### PR TITLE
Avoid using HTML tags in translation strings

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -55,7 +55,7 @@ class EDD_Notices {
 		if( stristr( $_SERVER['SERVER_SOFTWARE'], 'nginx' ) && ! get_user_meta( get_current_user_id(), '_edd_nginx_redirect_dismissed', true ) && current_user_can( 'manage_shop_settings' ) ) {
 
 			echo '<div class="error">';
-				echo '<p>' . sprintf( __( 'The download files in <strong>%s</strong> are not currently protected due to your site running on NGINX.', 'easy-digital-downloads' ), edd_get_upload_dir() ) . '</p>';
+				echo '<p>' . sprintf( __( 'The download files in %s are not currently protected due to your site running on NGINX.', 'easy-digital-downloads' ), '<strong>' . edd_get_upload_dir() . '</strong>' ) . '</p>';
 				echo '<p>' . __( 'To protect them, you must add a redirect rule as explained in <a href="http://docs.easydigitaldownloads.com/article/682-protected-download-files-on-nginx">this guide</a>.', 'easy-digital-downloads' ) . '</p>';
 				echo '<p>' . __( 'If you have already added the redirect rule, you may safely dismiss this notice', 'easy-digital-downloads' ) . '</p>';
 				echo '<p><a href="' . add_query_arg( array( 'edd_action' => 'dismiss_notices', 'edd_notice' => 'nginx_redirect' ) ) . '">' . __( 'Dismiss Notice', 'easy-digital-downloads' ) . '</a></p>';
@@ -68,8 +68,8 @@ class EDD_Notices {
 				return; // Bail if we aren't using Apache... nginx doesn't use htaccess!
 
 			echo '<div class="error">';
-				echo '<p>' . sprintf( __( 'The Easy Digital Downloads .htaccess file is missing from <strong>%s</strong>!', 'easy-digital-downloads' ), edd_get_upload_dir() ) . '</p>';
-				echo '<p>' . sprintf( __( 'First, please resave the Misc settings tab a few times. If this warning continues to appear, create a file called ".htaccess" in the <strong>%s</strong> directory, and copy the following into it:', 'easy-digital-downloads' ), edd_get_upload_dir() ) . '</p>';
+				echo '<p>' . sprintf( __( 'The Easy Digital Downloads .htaccess file is missing from %s!', 'easy-digital-downloads' ), '<strong>' . edd_get_upload_dir() . '</strong>' ) . '</p>';
+				echo '<p>' . sprintf( __( 'First, please resave the Misc settings tab a few times. If this warning continues to appear, create a file called ".htaccess" in the %s directory, and copy the following into it:', 'easy-digital-downloads' ), '<strong>' . edd_get_upload_dir() . '</strong>' ) . '</p>';
 				echo '<p><pre>' . edd_get_htaccess_rules() . '</pre>';
 				echo '<p><a href="' . add_query_arg( array( 'edd_action' => 'dismiss_notices', 'edd_notice' => 'htaccess_missing' ) ) . '">' . __( 'Dismiss Notice', 'easy-digital-downloads' ) . '</a></p>';
 			echo '</div>';

--- a/includes/admin/customers/class-customer-table.php
+++ b/includes/admin/customers/class-customer-table.php
@@ -136,9 +136,9 @@ class EDD_Customer_Reports_Table extends WP_List_Table {
 		$user        = ! empty( $item['user_id'] ) ? $item['user_id'] : $item['email'];
 		$view_url    = admin_url( 'edit.php?post_type=download&page=edd-customers&view=overview&id=' . $item['id'] );
 		$actions     = array(
-			'view'   => sprintf( __( '<a href="%s">View</a>', 'easy-digital-downloads' ), $view_url ),
-			'logs'   => sprintf( __( '<a href="%s">Download log</a>', 'easy-digital-downloads' ), admin_url( '/edit.php?post_type=download&page=edd-reports&tab=logs&user=' . urlencode( $user ) ) ),
-			'delete' => sprintf( __( '<a href="%s">Delete</a>', 'easy-digital-downloads' ), admin_url( 'edit.php?post_type=download&page=edd-customers&view=delete&id=' . $item['id'] ) )
+			'view'   => '<a href="' . $view_url . '">' . __( 'View', 'easy-digital-downloads' ) . '</a>',
+			'logs'   => '<a href="' . admin_url( 'edit.php?post_type=download&page=edd-reports&tab=logs&user=' . urlencode( $user ) ) . '">' . __( 'Download log', 'easy-digital-downloads' ) . '</a>',
+			'delete' => '<a href="' . admin_url( 'edit.php?post_type=download&page=edd-customers&view=delete&id=' . $item['id'] ) . '">' . __( 'Delete', 'easy-digital-downloads' ) . '</a>'
 		);
 
 		return '<a href="' . esc_url( $view_url ) . '">' . $name . '</a>' . $this->row_actions( $actions );

--- a/includes/admin/reporting/class-gateway-error-logs-list-table.php
+++ b/includes/admin/reporting/class-gateway-error-logs-list-table.php
@@ -94,7 +94,7 @@ class EDD_Gateway_Error_Log_Table extends WP_List_Table {
 				$data    = substr( $log_message, $serialized, strlen( $log_message ) - 1 );
 
 				echo wpautop( $intro );
-				echo wpautop( __( '<strong>Log data:</strong>', 'easy-digital-downloads' ) );
+				echo '<strong>' . wpautop( __( 'Log data:', 'easy-digital-downloads' ) ) . '</strong>';
 				echo '<div style="word-wrap: break-word;">' . wpautop( $data ) . '</div>';
 			} else {
 				// No serialized data found

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1312,7 +1312,10 @@ function edd_password_callback( $args ) {
  * @return void
  */
 function edd_missing_callback($args) {
-	printf( __( 'The callback function used for the <strong>%s</strong> setting is missing.', 'easy-digital-downloads' ), $args['id'] );
+	printf(
+		__( 'The callback function used for the %s setting is missing.', 'easy-digital-downloads' ),
+		'<strong>' . $args['id'] . '</strong>'
+	);
 }
 
 /**

--- a/includes/admin/welcome.php
+++ b/includes/admin/welcome.php
@@ -320,7 +320,7 @@ class EDD_Welcome {
 
 					<img src="<?php echo EDD_PLUGIN_URL . 'assets/images/screenshots/edit-download.png'; ?>" class="edd-welcome-screenshots"/>
 
-					<h4><?php printf( __( '<a href="%s">%s &rarr; Add New</a>', 'easy-digital-downloads' ), admin_url( 'post-new.php?post_type=download' ), edd_get_label_plural() ); ?></h4>
+					<h4><a href="<?php echo admin_url( 'post-new.php?post_type=download' ) ?>"><?php _e( '%s &rarr; Add New', 'easy-digital-downloads' ); ?></a></h4>
 					<p><?php printf( __( 'The %s menu is your access point for all aspects of your Easy Digital Downloads product creation and setup. To create your first product, simply click Add New and then fill out the product details.', 'easy-digital-downloads' ), edd_get_label_plural() ); ?></p>
 
 					<h4><?php _e( 'Product Price', 'easy-digital-downloads' );?></h4>

--- a/includes/gateways/amazon-payments.php
+++ b/includes/gateways/amazon-payments.php
@@ -272,7 +272,12 @@ final class EDD_Amazon_Payments {
 			'amazon_register' => array(
 				'id'   => 'amazon_register',
 				'name' => __( 'Register with Amazon', 'easy-digital-downloads' ),
-				'desc' => sprintf( __( '<p><a href="%s" class="button" target="_blank">Connect Easy Digital Downloads to Amazon</a></p><p class="description">Once registration is complete, enter your API credentials below.</p>', 'easy-digital-downloads' ), $this->get_registration_url() ),
+				'desc' => '<p><a href="' . $this->get_registration_url() . '" class="button" target="_blank">' .
+						__( 'Connect Easy Digital Downloads to Amazon', 'easy-digital-downloads' ) .
+						'</a></p>' .
+						'<p class="description">' .
+						__( 'Once registration is complete, enter your API credentials below.', 'easy-digital-downloads' ) .
+						'</p>',
 				'type' => 'descriptive_text',
 			),
 			'amazon_seller_id' => array(


### PR DESCRIPTION
In the next version of WordPress (4.4), we fixed many translation strings that used html tags.

See: https://core.trac.wordpress.org/query?milestone=4.4&component=I18N&reporter=ramiy&group=milestone&col=id&col=summary&col=milestone&col=type&col=priority&col=component&col=severity&col=resolution&order=priority

The same thing should be done in EDD.