### PR TITLE
Fix test warnings, removing useless 'use \CLASS'

### DIFF
--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -1,11 +1,8 @@
 <?php
 
-use \EDD_Roles;
-
 /**
  * @group edd_api
  */
-
 class Tests_API extends WP_UnitTestCase {
 	protected $_rewrite = null;
 

--- a/tests/tests-emails.php
+++ b/tests/tests-emails.php
@@ -1,7 +1,5 @@
 <?php
 
-use \EDD_Email_Template_Tags;
-
 /**
  * @group edd_emails
  */

--- a/tests/tests-payments.php
+++ b/tests/tests-payments.php
@@ -1,6 +1,5 @@
 <?php
 
-use \EDD_Payments_Query;
 /**
  * @group edd_payments
  */

--- a/tests/tests-roles.php
+++ b/tests/tests-roles.php
@@ -1,7 +1,5 @@
 <?php
 
-use \EDD_Roles;
-
 /**
  * @group edd_roles
  */

--- a/tests/tests-stats.php
+++ b/tests/tests-stats.php
@@ -1,8 +1,5 @@
 <?php
 
-use \EDD_Stats;
-use \EDD_Payment_Stats;
-use \WP_Error;
 /**
  * @group edd_stats
  */


### PR DESCRIPTION
This may be related to my specific PHPUnit version, as I didn't see it on any of the TravisCI tests so far, but it seems like a improvements.

I was getting these warnings:
![image](https://cloud.githubusercontent.com/assets/5774447/10307981/19b7bafc-6c33-11e5-81db-a5081c875655.png)

Which is fixed in this PR. 

Importing classes from the global namespace without any alias doesn't have any purpose as far as I know :smile_cat:  