### PR TITLE
Fix earnings by category report page

### DIFF
--- a/includes/admin/reporting/class-categories-reports-table.php
+++ b/includes/admin/reporting/class-categories-reports-table.php
@@ -33,7 +33,12 @@ class EDD_Categories_Reports_Table extends WP_List_Table {
 	 * @see WP_List_Table::__construct()
 	 */
 	public function __construct() {
-		global $status, $page;
+		// Set parent defaults
+		parent::__construct( array(
+			'singular'  => __( 'Earnings', 'edd' ),     // Singular name of the listed records
+			'plural'    => __( 'Earnings', 'edd' ),     // Plural name of the listed records
+			'ajax'      => false             			// Does this table support ajax?
+		) );
 	}
 
 	/**


### PR DESCRIPTION
Currently the "earnings by category" fails. This is possibly a WP 4.4+ only issue, although I haven't tried on previous to confirm I'm afraid. 

Backtrace below is from HHVM - although I've verified the same error occurs under PHP. 

Fatal error: Uncaught exception 'BadMethodCallException' with message 'Call to a member function render_screen_reader_content() on a non-object (null)' in /var/www/plugins/wp-admin/includes/class-wp-list-table.php:1128\nStack trace:\n
#0 /var/www/plugins/wp-content/plugins/easy-digital-downloads/includes/admin/reporting/reports.php(258): WP_List_Table->display()\n
#1 /var/www/plugins/wp-includes/plugin.php(525): edd_reports_categories()\n
#2 /var/www/plugins/wp-content/plugins/easy-digital-downloads/includes/admin/reporting/reports.php(106): do_action()\n
#3 /var/www/plugins/wp-includes/plugin.php(525): edd_reports_tab_reports()\n
#4 /var/www/plugins/wp-content/plugins/easy-digital-downloads/includes/admin/reporting/reports.php(39): do_action()\n
#5 /var/www/plugins/wp-includes/plugin.php(525): edd_reports_page()\n
#6 /var/www/plugins/wp-admin/admin.php(236): do_action()\n
#7 /var/www/plugins/wp-admin/edit.php(10): include()\n#8 {main}

Patch attached which resolves this. 