### PR TITLE
Issue with unsetting cart discount when code isn't set

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1140,7 +1140,9 @@ function edd_unset_cart_discount( $code = '' ) {
 
 	if ( $discounts ) {
 		$key = array_search( $code, $discounts );
-		unset( $discounts[ $key ] );
+		if ( false !== $key ) {
+			unset( $discounts[ $key ] );
+		}
 		$discounts = implode( '|', array_values( $discounts ) );
 		// update the active discounts
 		EDD()->session->set( 'cart_discounts', $discounts );


### PR DESCRIPTION
I encountered a problem when using `edd_unset_cart_discount()` with a discount code that isn't actually set/active. This causes `$key` to be `false` and trying to use `unset` with a `false` array key empties the entire array out (thus removing other discount codes that weren't expected to be removed).