### PR TITLE
Move Download CPT icon to registration arguments

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -58,6 +58,7 @@ function edd_setup_edd_post_types() {
 		'show_ui'            => true,
 		'show_in_menu'       => true,
 		'query_var'          => true,
+		'menu_icon'          => 'dashicons-download',
 		'rewrite'            => $rewrite,
 		'capability_type'    => 'product',
 		'map_meta_cap'       => true,

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -285,7 +285,6 @@ function edd_admin_downloads_icon() {
 	$icon_cpt_2x_url = $images_url . 'edd-cpt-2x.png';
 	?>
 	<style type="text/css" media="screen">
-		#adminmenu #menu-posts-download .wp-menu-image:before,
 		#dashboard_right_now .download-count:before {
 			content: '<?php echo $menu_icon; ?>';
 		}


### PR DESCRIPTION
I think this is better because then it's easier and more intuitive to change the menu icon.

And should #3052 be revisited? It seems like the effort to move to SVG has been basically dead for over a year unless there's more discussion I haven't found.