### PR TITLE
Change  to  to prevent the original  variable getting overwritten. #4940

### DIFF
--- a/includes/admin/import/class-batch-import-downloads.php
+++ b/includes/admin/import/class-batch-import-downloads.php
@@ -458,27 +458,33 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 
 			if( is_numeric( $term ) && 0 === (int) $term ) {
 
-				$term = get_term( $term, $taxonomy );
+				$t = get_term( $term, $taxonomy );
 
 			} else {
 
-				$term = get_term_by( 'name', $term, $taxonomy );
+				$t = get_term_by( 'name', $term, $taxonomy );
 
-				if( ! $term ) {
+				if( ! $t ) {
 
-					$term = get_term_by( 'slug', $term, $taxonomy );
+					$t = get_term_by( 'slug', $term, $taxonomy );
 
 				}
 
 			}
 
-			if( ! empty( $term ) ) {
+			if( ! empty( $t ) ) {
 
-				$term_ids[] = $term->term_id;
+				$term_ids[] = $t->term_id;
 
 			} else {
 
-				$term_ids[] = wp_insert_term( $term, $taxonomy );
+				$term_id = wp_insert_term( $term, $taxonomy, array( 'slug' => sanitize_title( $term ) ) );
+
+				if( ! is_wp_error( $term_id ) ) {
+
+					$term_ids[] = $term_id;
+
+				}
 
 			}
 

--- a/includes/admin/import/class-batch-import-downloads.php
+++ b/includes/admin/import/class-batch-import-downloads.php
@@ -478,11 +478,11 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 
 			} else {
 
-				$term_id = wp_insert_term( $term, $taxonomy, array( 'slug' => sanitize_title( $term ) ) );
+				$term_data = wp_insert_term( $term, $taxonomy, array( 'slug' => sanitize_title( $term ) ) );
 
-				if( ! is_wp_error( $term_id ) ) {
+				if( ! is_wp_error( $term_data ) ) {
 
-					$term_ids[] = $term_id;
+					$term_ids[] = $term_data['term_id'];
 
 				}
 


### PR DESCRIPTION
#4940 

Terms were not created because the `$term` variable was getting overwritten each time we tried to retrieve an existing term. When no term was retrieved, `$term` was set to `false` and thus we were passing `false` as the term name in `wp_insert_term()`, causing it to return a `WP_Error` with the message `A name is required for this term.`.