### PR TITLE
Add Wairarapa to New Zealand regions

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -868,6 +868,7 @@ function edd_get_new_zealand_states_list() {
 		'TK' => 'Taranaki',
 		'TM' => 'Tasman',
 		'WA' => 'Waikato',
+		'WR' => 'Wairarapa',
 		'WE' => 'Wellington',
 		'WC' => 'West Coast'
 	);


### PR DESCRIPTION
I just had a customer tell me that their credit card billing address is in Wairarapa, which is missing from the states list in New Zealand.