### PR TITLE
Add $items parameter to the `edd_post_add_to_cart` action

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -238,7 +238,6 @@ function edd_add_to_cart( $download_id, $options = array() ) {
 	foreach ( $items as &$item ) {
 		$item = apply_filters( 'edd_add_to_cart_item', $item );
 		$to_add = $item;
-		unset( $item );
 
 		if ( ! is_array( $to_add ) )
 			return;
@@ -263,6 +262,8 @@ function edd_add_to_cart( $download_id, $options = array() ) {
 
 		}
 	}
+
+	unset( $item );
 
 	EDD()->session->set( 'edd_cart', $cart );
 

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -233,8 +233,9 @@ function edd_add_to_cart( $download_id, $options = array() ) {
 		);
 	}
 
-	foreach ( $items as $item ) {
-		$to_add = apply_filters( 'edd_add_to_cart_item', $item );
+	foreach ( $items as &$item ) {
+		$item = apply_filters( 'edd_add_to_cart_item', $item );
+		$to_add = $item;
 		if ( ! is_array( $to_add ) )
 			return;
 

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -262,7 +262,7 @@ function edd_add_to_cart( $download_id, $options = array() ) {
 
 	EDD()->session->set( 'edd_cart', $cart );
 
-	do_action( 'edd_post_add_to_cart', $download_id, $options );
+	do_action( 'edd_post_add_to_cart', $download_id, $options, $items );
 
 	// Clear all the checkout errors, if any
 	edd_clear_errors();

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -199,6 +199,8 @@ function edd_add_to_cart( $download_id, $options = array() ) {
 		$options['price_id'] = explode( ',', $options['price_id'] );
 	}
 
+	$items = array();
+
 	if ( isset( $options['price_id'] ) && is_array( $options['price_id'] ) ) {
 
 		// Process multiple price options at once

--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -236,6 +236,8 @@ function edd_add_to_cart( $download_id, $options = array() ) {
 	foreach ( $items as &$item ) {
 		$item = apply_filters( 'edd_add_to_cart_item', $item );
 		$to_add = $item;
+		unset( $item );
+
 		if ( ! is_array( $to_add ) )
 			return;
 


### PR DESCRIPTION
This makes it unnecessary to reproduce the logic inside `edd_add_to_cart()`.

Closes #4820