### PR TITLE
Use existing function to build {receipt_link} purchase receipt email tag.

### DIFF
--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -90,7 +90,7 @@ function edd_email_preview_template_tags( $message ) {
 	$message = str_replace( '{sitename}', get_bloginfo( 'name' ), $message );
 	$message = str_replace( '{product_notes}', $notes, $message );
 	$message = str_replace( '{payment_id}', $payment_id, $message );
-	$message = str_replace( '{receipt_link}', sprintf( __( '%1$sView it in your browser.%2$s', 'easy-digital-downloads' ), '<a href="' . esc_url( add_query_arg( array ( 'payment_key' => $receipt_id, 'edd_action' => 'view_receipt' ), home_url() ) ) . '">', '</a>' ), $message );
+	$message = str_replace( '{receipt_link}', edd_email_tag_receipt_link( $payment_id ), $message );
 
 	return wpautop( apply_filters( 'edd_email_preview_template_tags', $message ) );
 }


### PR DESCRIPTION
DRY!

Found this while trying to change the {receipt_link} link text. Looks like I still need to create a custom email tag for that though.