### PR TITLE
Widgets admin fix for huge sites

### DIFF
--- a/includes/widgets.php
+++ b/includes/widgets.php
@@ -313,7 +313,7 @@ class EDD_Product_Details_Widget extends WP_Widget {
 		 <?php
 			$args = array(
 				'post_type'      => 'download',
-				'posts_per_page' => -1,
+				'posts_per_page' => 1000,
 				'post_status'    => 'publish',
 			);
 			$downloads = get_posts( $args );


### PR DESCRIPTION
By default, the "Download Details" widget form in the admin area attempts to load every download item into a drop-down. On sites with tens or hundreds of thousands of downloads, this causes wp-admin/widgets.php to break. This proposed change limits the drop-down to 1000 items, as opposed to -1 (no limit).