### PR TITLE
Wrong end date in payment export function leads to missing payments

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -96,7 +96,7 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 			$args['date_query'] = array(
 				array(
 					'after'     => date( 'Y-n-d H:i:s', strtotime( $this->start ) ),
-					'before'    => date( 'Y-n-d H:i:s', strtotime( $this->end ) ),
+					'before'    => date( 'Y-n-d 00:00:00', strtotime( $this->end ) ),
 					'inclusive' => true
 				)
 			);


### PR DESCRIPTION
End time must be 23:59:59 when the data filter is used or data result gets empty for end day in the time frame. 

Example: 

Filtering data from 10/01/2016 to 10/02/2016 does not contain purchases from 10/02/2016 without that fix. (This should be save as long as it is never be tried to filter by time)

![Alt text](https://monosnap.com/file/uEHbN0wwZemFsReSSwZKWOIZkQc4X6.png)

