### PR TITLE
Fixes #4753 - Warning: array_key_exists() on activation in WPMS sub-d…

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -331,8 +331,9 @@ function edd_install_roles_on_network() {
 	if( ! is_object( $wp_roles ) ) {
 		return;
 	}
+	
 
-	if( ! array_key_exists( 'shop_manager', $wp_roles->roles ) ) {
+	if( empty( $wp_roles->roles ) || ! array_key_exists( 'shop_manager', $wp_roles->roles ) ) {
 
 		// Create EDD shop roles
 		$roles = new EDD_Roles;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -58,7 +58,9 @@ function edd_download_shortcode( $atts, $content = null ) {
 	if( ! empty( $atts['sku'] ) ) {
 
 		$download = edd_get_download_by( 'sku', $atts['sku'] );
-		$atts['download_id'] = $download->ID;
+		if ( $download ) {
+			$atts['download_id'] = $download->ID;
+		}
 
 	} elseif( isset( $atts['id'] ) ) {
 

--- a/tests/tests-install.php
+++ b/tests/tests-install.php
@@ -182,7 +182,7 @@ class Tests_Activation extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that edd_install_roles_on_network() bails when $wp_roles is no object.
+	 * Test that edd_install_roles_on_network() creates the roles when 'shop_manager' is not defined.
 	 *
 	 * @since 2.2.4
 	 */
@@ -194,6 +194,35 @@ class Tests_Activation extends WP_UnitTestCase {
 
 		// Prepare variables for test
 		unset( $wp_roles->roles['shop_manager'] );
+		$wp_roles->roles = false;
+
+		edd_install_roles_on_network();
+
+		// Test that the roles are created
+		$this->assertInstanceOf( 'WP_Role', get_role( 'shop_manager' ) );
+		$this->assertInstanceOf( 'WP_Role', get_role( 'shop_accountant' ) );
+		$this->assertInstanceOf( 'WP_Role', get_role( 'shop_worker' ) );
+		$this->assertInstanceOf( 'WP_Role', get_role( 'shop_vendor' ) );
+
+
+		// Reset to origin
+		$wp_roles = $origin_roles;
+
+	}
+	
+	/**
+	 * Test that edd_install_roles_on_network() creates the roles when $wp_roles->roles is initially false.
+	 *
+	 * @since 2.6.3
+	 */
+	public function test_edd_install_roles_on_network_when_roles_false() {
+
+		global $wp_roles;
+
+		$origin_roles = $wp_roles;
+
+		// Prepare variables for test
+		$wp_roles->roles = false;
 
 		edd_install_roles_on_network();
 

--- a/tests/tests-install.php
+++ b/tests/tests-install.php
@@ -194,7 +194,6 @@ class Tests_Activation extends WP_UnitTestCase {
 
 		// Prepare variables for test
 		unset( $wp_roles->roles['shop_manager'] );
-		$wp_roles->roles = false;
 
 		edd_install_roles_on_network();
 


### PR DESCRIPTION
When no roles are define WP_roles->roles is set to false. 
Adding a test for empty() before ! array_key_exists() avoids the Warning message that may be issued. 

Fix for #4753 