### PR TITLE
Moved click handler on purchase submission to a named function.

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -16,7 +16,7 @@ jQuery(document).ready(function ($) {
 				cart_item: item
 			};
 
-		 $.ajax({
+		$.ajax({
 			type: "POST",
 			data: data,
 			dataType: "json",
@@ -118,7 +118,7 @@ jQuery(document).ready(function ($) {
 				}
 			} else {
 				if( ! form.find('.edd_price_option_' + download + ':checked', form).length ) {
-					 // hide the spinner
+					// hide the spinner
 					$this.removeAttr( 'data-edd-loading' );
 					alert( edd_scripts.select_option );
 					return;
@@ -334,7 +334,9 @@ jQuery(document).ready(function ($) {
 		}, 200);
 	}
 
-	$(document).on('click', '#edd_purchase_form #edd_purchase_submit input[type=submit]', function(e) {
+	$(document).on('click', '#edd_purchase_form #edd_purchase_submit input[type=submit]', 'edd_click_event_on_purchase_submit');
+
+	function edd_click_event_on_purchase_submit(e) {
 
 		var eddPurchaseform = document.getElementById('edd_purchase_form');
 
@@ -364,8 +366,7 @@ jQuery(document).ready(function ($) {
 			}
 		});
 
-	});
-
+	}
 });
 
 function edd_load_gateway( payment_mode ) {

--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -336,38 +336,39 @@ jQuery(document).ready(function ($) {
 
 	$(document).on('click', '#edd_purchase_form #edd_purchase_submit input[type=submit]', 'edd_click_event_on_purchase_submit');
 
-	function edd_click_event_on_purchase_submit(e) {
-
-		var eddPurchaseform = document.getElementById('edd_purchase_form');
-
-		if( typeof eddPurchaseform.checkValidity === "function" && false === eddPurchaseform.checkValidity() ) {
-			return;
-		}
-
-		e.preventDefault();
-
-		var complete_purchase_val = $(this).val();
-
-		$(this).val(edd_global_vars.purchase_loading);
-
-		$(this).after('<span class="edd-cart-ajax"><i class="edd-icon-spinner edd-icon-spin"></i></span>');
-
-		$.post(edd_global_vars.ajaxurl, $('#edd_purchase_form').serialize() + '&action=edd_process_checkout&edd_ajax=true', function(data) {
-			if ( $.trim(data) == 'success' ) {
-				$('.edd_errors').remove();
-				$('.edd-error').hide();
-				$(eddPurchaseform).submit();
-			} else {
-				$('#edd-purchase-button').val(complete_purchase_val);
-				$('.edd-cart-ajax').remove();
-				$('.edd_errors').remove();
-				$('.edd-error').hide();
-				$('#edd_purchase_submit').before(data);
-			}
-		});
-
-	}
 });
+
+function edd_click_event_on_purchase_submit(e) {
+
+	var eddPurchaseform = document.getElementById('edd_purchase_form');
+
+	if( typeof eddPurchaseform.checkValidity === "function" && false === eddPurchaseform.checkValidity() ) {
+		return;
+	}
+
+	e.preventDefault();
+
+	var complete_purchase_val = $(this).val();
+
+	$(this).val(edd_global_vars.purchase_loading);
+
+	$(this).after('<span class="edd-cart-ajax"><i class="edd-icon-spinner edd-icon-spin"></i></span>');
+
+	$.post(edd_global_vars.ajaxurl, $('#edd_purchase_form').serialize() + '&action=edd_process_checkout&edd_ajax=true', function(data) {
+		if ( $.trim(data) == 'success' ) {
+			$('.edd_errors').remove();
+			$('.edd-error').hide();
+			$(eddPurchaseform).submit();
+		} else {
+			$('#edd-purchase-button').val(complete_purchase_val);
+			$('.edd-cart-ajax').remove();
+			$('.edd_errors').remove();
+			$('.edd-error').hide();
+			$('#edd_purchase_submit').before(data);
+		}
+	});
+
+}
 
 function edd_load_gateway( payment_mode ) {
 


### PR DESCRIPTION
I am working on a payment gateway and it is important i temporarily off (.off) the click handler that is run when the purchase submit button is clicked and then on (.on)  and trigger it after a our custom JS validation is complete.

I really need this commit merged to proceed with my work.