### PR TITLE
Pass selected country to the edd_shop_states filter

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -462,7 +462,7 @@ function edd_ajax_get_states_field() {
 			'name'    => $_POST['field_name'],
 			'id'      => $_POST['field_name'],
 			'class'   => $_POST['field_name'] . '  edd-select',
-			'options' => edd_get_shop_states( $_POST['country'] ),
+			'options' => $states,
 			'show_option_all'  => false,
 			'show_option_none' => false
 		);

--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  */
 function edd_get_shop_country() {
 	$country = edd_get_option( 'base_country', 'US' );
-	
+
 	return apply_filters( 'edd_shop_country', $country );
 }
 
@@ -42,8 +42,8 @@ function edd_get_shop_state() {
  *
  * @since 1.6
  *
- * @param null $country
- * @return mixed|void  A list of states for the shop's base country
+ * @param string $country
+ * @return array A list of states for the selected country
  */
 function edd_get_shop_states( $country = null ) {
 	if( empty( $country ) )
@@ -126,7 +126,7 @@ function edd_get_shop_states( $country = null ) {
 
 	endswitch;
 
-	return apply_filters( 'edd_shop_states', $states );
+	return apply_filters( 'edd_shop_states', $states, $country );
 }
 
 


### PR DESCRIPTION
Makes it possible to add custom states without modifying core.
```php
function custom_edd_states($states, $country) {
    if(empty($states) && $country === 'AR') {
        $states['BA'] = 'Buenos Aires';
        $states['EA'] = 'Mendoza';
    }

    return $states;
}
add_filter('edd_shop_states', 'custom_edd_states', 10, 2);
```