### PR TITLE
Return false if EDD_Payment::setup_payment() fails

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -312,7 +312,11 @@ class EDD_Payment {
 			return false;
 		}
 
-		$this->setup_payment( $payment_id );
+		$setup_successful = $this->setup_payment( $payment_id );
+
+		if( false === $setup_successful ) {
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
This could cause problems with all the functions in /payments/functions.php - I started updating them, but it's so many that I figured I'd let @cklosowski and @pippinsplugins think about it first.

Related: #4718