### PR TITLE
Bug in date_end filter in payment history

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -96,7 +96,7 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 			$args['date_query'] = array(
 				array(
 					'after'     => date( 'Y-n-d H:i:s', strtotime( $this->start ) ),
-					'before'    => date( 'Y-n-d H:i:s', strtotime( $this->end ) ),
+					'before'    => date( 'Y-n-d 23:59:59', strtotime( $this->end ) ),
 					'inclusive' => true
 				)
 			);

--- a/includes/class-edd-stats.php
+++ b/includes/class-edd-stats.php
@@ -520,7 +520,7 @@ class EDD_Stats {
 		if( ! is_wp_error( $this->end_date ) ) {
 
 			if( $this->timestamp ) {
-				$format = 'Y-m-d H:i:s';
+				$format = 'Y-m-d H:i:';
 			} else {
 				$format = 'Y-m-d 23:59:59';
 			}

--- a/includes/class-edd-stats.php
+++ b/includes/class-edd-stats.php
@@ -520,7 +520,7 @@ class EDD_Stats {
 		if( ! is_wp_error( $this->end_date ) ) {
 
 			if( $this->timestamp ) {
-				$format = 'Y-m-d H:i:';
+				$format = 'Y-m-d 00:00:00';
 			} else {
 				$format = 'Y-m-d 23:59:59';
 			}


### PR DESCRIPTION
Wrong end_date condition in payment history. 
As a result the payment history is not showing all purchase made in the selected time frame.

Examples

![Alt text](https://monosnap.com/file/EXuu8ebQcxzUakwbYtSqWXquc5vr8g.png)

![Alt text](https://monosnap.com/file/EUMdDg8Tgg7gbIHQ1KKTN0sxh4EUPU.png)

