### PR TITLE
Disable button behavior option when not supported #4665

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -934,7 +934,7 @@ function edd_render_disable_button( $post_id ) {
 			<?php echo EDD()->html->select( $args ); ?>
 			<?php _e( 'Purchase button behavior', 'easy-digital-downloads' ); ?>
 			<?php if ( $supports_buy_now ) : ?>
-				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. A Buy Now button bypasses most of the process, taking the customer directly from button click to payment, greatly speeding up the process of getting the product.', 'easy-digital-downloads' ); ?>"></span>
+				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. A Buy Now button bypasses most of the process, taking the customer directly from button click to payment, greatly speeding up the process of buying the product.', 'easy-digital-downloads' ); ?>"></span>
 			<?php else: ?>
 				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. Buy now buttons are only available for supported gateways and stores that do not use taxes.', 'easy-digital-downloads' ); ?>"></span>
 			<?php endif; ?>

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -911,25 +911,37 @@ function edd_render_disable_button( $post_id ) {
 			<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Automatic Output</strong>: By default, the purchase buttons will be displayed at the bottom of the download, when disabled you will need to use the Purchase link shortcode below to output the ability to buy the product where you prefer.', 'easy-digital-downloads' ); ?>"></span>
 		</label>
 	</p>
-	<?php if( edd_shop_supports_buy_now() ) : ?>
+	<?php $supports_buy_now = edd_shop_supports_buy_now(); ?>
 	<p>
 		<label for="_edd_button_behavior">
-			<?php echo EDD()->html->select( array(
+			<?php
+			$args = array(
 				'name'    => '_edd_button_behavior',
 				'options' => array(
 					'add_to_cart' => __( 'Add to Cart', 'easy-digital-downloads' ),
-					'direct'      => __( 'Buy Now', 'easy-digital-downloads' )
+					'direct'      => __( 'Buy Now', 'easy-digital-downloads' ),
 				),
 				'show_option_all'  => null,
 				'show_option_none' => null,
 				'selected' => $behavior
-			) ); ?>
+			);
+
+			if ( ! $supports_buy_now ) {
+				$args['disabled'] = true;
+				$args['readonly'] = true;
+			}
+			?>
+			<?php echo EDD()->html->select( $args ); ?>
 			<?php _e( 'Purchase button behavior', 'easy-digital-downloads' ); ?>
-			<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. A Buy Now button bypasses most of the process, taking the customer directly from button click to payment, greatly speeding up the process of getting the product.', 'easy-digital-downloads' ); ?>"></span>
+			<?php if ( $supports_buy_now ) : ?>
+				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. A Buy Now button bypasses most of the process, taking the customer directly from button click to payment, greatly speeding up the process of getting the product.', 'easy-digital-downloads' ); ?>"></span>
+			<?php else: ?>
+				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. Buy now buttons are only available for supported gateways and stores that do not use taxes.', 'easy-digital-downloads' ); ?>"></span>
+			<?php endif; ?>
+
 		</label>
 	</p>
 <?php
-	endif;
 }
 add_action( 'edd_meta_box_settings_fields', 'edd_render_disable_button', 30 );
 

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -936,7 +936,7 @@ function edd_render_disable_button( $post_id ) {
 			<?php if ( $supports_buy_now ) : ?>
 				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. A Buy Now button bypasses most of the process, taking the customer directly from button click to payment, greatly speeding up the process of buying the product.', 'easy-digital-downloads' ); ?>"></span>
 			<?php else: ?>
-				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. Buy now buttons are only available for supported gateways and stores that do not use taxes.', 'easy-digital-downloads' ); ?>"></span>
+				<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Button Behavior</strong>: Add to Cart buttons follow a traditional eCommerce flow. Buy Now buttons are only available for supported gateways and stores that do not use taxes.', 'easy-digital-downloads' ); ?>"></span>
 			<?php endif; ?>
 
 		</label>

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -375,7 +375,7 @@ class EDD_HTML_Elements {
 		}
 
 		$class  = implode( ' ', array_map( 'sanitize_html_class', explode( ' ', $args['class'] ) ) );
-		$output = '<select ' . $disabled . $readonly . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( edd_sanitize_key( str_replace( '-', '_', $args['id'] ) ) ) . '" class="edd-select ' . $class . '"' . $multiple . ' data-placeholder="' . $placeholder . '"'. $data_elements . '>';
+		$output = '<select' . $disabled . $readonly . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( edd_sanitize_key( str_replace( '-', '_', $args['id'] ) ) ) . '" class="edd-select ' . $class . '"' . $multiple . ' data-placeholder="' . $placeholder . '"'. $data_elements . '>';
 
 		if ( $args['show_option_all'] ) {
 			if( $args['multiple'] ) {

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -335,6 +335,8 @@ class EDD_HTML_Elements {
 			'show_option_all'  => _x( 'All', 'all dropdown items', 'easy-digital-downloads' ),
 			'show_option_none' => _x( 'None', 'no dropdown items', 'easy-digital-downloads' ),
 			'data'             => array(),
+			'readonly'         => false,
+			'disabled'         => false,
 		);
 
 		$args = wp_parse_args( $args, $defaults );
@@ -360,8 +362,20 @@ class EDD_HTML_Elements {
 			$placeholder = '';
 		}
 
+		if ( isset( $args['readonly'] ) && $args['readonly'] ) {
+			$readonly = ' readonly="readonly"';
+		} else {
+			$readonly = '';
+		}
+
+		if ( isset( $args['disabled'] ) && $args['disabled'] ) {
+			$disabled = ' disabled="disabled"';
+		} else {
+			$disabled = '';
+		}
+
 		$class  = implode( ' ', array_map( 'sanitize_html_class', explode( ' ', $args['class'] ) ) );
-		$output = '<select name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( edd_sanitize_key( str_replace( '-', '_', $args['id'] ) ) ) . '" class="edd-select ' . $class . '"' . $multiple . ' data-placeholder="' . $placeholder . '"'. $data_elements . '>';
+		$output = '<select ' . $disabled . $readonly . ' name="' . esc_attr( $args['name'] ) . '" id="' . esc_attr( edd_sanitize_key( str_replace( '-', '_', $args['id'] ) ) ) . '" class="edd-select ' . $class . '"' . $multiple . ' data-placeholder="' . $placeholder . '"'. $data_elements . '>';
 
 		if ( $args['show_option_all'] ) {
 			if( $args['multiple'] ) {


### PR DESCRIPTION
#4665 
This does 2 things. When buy now buttons aren't supported, the `Button Behavior` checkbox on the downloads meta boxes is disabled, instead of being hidden. It also modifies the tooltip text to mention why it's not allowed.

In order to do this, we had to allow our `select` HTML helper to accept a `readonly` and `disabled` argument.