### PR TITLE
Fix horizontal alignment of items in the dashboard widget

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -554,6 +554,11 @@ textarea#edd-payment-note {
 .edd_dashboard_widget td {
 	padding: 3px 0;
 }
+.edd_dashboard_widget .b,
+.edd_dashboard_widget .t {
+	line-height: 1.5;
+	vertical-align: middle;
+}
 .edd_dashboard_widget .b {
 	font-size: 14px;
 	font-family: Georgia,"Times New Roman","Bitstream Charter",Times,serif;
@@ -563,7 +568,6 @@ textarea#edd-payment-note {
 .edd_dashboard_widget .t {
 	font-size: 12px;
 	padding-right: 12px;
-	padding-top: 6px;
 	color: #777;
 	width: 100%;
 }


### PR DESCRIPTION
I couldn't see how you generate your minified CSS, so this doesn't update `edd-admin.min.css`.

Before:
![selection_011](https://cloud.githubusercontent.com/assets/2306629/17362936/7c6f1df0-596f-11e6-88c3-0eb44bd983e5.png)

After:
![selection_013](https://cloud.githubusercontent.com/assets/2306629/17362950/965c459e-596f-11e6-8399-e465468948d6.png)

