### PR TITLE
Add new labels in Downloads list admin page.

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -42,6 +42,9 @@ function edd_setup_edd_post_types() {
 		'set_featured_image'    => __( 'Set %1$s Image', 'easy-digital-downloads' ),
 		'remove_featured_image' => __( 'Remove %1$s Image', 'easy-digital-downloads' ),
 		'use_featured_image'    => __( 'Use as %1$s Image', 'easy-digital-downloads' ),
+		'filter_items_list'     => __( 'Filter %2$s list', 'easy-digital-downloads' ),
+		'items_list_navigation' => __( '%2$s list navigation', 'easy-digital-downloads' ),
+		'items_list'            => __( '%2$s list', 'easy-digital-downloads' ),
 	) );
 
 	foreach ( $download_labels as $key => $value ) {


### PR DESCRIPTION
In issue #4338 there is more info about new `screen-reader-text` labels for Custom Post Types. This PR adds those new labels.