### PR TITLE
Allow payments via PayPal to be refunded in the WordPress admin.

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -441,6 +441,48 @@ function edd_get_registered_settings() {
 						'desc' => __( 'If payments are not getting marked as complete, then check this box. This forces the site to use a slightly less secure method of verifying purchases.', 'easy-digital-downloads' ),
 						'type' => 'checkbox',
 					),
+					'paypal_live_api_username' => array(
+						'id'   => 'paypal_live_api_username',
+						'name' => __( 'Live API Username', 'easy-digital-downloads' ),
+						'desc' => __( 'Your PayPal live API username. Necessary if you want to refund PayPal payments inside the WordPress admin.', 'easy-digital-downloads' ),
+						'type' => 'text',
+						'size' => 'regular'
+					),
+					'paypal_live_api_password' => array(
+						'id'   => 'paypal_live_api_password',
+						'name' => __( 'Live API Password', 'easy-digital-downloads' ),
+						'desc' => __( 'Your PayPal live API password. Necessary if you want to refund PayPal payments inside the WordPress admin.', 'easy-digital-downloads' ),
+						'type' => 'text',
+						'size' => 'regular'
+					),
+					'paypal_live_api_signature' => array(
+						'id'   => 'paypal_live_api_signature',
+						'name' => __( 'Live API Signature', 'easy-digital-downloads' ),
+						'desc' => __( 'Your PayPal live API signature. Necessary if you want to refund PayPal payments inside the WordPress admin.', 'easy-digital-downloads' ),
+						'type' => 'text',
+						'size' => 'regular'
+					),
+					'paypal_test_api_username' => array(
+						'id'   => 'paypal_test_api_username',
+						'name' => __( 'Test API Username', 'easy-digital-downloads' ),
+						'desc' => __( 'Your PayPal test API username. Necessary if you want to refund PayPal payments inside the WordPress admin.', 'easy-digital-downloads' ),
+						'type' => 'text',
+						'size' => 'regular'
+					),
+					'paypal_test_api_password' => array(
+						'id'   => 'paypal_test_api_password',
+						'name' => __( 'Test API Password', 'easy-digital-downloads' ),
+						'desc' => __( 'Your PayPal test API password. Necessary if you want to refund PayPal payments inside the WordPress admin.', 'easy-digital-downloads' ),
+						'type' => 'text',
+						'size' => 'regular'
+					),
+					'paypal_test_api_signature' => array(
+						'id'   => 'paypal_test_api_signature',
+						'name' => __( 'Test API Signature', 'easy-digital-downloads' ),
+						'desc' => __( 'Your PayPal test API signature. Necessary if you want to refund PayPal payments inside the WordPress admin.', 'easy-digital-downloads' ),
+						'type' => 'text',
+						'size' => 'regular'
+					),
 				),
 			)
 		),


### PR DESCRIPTION
Merry Christmas from myself and all the other devs at Awesome Motive. :-)

See issue #4403 for more info.

This code allows you to refund payments made with PayPal Standard or PayPal Express right inside of the WordPress admin, just like how Stripe refunds work. It works with both sandbox and live transactions. You simply need to add your live/test PayPal API credentials in the PayPal Standard settings area.

Hooks and filters are added throughout, and the checking process is very thorough. We have been using this in production on OptinMonster, Soliloquy and Envira for 10+ months, so it is battle tested and works well. Refund IDs are stored as a note once it is confirmed that the transaction has been successfully refunded. Should an error occur during the process, we print out a note and let the user know exactly what went wrong and guide them to refund in the PayPal interface.

One thing to note: **this does work with sandbox transactions, but you do need to have a sandbox account created with the same email as your live account, and you should use those credentials in the admin.** From that point, it doesn't matter which sandbox account you use to test purchases - they will be refunded properly.

Let me know if you have any questions. :-)