### PR TITLE
Change capability for the Tools page

### DIFF
--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -37,7 +37,7 @@ function edd_add_options_link() {
 	$edd_discounts_page     = add_submenu_page( 'edit.php?post_type=download', __( 'Discount Codes', 'easy-digital-downloads' ), __( 'Discount Codes', 'easy-digital-downloads' ), 'manage_shop_discounts', 'edd-discounts', 'edd_discounts_page' );
 	$edd_reports_page       = add_submenu_page( 'edit.php?post_type=download', __( 'Earnings and Sales Reports', 'easy-digital-downloads' ), __( 'Reports', 'easy-digital-downloads' ), 'view_shop_reports', 'edd-reports', 'edd_reports_page' );
 	$edd_settings_page      = add_submenu_page( 'edit.php?post_type=download', __( 'Easy Digital Download Settings', 'easy-digital-downloads' ), __( 'Settings', 'easy-digital-downloads' ), 'manage_shop_settings', 'edd-settings', 'edd_options_page' );
-	$edd_tools_page         = add_submenu_page( 'edit.php?post_type=download', __( 'Easy Digital Download Info and Tools', 'easy-digital-downloads' ), __( 'Tools', 'easy-digital-downloads' ), 'install_plugins', 'edd-tools', 'edd_tools_page' );
+	$edd_tools_page         = add_submenu_page( 'edit.php?post_type=download', __( 'Easy Digital Download Info and Tools', 'easy-digital-downloads' ), __( 'Tools', 'easy-digital-downloads' ), 'manage_shop_settings', 'edd-tools', 'edd_tools_page' );
 	$edd_add_ons_page       = add_submenu_page( 'edit.php?post_type=download', __( 'Easy Digital Download Extensions', 'easy-digital-downloads' ), __( 'Extensions', 'easy-digital-downloads' ), 'install_plugins', 'edd-addons', 'edd_add_ons_page' );
 	$edd_upgrades_screen    = add_submenu_page( null, __( 'EDD Upgrades', 'easy-digital-downloads' ), __( 'EDD Upgrades', 'easy-digital-downloads' ), 'manage_shop_settings', 'edd-upgrades', 'edd_upgrades_screen' );
 


### PR DESCRIPTION
The reason for this change is that the tools page is hidden when the constant `DISALLOW_FILE_MODS` is defined. This is a bigger issue for me as the fraud monitor settings are in the tools page. 

There does not seem to be any reason to limit the access to those who can install plugins. 