### PR TITLE
Disable add to cart button during ajax request

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -85,6 +85,9 @@ jQuery(document).ready(function ($) {
 
 		var $this = $(this), form = $this.closest('form');
 
+		// Disable button, preventing rapid additions to cart during ajax request
+		$this.prop('disabled', true);
+
 		var $spinner = $this.find('.edd-loading');
 		var container = $this.closest('div');
 
@@ -241,6 +244,9 @@ jQuery(document).ready(function ($) {
 							$('.edd-cart-added-alert', container).fadeOut();
 						}, 3000);
 					}
+
+					// Re-enable the add to cart button
+					$this.prop('disabled', false);
 
 					$('body').trigger('edd_cart_item_added', [ response ]);
 


### PR DESCRIPTION
Disable the add to cart button during ajax requests to prevent items from being added multiple times due to user rapidly clicking the button (issue #3927). The add to cart button is re-enabled when the ajax request is complete, so that it can be used again in the event that the user removes the item from the cart and then needs to re-add it.