### PR TITLE
EDD_Payment::setup_fees_total with unit tests

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1710,7 +1710,7 @@ final class EDD_Payment {
 	/**
 	 * Setup the payment fees
 	 *
-	 * @since  XXX
+	 * @since  2.5.10
 	 * @return float The fees total for the payment
 	 */
 	private function setup_fees_total() {

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -435,6 +435,7 @@ final class EDD_Payment {
 		// Currency Based
 		$this->total           = $this->setup_total();
 		$this->tax             = $this->setup_tax();
+		$this->fees_total      = $this->setup_fees_total();
 		$this->subtotal        = $this->setup_subtotal();
 		$this->currency        = $this->setup_currency();
 
@@ -1703,6 +1704,26 @@ final class EDD_Payment {
 		}
 
 		return $tax;
+
+	}
+
+	/**
+	 * Setup the payment fees
+	 *
+	 * @since  XXX
+	 * @return float The fees total for the payment
+	 */
+	private function setup_fees_total() {
+		$fees_total = (float) 0.00;
+
+		$payment_fees = isset( $this->payment_meta['fees'] ) ? $this->payment_meta['fees'] : array();
+		if ( ! empty( $payment_fees ) ) {
+			foreach ( $payment_fees as $fee ) {
+				$fees_total += (float) $fee['amount'];
+			}
+		}
+
+		return $fees_total;
 
 	}
 

--- a/tests/tests-payment-class.php
+++ b/tests/tests-payment-class.php
@@ -209,6 +209,10 @@ class Tests_Payment_Class extends WP_UnitTestCase {
 		$this->assertEquals( 125, $payment->total );
 		$payment->save();
 
+		$payment = new EDD_Payment( $this->_payment_id );
+		$this->assertEquals( 5, $payment->fees_total );
+		$this->assertEquals( 125, $payment->total );
+
 		// Test that it saves to the DB
 		$payment_meta = get_post_meta( $this->_payment_id, '_edd_payment_meta', true );
 		$this->assertArrayHasKey( 'fees', $payment_meta );


### PR DESCRIPTION
For #4350, Originally submitted by @dancameron in #4351, just adds unit tests to verify the fix.

I removed the fix and added a unit tests, and it proved a failure. After re-enabling the fix from Dan, the unit tests passed with no errors.