### PR TITLE
Issue/4735

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1585,7 +1585,7 @@ function edd_discount_status_cleanup() {
 			array(
 				'key'     => '_edd_discount_expiration',
 				'value'   => current_time( 'mysql' ),
-				'compare' => '<',
+				'compare' => '>',
 			),
 		),
 	);

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1584,8 +1584,8 @@ function edd_discount_status_cleanup() {
 			),
 			array(
 				'key'     => '_edd_discount_expiration',
-				'value'   => current_time( 'mysql' ),
-				'compare' => '>',
+				'value'   => date( 'm/d/Y H:i:s' ),
+				'compare' => '<',
 			),
 		),
 	);

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1584,7 +1584,7 @@ function edd_discount_status_cleanup() {
 			),
 			array(
 				'key'     => '_edd_discount_expiration',
-				'value'   => date( 'm/d/Y H:i:s' ),
+				'value'   => date( 'm/d/Y H:i:s', current_time( 'timestamp' ) ),
 				'compare' => '<',
 			),
 		),


### PR DESCRIPTION
Fix for #4735 

The date format stored in _edd_discount_expiration is 06/30/2016 10:00:00 whereas the format returned from current_time( 'mysql' ) is 2016-06-30 18:05:54 causing the MySQL comparison query to be incorrect hence returning discounts which shouldn't be returned.