### PR TITLE
Trim states response

### DIFF
--- a/assets/js/edd-checkout-global.js
+++ b/assets/js/edd-checkout-global.js
@@ -98,7 +98,7 @@ window.EDD_Checkout = (function($) {
 					withCredentials: true
 				},
 				success: function (response) {
-					if( 'nostates' == response ) {
+					if( 'nostates' == $.trim(response) ) {
 						var text_field = '<input type="text" name="card_state" class="cart-state edd-input required" value=""/>';
 						$form.find('input[name="card_state"], select[name="card_state"]').replaceWith( text_field );
 					} else {


### PR DESCRIPTION
I was having an issue (as described here: https://github.com/easydigitaldownloads/easy-digital-downloads/issues/2963) where the states field was just showing `nostates` instead of the field.

Turns out the response from the ajax was: `"        nostates"` (without quotes, but with spaces infront). this meant the conditional was not met. Added $.trim() to fix the issue and the field shows as it should.

Not sure why there were spaces before the response, but this solution works well and should avoid it in future.