### PR TITLE
Logs user out if they're changing their password #4376

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -842,6 +842,9 @@ function edd_process_profile_editor_updates( $data ) {
 
 	if ( $updated ) {
 		do_action( 'edd_user_profile_updated', $user_id, $userdata );
+		if ( isset( $userdata['user_pass'] ) ) {
+			wp_logout();
+		}
 		wp_redirect( add_query_arg( 'updated', 'true', $data['edd_redirect'] ) );
 		edd_die();
 	}


### PR DESCRIPTION
The user is now automatically logged out if they change their password from the Profile Editor and will be redirected back to the back where they will be presented with a log in form.

#4376 