### PR TITLE
Let extensions validate fields after a user has been logged in

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -46,6 +46,9 @@ function edd_process_purchase_form() {
 
 	// Validate the user
 	$user = edd_get_purchase_form_user( $valid_data );
+	
+	// Let extensions validate fields after user is logged in if user has used login/registration form
+	do_action( 'edd_checkout_user_error_checks', $user, $valid_data, $_POST );
 
 	if ( false === $valid_data || edd_get_errors() || ! $user ) {
 		if ( $is_ajax ) {


### PR DESCRIPTION
Right now, a couple of our extensions add extra validation to the checkout form.

The problem is that if they rely on knowing the correct user_id, right now, the hook they have to use is before EDD logs in a user if they've used the registration or login forms. To accurately log these users in, we need to add a new hook to let the extensions do this.

I've submitted this to master, as right now, a couple of our extensions have bugs that mean the validation will fail even for valid users, and the sooner we can get this hook out, the better, so the extensions can immediately update and fix this problem.

Additionally, there appears to be a related bug in core in that EDD is not correctly storing the user_id of the user placing an order if the user uses the login/registration forms while checking out (for example with guest checkout disabled). Haven't had time to look into this yet, but it's possible that either EDD isn't saving the correct user_id in the payment post meta, or the customer table isn't getting the user_id, or both.

Working on finding it