### PR TITLE
Add missing <p> wrapping payment status drop-down.

### DIFF
--- a/includes/admin/payments/view-order-details.php
+++ b/includes/admin/payments/view-order-details.php
@@ -70,6 +70,7 @@ $currency_code  = $payment->currency;
 										<?php do_action( 'edd_view_order_details_totals_before', $payment_id ); ?>
 
 										<div class="edd-admin-box-inside">
+											<p>
 												<span class="label"><?php _e( 'Status:', 'easy-digital-downloads' ); ?></span>&nbsp;
 												<select name="edd-payment-status" class="medium-text">
 													<?php foreach( edd_get_payment_statuses() as $key => $status ) : ?>


### PR DESCRIPTION
Also affected "Refund Charge in Stripe" checkbox placement.

![image](https://cloud.githubusercontent.com/assets/79667/13119615/f056d5cc-d55e-11e5-8a04-579d81b73411.png)
