### PR TITLE
Fixes #4755 - Notice from purchase_link with invalid sku parameter

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -58,7 +58,10 @@ function edd_download_shortcode( $atts, $content = null ) {
 	if( ! empty( $atts['sku'] ) ) {
 
 		$download = edd_get_download_by( 'sku', $atts['sku'] );
-		$atts['download_id'] = $download->ID;
+		
+		if ( $download ) {
+			$atts['download_id'] = $download->ID;
+		}
 
 	} elseif( isset( $atts['id'] ) ) {
 


### PR DESCRIPTION
Should no longer issue the Notice when WP_DEBUG true and the given sku is invalid. #4755 