### PR TITLE
Allow for the removal of tax from edd_get_cart_item_price

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -406,7 +406,8 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
 
 		if( edd_prices_show_tax_on_checkout() && ! edd_prices_include_tax() ) {
 			$price += edd_get_cart_item_tax( $item_id, $options, $price );
-		} else if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
+		} 
+		if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
 			$price -= edd_get_cart_item_tax( $item_id, $options, $price );
 		}
 

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -405,13 +405,9 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
 	if ( ! edd_is_free_download( $item_id, $price_id ) && ! edd_download_is_tax_exclusive( $item_id ) ) {
 
 		if( edd_prices_show_tax_on_checkout() && ! edd_prices_include_tax() ) {
-
 			$price += edd_get_cart_item_tax( $item_id, $options, $price );
-
-		} if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
-
+		} else if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
 			$price -= edd_get_cart_item_tax( $item_id, $options, $price );
-
 		}
 
 		if( edd_display_tax_rate() ) {
@@ -445,9 +441,10 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
  * @since 1.0
  * @param int   $download_id Download ID number
  * @param array $options Optional parameters, used for defining variable prices
+ * @param bool  $$remove_tax_from_inclusive Remove the tax amount from tax inclusive priced products.
  * @return float|bool Price for this item
  */
-function edd_get_cart_item_price( $download_id = 0, $options = array() ) {
+function edd_get_cart_item_price( $download_id = 0, $options = array(), $remove_tax_from_inclusive = false ) {
 
 	$price = 0;
 	$variable_prices = edd_has_variable_prices( $download_id );
@@ -476,6 +473,11 @@ function edd_get_cart_item_price( $download_id = 0, $options = array() ) {
 		// Get the standard Download price if not using variable prices
 		$price = edd_get_download_price( $download_id );
 	}
+	
+	if ( $remove_tax_from_inclusive && edd_prices_include_tax() ) {
+
+		$price -= edd_get_cart_item_tax( $item_id, $options, $price );
+	}	
 
 	return apply_filters( 'edd_cart_item_price', $price, $download_id, $options );
 }

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -480,7 +480,7 @@ function edd_get_cart_item_price( $download_id = 0, $options = array(), $remove_
 	
 	if ( $remove_tax_from_inclusive && edd_prices_include_tax() ) {
 
-		$price -= edd_get_cart_item_tax( $item_id, $options, $price );
+		$price -= edd_get_cart_item_tax( $download_id, $options, $price );
 	}	
 
 	return apply_filters( 'edd_cart_item_price', $price, $download_id, $options );

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -405,13 +405,13 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
 	if ( ! edd_is_free_download( $item_id, $price_id ) && ! edd_download_is_tax_exclusive( $item_id ) ) {
 
 		if( edd_prices_show_tax_on_checkout() && ! edd_prices_include_tax() ) {
-			
+
 			$price += edd_get_cart_item_tax( $item_id, $options, $price );
-			
+
 		} if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
-			
+
 			$price -= edd_get_cart_item_tax( $item_id, $options, $price );
-			
+
 		}
 
 		if( edd_display_tax_rate() ) {

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -406,8 +406,7 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
 
 		if( edd_prices_show_tax_on_checkout() && ! edd_prices_include_tax() ) {
 			$price += edd_get_cart_item_tax( $item_id, $options, $price );
-		} 
-		if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
+		} if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
 			$price -= edd_get_cart_item_tax( $item_id, $options, $price );
 		}
 

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -445,7 +445,7 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
  * @since 1.0
  * @param int   $download_id Download ID number
  * @param array $options Optional parameters, used for defining variable prices
- * @param bool  $$remove_tax_from_inclusive Remove the tax amount from tax inclusive priced products.
+ * @param bool  $remove_tax_from_inclusive Remove the tax amount from tax inclusive priced products.
  * @return float|bool Price for this item
  */
 function edd_get_cart_item_price( $download_id = 0, $options = array(), $remove_tax_from_inclusive = false ) {

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -405,9 +405,13 @@ function edd_cart_item_price( $item_id = 0, $options = array() ) {
 	if ( ! edd_is_free_download( $item_id, $price_id ) && ! edd_download_is_tax_exclusive( $item_id ) ) {
 
 		if( edd_prices_show_tax_on_checkout() && ! edd_prices_include_tax() ) {
+			
 			$price += edd_get_cart_item_tax( $item_id, $options, $price );
+			
 		} if( ! edd_prices_show_tax_on_checkout() && edd_prices_include_tax() ) {
+			
 			$price -= edd_get_cart_item_tax( $item_id, $options, $price );
+			
 		}
 
 		if( edd_display_tax_rate() ) {


### PR DESCRIPTION
For simplicity, we'll have a cart with 1 product, with an entered cost of $100. 
We've set the global tax rate to 10%, and have an active discount fee of 10%

As in the rest of EDD, we should always calculate tax after discounts.

When item price excludes tax
Total should be ($100 - 10%) * 1.10 = $99
of which the tax amount is ($100 - 10%) *.10 = $9
of which the product amount is ($100 - 10%) * 1 = $90

This part works fine.

Also calculating without taxes works fine. 

So why does this code only not work when prices are entered inclusive of taxes?


When item price includes tax
Raw product amount: ( 100 / 1.10 (this step makes the price exclusive of 10% tax) ) = $90.91 ******
Final raw product amount (post-discount) should be $90.91 - 10% = $81.82
Final product amount should be $81.82 * 1.1 = $90.00
Final tax amount should be $81.82 * .1 = $8.18

Total should be $90.

However, the problem isn't that fee based discount isn't calculating correctly. As a matter of fact, when I substitute the get cart item price function calls for (float) 90.91, this is exactly what I get.

Note also, EDD's discounts should always match the fee based discount. So why does EDD handle both inclusive and exclusive fine, but the fee based discount cannot? 

It all boils down to one function, which at some point has changed. In fact, the docbloc on this function is completely misleading:

If you get the price of an item in the cart using edd_get_cart_item_price. As per the docbloc __this excludes tax always__. Well, unless of course it doesn't at all. In fact, this function doesn't take any sort of taxes into account. So when it claims to always return the price exclusive of tax, this only works for when an EDD site is set to exclude tax because the price entered excludes tax. If you call this function, when you have edd set to include tax, the result is "100.00". This is wrong, because the *actual* product price, exclusive of tax is $90.91. This is why when I substitute the calls to this function for the "90.91" it works.

Moreover, this function has a display function, called edd_cart_item_price(). This function is used to display the price "exclusive of tax". However, as you can see by comparing the functions, the latter actually works as expected. It does take into account that prices can be entered inclusive of taxes, and if that's the case, remove the tax amount. And only then does it format the price (which is unfortunate because otherwise we could just use this function).

So basically, what needs to happen here is EDD needs to correct edd_get_cart_item_price to work like it's supposed to, the way it's described, and the way the display equivalent of it correctly works.

For comparison purposes,
here is the display function, which works: https://github.com/easydigitaldownloads/Easy-Digital-Downloads/blob/f2f1f7db7322f5abe2d5900be0c40895978aed21/includes/cart/functions.php#L393

and here is the non-display function, which doesn't: https://github.com/easydigitaldownloads/Easy-Digital-Downloads/blob/f2f1f7db7322f5abe2d5900be0c40895978aed21/includes/cart/functions.php#L444

In this PR, I've adjusted the former function to have an extra parameter to allow for the removal of the raw tax amount.

While it's unideal to add another parameter to support something that the function claims to do by default, looking through EDD core, unwinding this mess might be more than anyone has bargained for.