### PR TITLE
Lowercase "e" for the schedule_events method in EDD_Cron class

### DIFF
--- a/includes/class-edd-cron.php
+++ b/includes/class-edd-cron.php
@@ -28,7 +28,7 @@ class EDD_Cron {
 	 */
 	public function __construct() {
 		add_filter( 'cron_schedules', array( $this, 'add_schedules'   ) );
-		add_action( 'wp',             array( $this, 'schedule_Events' ) );
+		add_action( 'wp',             array( $this, 'schedule_events' ) );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class EDD_Cron {
 	 * @since 1.6
 	 * @return void
 	 */
-	public function schedule_Events() {
+	public function schedule_events() {
 		$this->weekly_events();
 		$this->daily_events();
 	}


### PR DESCRIPTION
I'm not sure why it was capitalized but I standardized it to match other methods in the class