### PR TITLE
Implement variable picker in select field & first pass with variation support for coupons

### DIFF
--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -72,8 +72,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 							'name'        => 'products[]',
 							'id'          => 'products',
 							'multiple'    => true,
-                            'chosen'      => true,
-                            'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
+							'chosen'      => true,
+							'variations'  => true,
+							'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
 						) ); ?><br/>
 					</p>
 					<div id="edd-discount-product-conditions" style="display:none;">
@@ -108,8 +109,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 						'id'       => 'excluded-products',
 						'selected' => array(),
 						'multiple' => true,
-                        'chosen'   => true,
-                        'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
+						'chosen'   => true,
+						'variations'  => true,
+						'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
 					) ); ?><br/>
 					<p class="description"><?php printf( __( '%s that this discount code cannot be applied to.', 'easy-digital-downloads' ), edd_get_label_plural() ); ?></p>
 				</td>

--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -105,8 +105,11 @@ function edd_edit_discount( $data ) {
 
 			} elseif ( is_array( $value ) ) {
 
-				$discount[ $key ] = array_map( 'absint', $value );
-
+				if ( $key !== 'products' && $key !== 'excluded-products' ){
+					$discount[ $key ] = array_map( 'absint', $value );
+				} else {
+					$discount[ $key ] = array_map( 'sanitize_key', $value );
+				}
 			}
 
 		}

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -87,8 +87,9 @@ $condition_display = empty( $product_reqs ) ? ' style="display:none;"' : '';
 							'id'          => 'products',
 							'selected'    => $product_reqs,
 							'multiple'    => true,
-                            'chosen'      => true,
-                            'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
+							'chosen'      => true,
+							'variations'  => true,
+							'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
 						) ); ?><br/>
 					</p>
 					<div id="edd-discount-product-conditions"<?php echo $condition_display; ?>>
@@ -123,8 +124,9 @@ $condition_display = empty( $product_reqs ) ? ' style="display:none;"' : '';
 						'id'       => 'excluded-products',
 						'selected' => $excluded_products,
 						'multiple' => true,
-                        'chosen'   => true,
-                        'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
+						'chosen'   => true,
+						'variations'  => true,
+						'placeholder' => sprintf( __( 'Select one or more %s', 'easy-digital-downloads' ), edd_get_label_plural() )
 					) ); ?><br/>
 					<p class="description"><?php printf( __( '%s that this discount code cannot be applied to.', 'easy-digital-downloads' ), edd_get_label_plural() ); ?></p>
 				</td>

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -40,6 +40,7 @@ class EDD_HTML_Elements {
 			'chosen'      => false,
 			'number'      => 30,
 			'bundles'     => true,
+			'variations'  => false,
 			'placeholder' => sprintf( __( 'Choose a %s', 'easy-digital-downloads' ), edd_get_label_singular() ),
 			'data'        => array( 'search-type' => 'download' ),
 		);
@@ -71,6 +72,18 @@ class EDD_HTML_Elements {
 		if ( $products ) {
 			foreach ( $products as $product ) {
 				$options[ absint( $product->ID ) ] = esc_html( $product->post_title );
+				if ( $args['variations'] && edd_has_variable_prices( $product->ID ) ) {
+					$prices = edd_get_variable_prices( $product->ID );
+					
+					foreach ( $prices as $key => $value ) {
+						$name   = isset( $value['name'] )   ? $value['name']   : '';
+						$amount = isset( $value['amount'] ) ? $value['amount'] : '';
+						$index  = isset( $value['index'] )  ? $value['index']  : $key;
+						if ( $name && $index ) {
+							$options[ absint( $product->ID ) . '_' . $index ] = esc_html( $product->post_title . ': ' . $name );
+						}
+					}
+				} 
 			}
 		}
 
@@ -78,12 +91,40 @@ class EDD_HTML_Elements {
 		if( is_array( $args['selected'] ) ) {
 			foreach( $args['selected'] as $item ) {
 				if( ! in_array( $item, $options ) ) {
-					$options[$item] = get_the_title( $item );
+					if ( strpos( $item, '_' ) !== false ) {
+						$pieces = explode( '_' , $item );
+						if ( empty( $pieces[0] ) && ! isset( $pieces[1] ) );
+						$prices = edd_get_variable_prices( (int) $pieces[0] );
+						foreach ( $prices as $key => $value ) {
+							$name   = isset( $value['name'] )   ? $value['name']   : '';
+							$amount = isset( $value['amount'] ) ? $value['amount'] : '';
+							$index  = isset( $value['index'] )  ? $value['index']  : $key;
+							if ( $name && $index && (int) $pieces[1] === (int) $index  ) {
+								$options[ absint( $product->ID ) . '_' . $index ] = esc_html( get_the_title( (int) $pieces[0] ) . ': ' . $name );
+							}
+						}
+					} else {
+						$options[$item] = get_the_title( $item );
+					}
 				}
 			}
 		} elseif ( is_numeric( $args['selected'] ) && $args['selected'] !== 0 ) {
 			if ( ! in_array( $args['selected'], $options ) ) {
-				$options[$args['selected']] = get_the_title( $args['selected'] );
+				if ( strpos( $args['selected'], '_' ) !== false ) {
+					$pieces = explode( '_' , $item );
+					if ( empty( $pieces[0] ) && ! isset( $pieces[1] ) );
+					$prices = edd_get_variable_prices( (int) $pieces[0] );
+					foreach ( $prices as $key => $value ) {
+						$name   = isset( $value['name'] )   ? $value['name']   : '';
+						$amount = isset( $value['amount'] ) ? $value['amount'] : '';
+						$index  = isset( $value['index'] )  ? $value['index']  : $key;
+						if ( $name && $index && (int) $pieces[1] === (int) $index  ) {
+							$options[ absint( $product->ID ) . '_' . $index ] = esc_html( get_the_title( (int) $pieces[0] ) . ': ' . $name );
+						}
+					}
+				} else {
+					$options[$item] = get_the_title( $item );
+				}
 			}
 		}
 


### PR DESCRIPTION
This is a first pass of implementing variations in the EDD HTML class product_dropdown (working). It also enables the ability to create discounts that require or limit by product variations (working).

Note, I do not have the bandwidth to go around to other places of EDD that use product_dropdown to enable variation support, like for example in reporting ( #4487 ), so this pr should either be used as a base that is extended to do that or as guidance on how to do this for a completely new pr.

Solves https://github.com/easydigitaldownloads/easy-digital-downloads/issues/3175 and  https://github.com/easydigitaldownloads/easy-digital-downloads/issues/3405

This also makes doing https://github.com/easydigitaldownloads/easy-digital-downloads/issues/3972 pretty trivial (just turn on chosen + variable support)