### PR TITLE
Added filters to process the earnings as they are updated

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -702,7 +702,8 @@ class EDD_Download {
 	 */
 	public function increase_earnings( $amount = 0 ) {
 
-		$new_amount = $this->get_earnings() + (float) $amount;
+		$current_earnings = $this->get_earnings();
+		$new_amount = apply_filters( 'edd_download_increase_earnings_amount', $current_earnings + (float) $amount, $current_earnings, $amount, $this );
 
 		if ( $this->update_meta( '_edd_download_earnings', $new_amount ) ) {
 
@@ -730,7 +731,8 @@ class EDD_Download {
 		// Only decrease if greater than zero
 		if ( $this->get_earnings() > 0 ) {
 
-			$new_amount = $this->get_earnings() - (float) $amount;
+			$current_earnings = $this->get_earnings();
+			$new_amount = apply_filters( 'edd_download_decrease_earnings_amount', $current_earnings - (float) $amount, $current_earnings, $amount, $this );
 
 			if ( $this->update_meta( '_edd_download_earnings', $new_amount ) ) {
 


### PR DESCRIPTION
The filter have the same purpose of the action added for customers, i.e. to allow processing the earnings before they are update on the product. This needed in cases like multi-currency shops, where earnings cannot just be added or subtracted, but must be first converted to the base currency.