### PR TITLE
Update the current time to get GMT

### DIFF
--- a/includes/class-edd-cron.php
+++ b/includes/class-edd-cron.php
@@ -70,7 +70,7 @@ class EDD_Cron {
 	 */
 	private function weekly_events() {
 		if ( ! wp_next_scheduled( 'edd_weekly_scheduled_events' ) ) {
-			wp_schedule_event( current_time( 'timestamp' ), 'weekly', 'edd_weekly_scheduled_events' );
+			wp_schedule_event( current_time( 'timestamp', true ), 'weekly', 'edd_weekly_scheduled_events' );
 		}
 	}
 
@@ -83,7 +83,7 @@ class EDD_Cron {
 	 */
 	private function daily_events() {
 		if ( ! wp_next_scheduled( 'edd_daily_scheduled_events' ) ) {
-			wp_schedule_event( current_time( 'timestamp' ), 'daily', 'edd_daily_scheduled_events' );
+			wp_schedule_event( current_time( 'timestamp', true ), 'daily', 'edd_daily_scheduled_events' );
 		}
 	}
 


### PR DESCRIPTION
Hi,
If you live in a UTC+0 timezone this doesn't affect you, but if you live in a UTC+2 i.e. timezone, without getting GMT time, the first time the cron will start after two hours.

With the use of the true parameter the cron will start immediately.
