### PR TITLE
Fix test constants plugin folder path check

### DIFF
--- a/tests/tests-easy-digital-downloads.php
+++ b/tests/tests-easy-digital-downloads.php
@@ -27,7 +27,9 @@ class Tests_EDD extends WP_UnitTestCase {
 
 		// Plugin Folder Path
 		$path = str_replace( 'tests/', '', plugin_dir_path( __FILE__ ) );
-		$this->assertSame( EDD_PLUGIN_DIR, $path );
+		$path = substr( $path, 0, -1 );
+		$edd  = substr( EDD_PLUGIN_DIR, 0, -1 );
+		$this->assertSame( $edd, $path );
 
 		// Plugin Root File
 		$path = str_replace( 'tests/', '', plugin_dir_path( __FILE__ ) );


### PR DESCRIPTION
On a Windows environment this unit test will fail. 

This is purely a problem with phpunit and not an actual bug in EDD.

What happens is Windows sees the EDD constant declaration and ends the path with a "/" whereas the unit test declaration path ends in "\". This is simply a result of PHPUnit's path being called in a folder above the file versus the original file. In EDD since the constant is declared once, as it's a constant, this isn't a problem. The path removes the last character of each path, allowing the test to pass on Windows.