### PR TITLE
Fix lack of JS support when ajax is turned off

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -800,7 +800,7 @@ function edd_checkout_submit() {
 		<?php do_action( 'edd_purchase_form_after_submit' ); ?>
 
 		<?php if ( edd_is_ajax_disabled() ) { ?>
-			<p class="edd-cancel"><a href="javascript:history.go(-1)"><?php _e( 'Go back', 'easy-digital-downloads' ); ?></a></p>
+			<p class="edd-cancel"><a href="<?php echo edd_get_checkout_uri(); ?>"><?php _e( 'Go back', 'easy-digital-downloads' ); ?></a></p>
 		<?php } ?>
 	</fieldset>
 <?php


### PR DESCRIPTION
When ajax is turned off, we give a back button from step 2 (checkout fields) to step 1 (gateway selection). Unfortunately, apparently you can't use Javascript to do the redirect when Javascript is disabled. Also the lack of query param stripping means that extensions that depend on edd_get_chosen_gateway() to work will find that there's a mismatch between what that function says the selected gateway is and what the radio buttons have selected (because those fallback to edd_get_default_gateway()). Crossref: https://github.com/chriscct7/edd-gateway-fees/issues/16 1 and 2