### PR TITLE
Multiple reverse proxy IPs in $_SERVER['HTTP_X_FORWARDED_FOR']

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ $RECYCLE.BIN/
 
 # PhpStorm
 .idea
+Easy-Digital-Downloads.iml
 
 # Eclipse
 *.pydevproject

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -169,7 +169,9 @@ function edd_get_ip() {
 		$ip = $_SERVER['HTTP_CLIENT_IP'];
 	} elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 		//to check ip is pass from proxy
-		$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+		// can include more than 1 ip, first is the public one
+		$ip = explode(',',$_SERVER['HTTP_X_FORWARDED_FOR']);
+		$ip = trim($ip[0]);
 	} elseif( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
 		$ip = $_SERVER['REMOTE_ADDR'];
 	}

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -51,6 +51,19 @@ class Test_Misc extends WP_UnitTestCase {
 		$this->assertEquals( '127.0.0.1', edd_get_ip() );
 	}
 
+	public function test_get_ip_reverse_proxies() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '123.123.123.123, 10.0.0.2';
+		$this->assertEquals( '123.123.123.123', edd_get_ip() );
+		unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+	}
+
+	public function test_get_ip_reverse_proxy() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '123.123.123.123';
+		$this->assertEquals( '123.123.123.123', edd_get_ip() );
+		unset($_SERVER['HTTP_X_FORWARDED_FOR']);
+	}
+
+
 	public function test_get_currencies() {
 		$expected = array(
 			'USD'  => __( 'US Dollars (&#36;)', 'easy-digital-downloads' ),


### PR DESCRIPTION
In situations where there are multiple reverse proxies, there will be multiple IPs stored in $_SERVER['HTTP_X_FORWARDED_FOR']. 
