### PR TITLE
Standardize the method of getting file names

### DIFF
--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -787,8 +787,10 @@ function edd_get_download_files( $download_id = 0, $variable_price_id = null ) {
  * @return string The file name
  */
 function edd_get_file_name( $file = array() ) {
-	if( empty( $file ) || ! is_array( $file ) )
+	if( empty( $file ) || ! is_array( $file ) ) {
 		return false;
+	}
+
 	$name = ! empty( $file['name'] ) ? esc_html( $file['name'] ) : basename( $file['file'] );
 
 	return $name;

--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -451,11 +451,11 @@ function edd_email_tag_download_list( $payment_id ) {
 						if ( $show_links ) {
 							$download_list .= '<div>';
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $price_id );
-							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . $file['name'] . '</a>';
+							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
 							$download_list .= '</div>';
 						} else {
 							$download_list .= '<div>';
-							$download_list .= $file['name'];
+							$download_list .= edd_get_file_name( $file );
 							$download_list .= '</div>';
 						}
 					}
@@ -559,9 +559,9 @@ function edd_email_tag_download_list_plain( $payment_id ) {
 					foreach ( $files as $filekey => $file ) {
 						if( $show_links ) {
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $price_id );
-							$download_list .= $file['name'] . ': ' . $file_url . "\n";
+							$download_list .= edd_get_file_name( $file ) . ': ' . $file_url . "\n";
 						} else {
-							$download_list .= $file['name'] . "\n";
+							$download_list .= edd_get_file_name( $file ) . "\n";
 						}
 					}
 				}

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -529,10 +529,7 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 				foreach ( $files as $filekey => $file ) {
 					$links .= '<div class="edd_download_link_file">';
 						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '">';
-							if ( isset( $file['name'] ) )
-								$links .= esc_html( $file['name'] );
-							else
-								$links .= esc_html( $file['file'] );
+						$links .= edd_get_file_name( $file );
 						$links .= '</a>';
 					$links .= '</div>';
 				}

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -63,7 +63,7 @@ if ( $purchases ) :
 
 											<div class="edd_download_file">
 												<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link">
-													<?php echo isset( $file['name'] ) ? esc_html( $file['name'] ) : esc_html( $name ); ?>
+													<?php echo edd_get_file_name( $file ); ?>
 												</a>
 											</div>
 

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -192,7 +192,7 @@ $status    = edd_get_payment_status( $payment, true );
 
 													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); ?>
 													<li class="edd_download_file">
-														<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo esc_html( $file['name'] ); ?></a>
+														<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
 													</li>
 													<?php
 													do_action( 'edd_receipt_bundle_files', $filekey, $file, $item['id'], $bundle_item, $payment->ID, $meta );


### PR DESCRIPTION
This swaps usage of `$file['name']` for `edd_get_file_name( $file )`, which means we're getting file names in our templates the same way everywhere.

Addresses #4555