### PR TITLE
Fix price metadata by providing separate price and priceCurrency

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -265,7 +265,9 @@ function edd_purchase_variable_pricing( $download_id = 0, $args = array() ) {
 					echo '<li id="edd_price_option_' . $download_id . '_' . sanitize_key( $price['name'] ) . '"' . $schema . '>';
 						echo '<label for="'	. esc_attr( 'edd_price_option_' . $download_id . '_' . $key ) . '">';
 							echo '<input type="' . $type . '" ' . checked( apply_filters( 'edd_price_option_checked', $checked_key, $download_id, $key ), $key, false ) . ' name="edd_options[price_id][]" id="' . esc_attr( 'edd_price_option_' . $download_id . '_' . $key ) . '" class="' . esc_attr( 'edd_price_option_' . $download_id ) . '" value="' . esc_attr( $key ) . '" data-price="' . edd_get_price_option_amount( $download_id, $key ) .'"/>&nbsp;';
-							echo '<span class="edd_price_option_name" itemprop="description">' . esc_html( $price['name'] ) . '</span><span class="edd_price_option_sep">&nbsp;&ndash;&nbsp;</span><span class="edd_price_option_price" itemprop="price">' . edd_currency_filter( edd_format_amount( $price['amount'] ) ) . '</span>';
+							echo '<span class="edd_price_option_name" itemprop="description">' . esc_html( $price['name'] ) . '</span><span class="edd_price_option_sep">&nbsp;&ndash;&nbsp;</span><span class="edd_price_option_price">' . edd_currency_filter( edd_format_amount( $price['amount'] ) ) . '</span>';
+							echo '<meta itemprop="price" content="' . esc_attr( $price['amount'] ) .'" />';
+							echo '<meta itemprop="priceCurrency" content="' . esc_attr( edd_get_currency() ) .'" />';
 						echo '</label>';
 						do_action( 'edd_after_price_option', $key, $price, $download_id );
 					echo '</li>';


### PR DESCRIPTION
Currently EDD outputs the following schema.org metadata:

```html
<span class="edd_price_option_price" itemprop="price">$17.00</span>
```

This is incorrect according to https://schema.org/price, which states

> Use the priceCurrency property (with ISO 4217 codes e.g. "USD") instead of including ambiguous symbols such as '$' in the value.

The attached PR removes the itemprop="price" from the human-readable price, and adds two hidden meta values, e.g. 

```html
<span class="edd_price_option_price">$17.00</span>
<meta itemprop="price" content="17.00">
<meta itemprop="priceCurrency" content="USD">
```

This removes warnings when pages are run through Google's structured data testing tool (https://developers.google.com/structured-data/testing-tool/)

Before:
https://www.dropbox.com/s/rf2k8s5miiflq94/Screenshot%202016-05-12%2010.31.24.png?dl=0

After:
https://www.dropbox.com/s/hberjk7l8airt6r/Screenshot%202016-05-12%2010.34.18.png?dl=0