### PR TITLE
Standardize "Zip / Postal Code" string

### DIFF
--- a/includes/admin/reporting/class-export-payments.php
+++ b/includes/admin/reporting/class-export-payments.php
@@ -68,7 +68,7 @@ class EDD_Payments_Export extends EDD_Export {
 			'city'     => __( 'City', 'easy-digital-downloads' ),
 			'state'    => __( 'State', 'easy-digital-downloads' ),
 			'country'  => __( 'Country', 'easy-digital-downloads' ),
-			'zip'      => __( 'Zip Code', 'easy-digital-downloads' ),
+			'zip'      => __( 'Zip / Postal Code', 'easy-digital-downloads' ),
 			'products' => __( 'Products', 'easy-digital-downloads' ),
 			'skus'     => __( 'SKUs', 'easy-digital-downloads' ),
 			'amount'   => __( 'Amount', 'easy-digital-downloads' ) . ' (' . html_entity_decode( edd_currency_filter( '' ) ) . ')',

--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -47,7 +47,7 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 			'city'     => __( 'City', 'easy-digital-downloads' ),
 			'state'    => __( 'State', 'easy-digital-downloads' ),
 			'country'  => __( 'Country', 'easy-digital-downloads' ),
-			'zip'      => __( 'Zip Code', 'easy-digital-downloads' ),
+			'zip'      => __( 'Zip / Postal Code', 'easy-digital-downloads' ),
 			'products' => __( 'Products', 'easy-digital-downloads' ),
 			'skus'     => __( 'SKUs', 'easy-digital-downloads' ),
 			'amount'   => __( 'Amount', 'easy-digital-downloads' ) . ' (' . html_entity_decode( edd_currency_filter( '' ) ) . ')',

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -362,7 +362,7 @@ function edd_default_cc_address_fields() {
 				<?php } ?>
 			</label>
 			<span class="edd-description"><?php _e( 'The zip or postal code for your billing address.', 'easy-digital-downloads' ); ?></span>
-			<input type="text" size="4" name="card_zip" class="card-zip edd-input<?php if( edd_field_is_required( 'card_zip' ) ) { echo ' required'; } ?>" placeholder="<?php _e( 'Zip / Postal code', 'easy-digital-downloads' ); ?>" value="<?php echo $customer['address']['zip']; ?>"/>
+			<input type="text" size="4" name="card_zip" class="card-zip edd-input<?php if( edd_field_is_required( 'card_zip' ) ) { echo ' required'; } ?>" placeholder="<?php _e( 'Zip / Postal Code', 'easy-digital-downloads' ); ?>" value="<?php echo $customer['address']['zip']; ?>"/>
 		</p>
 		<p id="edd-card-country-wrap">
 			<label for="billing_country" class="edd-label">


### PR DESCRIPTION
Instead of having "Zip / Postal code" with a small "c" and "Zip Code" to have only "Zip / Postal Code". This reduces the number of strings slightly.

"Zip / Postal Code" already exists as a string.