### PR TITLE
Add JS trigger to for third-party hooks

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -378,6 +378,7 @@ function edd_load_gateway( payment_mode ) {
 		function(response){
 			jQuery('#edd_purchase_form_wrap').html(response);
 			jQuery('.edd-no-js').hide();
+			jQuery('body').trigger('edd_gateway_loaded', [ payment_mode ]);
 		}
 	);
 


### PR DESCRIPTION
References issue #4146.

Adds a third party JS hook, passing in the `payment_mode` the user is loading so third-party JS validation can be performed.

Usage:

```js
// Format CC input using Stripe's jquery.payment library
$('body').on('edd_gateway_loaded', function( event, payment_mode ) {
    if ( 'stripe' === payment_mode) {
        $('input#card_number').payment('formatCardNumber');
    }
});
```