### PR TITLE
Change admin page heading from H2 to H1.

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -60,7 +60,7 @@ function edd_customers_list() {
 	$customers_table->prepare_items();
 	?>
 	<div class="wrap">
-		<h2><?php _e( 'Customers', 'easy-digital-downloads' ); ?></h2>
+		<h1><?php _e( 'Customers', 'easy-digital-downloads' ); ?></h1>
 		<?php do_action( 'edd_customers_table_top' ); ?>
 		<form id="edd-customers-filter" method="get" action="<?php echo admin_url( 'edit.php?post_type=download&page=edd-customers' ); ?>">
 			<?php

--- a/includes/admin/discounts/discount-codes.php
+++ b/includes/admin/discounts/discount-codes.php
@@ -30,7 +30,7 @@ function edd_discounts_page() {
 		$discount_codes_table->prepare_items();
 	?>
 	<div class="wrap">
-		<h2><?php _e( 'Discount Codes', 'easy-digital-downloads' ); ?><a href="<?php echo esc_url( add_query_arg( array( 'edd-action' => 'add_discount' ) ) ); ?>" class="add-new-h2"><?php _e( 'Add New', 'easy-digital-downloads' ); ?></a></h2>
+		<h1><?php _e( 'Discount Codes', 'easy-digital-downloads' ); ?><a href="<?php echo esc_url( add_query_arg( array( 'edd-action' => 'add_discount' ) ) ); ?>" class="add-new-h2"><?php _e( 'Add New', 'easy-digital-downloads' ); ?></a></h1>
 		<?php do_action( 'edd_discounts_page_top' ); ?>
 		<form id="edd-discounts-filter" method="get" action="<?php echo admin_url( 'edit.php?post_type=download&page=edd-discounts' ); ?>">
 			<?php $discount_codes_table->search_box( __( 'Search', 'easy-digital-downloads' ), 'edd-discounts' ); ?>

--- a/includes/admin/payments/payments-history.php
+++ b/includes/admin/payments/payments-history.php
@@ -32,7 +32,7 @@ function edd_payment_history_page() {
 		$payments_table->prepare_items();
 	?>
 	<div class="wrap">
-		<h2><?php echo $edd_payment->labels->menu_name ?></h2>
+		<h1><?php echo $edd_payment->labels->menu_name ?></h1>
 		<?php do_action( 'edd_payments_page_top' ); ?>
 		<form id="edd-payments-filter" method="get" action="<?php echo admin_url( 'edit.php?post_type=download&page=edd-payment-history' ); ?>">
 			<input type="hidden" name="post_type" value="download" />


### PR DESCRIPTION
In all admin pages Core uses now `H1` heading as main heading. This PR changes `H2` heading to `H1`. 

Reference issue is #4339.