### PR TITLE
Add framework for beta support

### DIFF
--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -320,7 +320,8 @@ class EDD_SL_Plugin_Updater {
 			'item_id'    => isset( $data['item_id'] ) ? $data['item_id'] : false,
 			'slug'       => $data['slug'],
 			'author'     => $data['author'],
-			'url'        => home_url()
+			'url'        => home_url(),
+			'beta'       => $data['beta']
 		);
 
 		$request = wp_remote_post( $this->api_url, array( 'timeout' => 15, 'sslverify' => false, 'body' => $api_params ) );

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -316,6 +316,25 @@ function edd_has_beta_support() {
 
 
 /**
+ * Check if a given product has beta support enabled
+ *
+ * @since       2.6.9
+ * @param       string $slug The slug of the product to check
+ * @return      bool True if enabled, false otherwise
+ */
+function edd_is_beta_support_enabled( $slug ) {
+	$enabled_betas = edd_get_option( 'enabled_betas', array() );
+	$return        = false;
+
+	if( array_key_exists( $slug, $enabled_betas ) ) {
+		$return = true;
+	}
+
+	return $return;
+}
+
+
+/**
  * Save enabled betas
  *
  * @since       2.6.9

--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -25,6 +25,7 @@ class EDD_License {
 	private $version;
 	private $author;
 	private $api_url = 'https://easydigitaldownloads.com/edd-sl-api/';
+	private $beta;
 
 	/**
 	 * Class constructor
@@ -36,7 +37,7 @@ class EDD_License {
 	 * @param string  $_optname
 	 * @param string  $_api_url
 	 */
-	function __construct( $_file, $_item, $_version, $_author, $_optname = null, $_api_url = null ) {
+	function __construct( $_file, $_item, $_version, $_author, $_optname = null, $_api_url = null, $_beta = false ) {
 
 		$this->file           = $_file;
 
@@ -51,6 +52,7 @@ class EDD_License {
 		$this->license        = trim( edd_get_option( $this->item_shortname . '_license_key', '' ) );
 		$this->author         = $_author;
 		$this->api_url        = is_null( $_api_url ) ? $this->api_url : $_api_url;
+		$this->beta           = $_beta;
 
 		/**
 		 * Allows for backwards compatibility with old license options,
@@ -131,7 +133,8 @@ class EDD_License {
 		$args = array(
 			'version'   => $this->version,
 			'license'   => $this->license,
-			'author'    => $this->author
+			'author'    => $this->author,
+			'beta'      => $this->beta
 		);
 
 		if( ! empty( $this->item_id ) ) {


### PR DESCRIPTION
This is the first pass at adding a framework for beta support to EDD core. Relevant to https://github.com/easydigitaldownloads/EDD-Software-Licensing/issues/662. Utilizing the framework is a two-part process. First, plugins wishing to utilize betas need to add themselves to the `has_beta_support` array:

```
function add_me_to_betas( $products ) {
    $products['my-slug'] = 'My Product';

    return $products;
}
add_filter( 'edd_has_beta_support', 'add_me_to_betas' );
```

Once added, the item will be added to the beta list on the Tools page. Checked items will be saved under the option `enabled_betas`. To actually enable beta notification, you have to add a check to the `EDD_SL_Plugin_Updater` class in your plugin and, if the option is enabled, pass an extra argument to the constructer with a value of `true`.

In hindsight, it might make sense to add a helper function to check if betas are enabled and return true/false to streamline that process rather than leaving it up to the plugin dev.