### PR TITLE
Fix broken test (due to typo being fixed)

### DIFF
--- a/tests/tests-stats.php
+++ b/tests/tests-stats.php
@@ -127,7 +127,7 @@ class Tests_Stats extends WP_UnitTestCase {
 			'this_month'   => 'This Month',
 			'last_month'   => 'Last Month',
 			'this_quarter' => 'This Quarter',
-			'last_quarter' => 'Last Quater',
+			'last_quarter' => 'Last Quarter',
 			'this_year'    => 'This Year',
 			'last_year'    => 'Last Year'
 		);


### PR DESCRIPTION
Hi!

Long time since my last commit, have been quite busy! Trying to pick it back up..

Noticed the tests were failling locally and with other PRs, probably due to a typo that has been fixed.
This fixes the broken unit test.