### PR TITLE
Don't output a label if one isn't set for text and select HTML elements

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -497,9 +497,10 @@ class EDD_HTML_Elements {
 		}
 
 		$output = '<span id="edd-' . edd_sanitize_key( $args['name'] ) . '-wrap">';
-
-			$output .= '<label class="edd-label" for="' . edd_sanitize_key( $args['id'] ) . '">' . esc_html( $args['label'] ) . '</label>';
-
+			if ( ! empty( $args['label'] ) ) {
+				$output .= '<label class="edd-label" for="' . edd_sanitize_key( $args['id'] ) . '">' . esc_html( $args['label'] ) . '</label>';
+			}
+			
 			if ( ! empty( $args['desc'] ) ) {
 				$output .= '<span class="edd-description">' . esc_html( $args['desc'] ) . '</span>';
 			}
@@ -557,8 +558,10 @@ class EDD_HTML_Elements {
 
 		$output = '<span id="edd-' . edd_sanitize_key( $args['name'] ) . '-wrap">';
 
-			$output .= '<label class="edd-label" for="' . edd_sanitize_key( $args['name'] ) . '">' . esc_html( $args['label'] ) . '</label>';
-
+			if ( ! empty( $args['label'] ) ) {
+				$output .= '<label class="edd-label" for="' . edd_sanitize_key( $args['name'] ) . '">' . esc_html( $args['label'] ) . '</label>';
+			}
+			
 			$output .= '<textarea name="' . esc_attr( $args['name'] ) . '" id="' . edd_sanitize_key( $args['name'] ) . '" class="' . $class . '"' . $disabled . '>' . esc_attr( $args['value'] ) . '</textarea>';
 
 			if ( ! empty( $args['desc'] ) ) {


### PR DESCRIPTION
Right now is label passed to an HTML element is empty, it still outputs an empty label. This is bad practice, because it causes issues if you're defining a label for that field elsewhere.