### PR TITLE
Set in_array check to strict

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -375,7 +375,7 @@ class EDD_HTML_Elements {
 			foreach( $args['options'] as $key => $option ) {
 
 				if( $args['multiple'] && is_array( $args['selected'] ) ) {
-					$selected = selected( true, in_array( $key, $args['selected'] ), false );
+					$selected = selected( true, in_array( $key, $args['selected'], true ), false );
 				} else {
 					$selected = selected( $args['selected'], $key, false );
 				}


### PR DESCRIPTION
I wanted to add another select field and came across a problem that the placeholder text was being added as a selected item once I selected an option.

This was not happening in the bundle option as the values were numbers but in my case I needed to values to be text.
![image](https://cloud.githubusercontent.com/assets/1785641/11368637/26f2633a-92bb-11e5-959e-60f6ff5093af.png)
![image](https://cloud.githubusercontent.com/assets/1785641/11368664/555d8bb4-92bb-11e5-96fd-eae7e9267cad.png)


The following will return `1`
```php
$array[0] = 'abc';
echo in_array( 0, $array );
```
Where as the following will not return a result.
```php
$array[0] = '123';
echo in_array( 0, $array );
```

By setting the check to strict the result will be the same for both situations.

P.s. You may want to think about making all of the checks strict.