### PR TITLE
Store api_request in a transient for 24 hours.

### DIFF
--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -241,11 +241,22 @@ class EDD_SL_Plugin_Updater {
 				'reviews' => false
 			)
 		);
+		
+		//Get the transient where we store the api request for this plugin for 24 hours
+		$edd_api_request_transient = get_site_transient( 'edd_api_request_' . $this->slug );
+			
+		//If we have no transient-saved value, run the API, set a fresh transient with the API value, and return that value too right now.
+		if ( empty( $edd_api_request_transient ) ){ 
 
-		$api_response = $this->api_request( 'plugin_information', $to_send );
-
-		if ( false !== $api_response ) {
-			$_data = $api_response;
+			$api_response = $this->api_request( 'plugin_information', $to_send );
+			
+			//Expires in 1 day (86400 seconds)
+			set_site_transient( 'edd_api_request_' . $this->slug, $api_response, 86400 );
+			
+			if ( false !== $api_response ) {
+				$_data = $api_response;
+			}
+			
 		}
 
 		return $_data;

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -79,7 +79,7 @@ class EDD_SL_Plugin_Updater {
 	public function check_update( $_transient_data ) {
 
 		global $pagenow;
-				
+
 		if( ! is_object( $_transient_data ) ) {
 			$_transient_data = new stdClass;
 		}
@@ -89,7 +89,7 @@ class EDD_SL_Plugin_Updater {
 		}
 
 		if ( empty( $_transient_data->response ) || empty( $_transient_data->response[ $this->name ] ) ) {
-					
+
 			$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug ) );
 
 			if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
@@ -106,7 +106,7 @@ class EDD_SL_Plugin_Updater {
 			}
 
 		}
-		
+
 		return $_transient_data;
 
 	}
@@ -135,7 +135,7 @@ class EDD_SL_Plugin_Updater {
 		remove_filter( 'pre_set_site_transient_update_plugins', array( $this, 'check_update' ), 10 );
 
 		$update_cache = get_site_transient( 'update_plugins' );
-		
+
 		$update_cache = is_object( $update_cache ) ? $update_cache : new stdClass();
 
 		if ( empty( $update_cache->response ) || empty( $update_cache->response[ $this->name ] ) ) {
@@ -242,22 +242,24 @@ class EDD_SL_Plugin_Updater {
 				'reviews' => false
 			)
 		);
-		
+
+		$cache_key = 'edd_api_request_' . substr( md5( serialize( $this->slug ) ), 0, 15 );
+
 		//Get the transient where we store the api request for this plugin for 24 hours
-		$edd_api_request_transient = get_site_transient( 'edd_api_request_' . $this->slug );
-			
+		$edd_api_request_transient = get_site_transient( $cache_key );
+
 		//If we have no transient-saved value, run the API, set a fresh transient with the API value, and return that value too right now.
-		if ( empty( $edd_api_request_transient ) ){ 
+		if ( empty( $edd_api_request_transient ) ){
 
 			$api_response = $this->api_request( 'plugin_information', $to_send );
-			
+
 			//Expires in 1 day
-			set_site_transient( 'edd_api_request_' . 'edd_api_request_' . substr( md5( serialize( $this->slug ) ), 0, 15 ), $api_response, DAY_IN_SECONDS );
-			
+			set_site_transient( $cache_key, $api_response, DAY_IN_SECONDS );
+
 			if ( false !== $api_response ) {
 				$_data = $api_response;
 			}
-			
+
 		}
 
 		return $_data;

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -262,8 +262,8 @@ class EDD_SL_Plugin_Updater {
 
 			$api_response = $this->api_request( 'plugin_information', $to_send );
 			
-			//Expires in 1 day (86400 seconds)
-			set_site_transient( 'edd_api_request_' . $this->slug, $api_response, 86400 );
+			//Expires in 1 day
+			set_site_transient( 'edd_api_request_' . $this->slug, $api_response, DAY_IN_SECONDS );
 			
 			if ( false !== $api_response ) {
 				$_data = $api_response;

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -79,35 +79,47 @@ class EDD_SL_Plugin_Updater {
 	public function check_update( $_transient_data ) {
 
 		global $pagenow;
-
-		if( ! is_object( $_transient_data ) ) {
-			$_transient_data = new stdClass;
-		}
-
-		if( 'plugins.php' == $pagenow && is_multisite() ) {
-			return $_transient_data;
-		}
-
-		if ( empty( $_transient_data->response ) || empty( $_transient_data->response[ $this->name ] ) ) {
-
-			$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug ) );
-
-			if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
-
-				if( version_compare( $this->version, $version_info->new_version, '<' ) ) {
-
-					$_transient_data->response[ $this->name ] = $version_info;
-
-				}
-
-				$_transient_data->last_checked = time();
-				$_transient_data->checked[ $this->name ] = $this->version;
-
+		
+		global $edd_update_plugins_flag;
+	
+		//If flag is true, this is our second go around with pre_set_site_transient_update_plugins
+		if ( $edd_update_plugins_flag ){
+			
+			if( ! is_object( $_transient_data ) ) {
+				$_transient_data = new stdClass;
 			}
-
+	
+			if( 'plugins.php' == $pagenow && is_multisite() ) {
+				return $_transient_data;
+			}
+	
+			if ( empty( $_transient_data->response ) || empty( $_transient_data->response[ $this->name ] ) ) {
+	
+				$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug ) );
+	
+				if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
+	
+					if( version_compare( $this->version, $version_info->new_version, '<' ) ) {
+	
+						$_transient_data->response[ $this->name ] = $version_info;
+	
+					}
+	
+					$_transient_data->last_checked = time();
+					$_transient_data->checked[ $this->name ] = $this->version;
+	
+				}
+	
+			}
+		
+			$edd_update_plugins_flag = false;
 		}
-
+		else{
+			$edd_update_plugins_flag = true;	
+		}
+		
 		return $_transient_data;
+
 	}
 
 	/**

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -78,45 +78,45 @@ class EDD_SL_Plugin_Updater {
 	 */
 	public function check_update( $_transient_data ) {
 
-		global $pagenow;
+		global $pagenow, $edd_update_plugins_flag;
 		
-		global $edd_update_plugins_flag;
-	
-		//If flag is true, this is our second go around with pre_set_site_transient_update_plugins
-		if ( $edd_update_plugins_flag ){
+		//If flag is false, this is our first go around with pre_set_site_transient_update_plugins
+		if ( ! $edd_update_plugins_flag ){
 			
-			if( ! is_object( $_transient_data ) ) {
-				$_transient_data = new stdClass;
-			}
-	
-			if( 'plugins.php' == $pagenow && is_multisite() ) {
-				return $_transient_data;
-			}
-	
-			if ( empty( $_transient_data->response ) || empty( $_transient_data->response[ $this->name ] ) ) {
-	
-				$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug ) );
-	
-				if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
-	
-					if( version_compare( $this->version, $version_info->new_version, '<' ) ) {
-	
-						$_transient_data->response[ $this->name ] = $version_info;
-	
-					}
-	
-					$_transient_data->last_checked = time();
-					$_transient_data->checked[ $this->name ] = $this->version;
-	
+			//Set flag to true so next time this function is run, it actually executes instead of returning here.
+			$edd_update_plugins_flag = true;
+			return $_transient_data;
+		}
+				
+		if( ! is_object( $_transient_data ) ) {
+			$_transient_data = new stdClass;
+		}
+
+		if( 'plugins.php' == $pagenow && is_multisite() ) {
+			return $_transient_data;
+		}
+
+		if ( empty( $_transient_data->response ) || empty( $_transient_data->response[ $this->name ] ) ) {
+
+			$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug ) );
+
+			if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
+
+				if( version_compare( $this->version, $version_info->new_version, '<' ) ) {
+
+					$_transient_data->response[ $this->name ] = $version_info;
+
 				}
-	
+
+				$_transient_data->last_checked = time();
+				$_transient_data->checked[ $this->name ] = $this->version;
+
 			}
+
+		}
 		
-			$edd_update_plugins_flag = false;
-		}
-		else{
-			$edd_update_plugins_flag = true;	
-		}
+		//Reset flag to false so it skips the first call of pre_set_site_transient_update_plugins for any other plugins using this class as well.
+		$edd_update_plugins_flag = false;
 		
 		return $_transient_data;
 

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -78,15 +78,7 @@ class EDD_SL_Plugin_Updater {
 	 */
 	public function check_update( $_transient_data ) {
 
-		global $pagenow, $edd_update_plugins_flag;
-		
-		//If flag is false, this is our first go around with pre_set_site_transient_update_plugins
-		if ( ! $edd_update_plugins_flag ){
-			
-			//Set flag to true so next time this function is run, it actually executes instead of returning here.
-			$edd_update_plugins_flag = true;
-			return $_transient_data;
-		}
+		global $pagenow;
 				
 		if( ! is_object( $_transient_data ) ) {
 			$_transient_data = new stdClass;
@@ -97,7 +89,7 @@ class EDD_SL_Plugin_Updater {
 		}
 
 		if ( empty( $_transient_data->response ) || empty( $_transient_data->response[ $this->name ] ) ) {
-
+					
 			$version_info = $this->api_request( 'plugin_latest_version', array( 'slug' => $this->slug ) );
 
 			if ( false !== $version_info && is_object( $version_info ) && isset( $version_info->new_version ) ) {
@@ -114,9 +106,6 @@ class EDD_SL_Plugin_Updater {
 			}
 
 		}
-		
-		//Reset flag to false so it skips the first call of pre_set_site_transient_update_plugins for any other plugins using this class as well.
-		$edd_update_plugins_flag = false;
 		
 		return $_transient_data;
 

--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -252,7 +252,7 @@ class EDD_SL_Plugin_Updater {
 			$api_response = $this->api_request( 'plugin_information', $to_send );
 			
 			//Expires in 1 day
-			set_site_transient( 'edd_api_request_' . $this->slug, $api_response, DAY_IN_SECONDS );
+			set_site_transient( 'edd_api_request_' . 'edd_api_request_' . substr( md5( serialize( $this->slug ) ), 0, 15 ), $api_response, DAY_IN_SECONDS );
 			
 			if ( false !== $api_response ) {
 				$_data = $api_response;


### PR DESCRIPTION
Plugins built using the EDD_SL_Plugin_Updater class "Phone Home" twice when on the "Dashboard" > "Updates" page or the "Plugins" page. This may be un-necessary.

The "plugins_api" hook is what's causing it to "phone home" twice on plugins and updates pages. If we cache the result of that for 24 hours in a transient (but not the result that comes through "pre_set_site_transient_update_plugins"), then "Dashboard" > "Updates" page will check for updates every time but only once every 24 hours on the "Plugins" page - and in turn only once every 24 hours will it check twice on the "Dashboard" > "Updates" page as well.

![store-api_request-in-a-transient-for-24-hours](https://cloud.githubusercontent.com/assets/1638128/14268293/3313a54e-faa7-11e5-8c53-cb5ba2bb0a07.jpg)