### PR TITLE
Made Sales Log currency-aware

### DIFF
--- a/includes/admin/reporting/class-sales-logs-list-table.php
+++ b/includes/admin/reporting/class-sales-logs-list-table.php
@@ -76,6 +76,9 @@ class EDD_Sales_Log_Table extends WP_List_Table {
 	 */
 	public function column_default( $item, $column_name ) {
 		$return = '';
+		// Use the currency associated with the payment from which each item is
+		// extracted
+		$currency = $item['currency'];
 
 		switch ( $column_name ){
 			case 'download' :
@@ -88,11 +91,11 @@ class EDD_Sales_Log_Table extends WP_List_Table {
 				break;
 
 			case 'item_price' :
-				$return = edd_currency_filter( edd_format_amount( $item['item_price'] ) );
+				$return = edd_currency_filter( edd_format_amount( $item['item_price'] ), $currency );
 				break;
 
 			case 'amount' :
-				$return = edd_currency_filter( edd_format_amount( $item['amount'] / $item['quantity'] ) );
+				$return = edd_currency_filter( edd_format_amount( $item['amount'] / $item['quantity'] ), $currency );
 				break;
 
 			case 'payment_id' :
@@ -344,6 +347,8 @@ class EDD_Sales_Log_Table extends WP_List_Table {
 							'user_name'  => $user_info['first_name'] . ' ' . $user_info['last_name'],
 							'date'       => get_post_field( 'post_date', $payment_id ),
 							'quantity'   => $item['quantity'],
+							// Keep track of the currency. Vital to produce the correct report
+							'currency'   => $item['currency'],
 						);
 
 					}

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -934,9 +934,15 @@ function edd_get_payment_meta_cart_details( $payment_id, $include_bundle_files =
 	$payment      = new EDD_Payment( $payment_id );
 	$cart_details = $payment->cart_details;
 
+	$payment_currency = $payment->currency;
+
 	if ( ! empty( $cart_details ) && is_array( $cart_details ) ) {
 
 		foreach ( $cart_details as $key => $cart_item ) {
+			// Carry the currency with each item, it's necessary to identify the amounts
+			// correctly (the currency it's an attribute of the payment, but we don'
+			// t have the parent payment in the returned array)
+			$cart_details[ $key ]['currency'] = $payment_currency;
 
 			// Ensure subtotal is set, for pre-1.9 orders
 			if ( ! isset( $cart_item['subtotal'] ) ) {


### PR DESCRIPTION
Target
--
Ensuring that all the rows in the Sales Log show the currency currency symbol.

Changes
--
* Added currency to the data returned by the `edd_get_payment_meta_cart_details()` function.
* Tweaked the Sales Log to use the currency associated with each item.

Why
--
The Sales Log, and practically every other log, calls the `edd_currency_filter()` function without passing a currency. This is imprecise, as the currency associated with a payment may or may not be the "global" one (this is true in multi-currency environements, but also if the admin changes the base currency). Since the log export classes are pretty much hard-coded, it's quite difficult to intercept the call to `edd_currency_filter()` and "sneak in" the correct currency. It's much simpler to do that within the core, as it takes few lines of code, as opposed as multiple "workaround" filters.

The solution is, simply, to use the currency associated with each order, and pass it to the `edd_currency_filter()` function. Since this information is attached to a payment, it's not included by `edd_get_payment_meta_cart_details()`, which just returns the cart items. I tweaked that function as well, so that the currency is attached to each item (it's the same for all of them, anyway), and it can be picked up by the report.

Remarks
--
The solution works correctly both in single and multi-currency environments (the payment currency is a core attribute, which is always returned by `EDD_Payment->currency`. In other words, it doesn't depend on any specific multi-currency implementation.