### PR TITLE
Always show reports and logs navigation

### DIFF
--- a/includes/admin/reporting/class-api-requests-logs-list-table.php
+++ b/includes/admin/reporting/class-api-requests-logs-list-table.php
@@ -302,4 +302,15 @@ class EDD_API_Request_Log_Table extends WP_List_Table {
 			)
 		);
 	}
+
+	/**
+	 * Since our "bulk actions" are navigational, we want them to always show, not just when there's items
+	 *
+	 * @access public
+	 * @since 2.5
+	 * @return bool
+	 */
+	public function has_items() {
+		return true;
+	}
 }

--- a/includes/admin/reporting/class-file-downloads-logs-list-table.php
+++ b/includes/admin/reporting/class-file-downloads-logs-list-table.php
@@ -438,4 +438,15 @@ class EDD_File_Downloads_Log_Table extends WP_List_Table {
 			)
 		);
 	}
+
+	/**
+	 * Since our "bulk actions" are navigational, we want them to always show, not just when there's items
+	 *
+	 * @access public
+	 * @since 2.5
+	 * @return bool
+	 */
+	public function has_items() {
+		return true;
+	}
 }

--- a/includes/admin/reporting/class-gateway-error-logs-list-table.php
+++ b/includes/admin/reporting/class-gateway-error-logs-list-table.php
@@ -217,4 +217,15 @@ class EDD_Gateway_Error_Log_Table extends WP_List_Table {
 			)
 		);
 	}
+
+	/**
+	 * Since our "bulk actions" are navigational, we want them to always show, not just when there's items
+	 *
+	 * @access public
+	 * @since 2.5
+	 * @return bool
+	 */
+	public function has_items() {
+		return true;
+	}
 }

--- a/includes/admin/reporting/class-sales-logs-list-table.php
+++ b/includes/admin/reporting/class-sales-logs-list-table.php
@@ -354,4 +354,15 @@ class EDD_Sales_Log_Table extends WP_List_Table {
 			)
 		);
 	}
+
+	/**
+	 * Since our "bulk actions" are navigational, we want them to always show, not just when there's items
+	 *
+	 * @access public
+	 * @since 2.5
+	 * @return bool
+	 */
+	public function has_items() {
+		return true;
+	}
 }


### PR DESCRIPTION
Currently the method for switching between different reports and logs views in EDD is to choose a view from the select field in the bulk actions part of `WP_List_Table`. The problem with this is that bulk actions only display if there are items to show in the table which results in users losing their navigation if they select a view that contains no entries.

This solution ensures that the navigation will always display by simply setting the `has_items()` method to `true` no matter what on the tables that require bulk actions regardless of whether items exist.

Resolves #4092 