### PR TITLE
Add filter for $edd_receipt_args

### DIFF
--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -4,7 +4,8 @@
  */
 global $edd_receipt_args;
 
-$payment   = get_post( $edd_receipt_args['id'] );
+$edd_receipt_args = apply_filters( 'edd_receipt_args', $edd_receipt_args );
+$payment          = get_post( $edd_receipt_args['id'] );
 
 if( empty( $payment ) ) : ?>
 


### PR DESCRIPTION
I would like to remove the discount from the purchase confirmation page. I could copy the template to my child theme and make the changes there. I don't really want to do this as this template is quite large and I will miss out of changes in future update.

With the filter I could remove the discount code and then the check below will return false and not show the discount field.