### PR TITLE
Preserve get parameters when straight to checkout is selected

### DIFF
--- a/includes/cart/actions.php
+++ b/includes/cart/actions.php
@@ -80,7 +80,15 @@ function edd_process_add_to_cart( $data ) {
 	$cart        = edd_add_to_cart( $download_id, $options );
 
 	if ( edd_straight_to_checkout() && ! edd_is_checkout() ) {
-		wp_redirect( edd_get_checkout_uri(), 303 );
+		$query_args = remove_query_arg( array( 'edd_action', 'download_id', 'edd_options' ) );
+		$query_part = strpos( $query_args, "?" );
+		$url_parameters = '';
+
+		if ( false !== $query_part ) { 
+			$url_parameters = substr( $query_args, $query_part ); 
+		}
+
+		wp_redirect( edd_get_checkout_uri() . $url_parameters, 303 );
 		edd_die();
 	} else {
 		wp_redirect( remove_query_arg( array( 'edd_action', 'download_id', 'edd_options' ) ) ); edd_die();

--- a/includes/cart/actions.php
+++ b/includes/cart/actions.php
@@ -80,8 +80,8 @@ function edd_process_add_to_cart( $data ) {
 	$cart        = edd_add_to_cart( $download_id, $options );
 
 	if ( edd_straight_to_checkout() && ! edd_is_checkout() ) {
-		$query_args = remove_query_arg( array( 'edd_action', 'download_id', 'edd_options' ) );
-		$query_part = strpos( $query_args, "?" );
+		$query_args 	= remove_query_arg( array( 'edd_action', 'download_id', 'edd_options' ) );
+		$query_part 	= strpos( $query_args, "?" );
 		$url_parameters = '';
 
 		if ( false !== $query_part ) { 


### PR DESCRIPTION
Fixes #4797 

Removes the edd parameters from the URL and then append the remaining parameters to checkout URL and then redirect.