### PR TITLE
Fix #5092

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1926,6 +1926,7 @@ function edd_tax_rates_callback($args) {
 					echo EDD()->html->select( array(
 						'options'          => edd_get_country_list(),
 						'name'             => 'tax_rates[0][country]',
+						'selected'         => '',
 						'show_option_all'  => false,
 						'show_option_none' => false,
 						'class'            => 'edd-tax-country',


### PR DESCRIPTION
By default `selected` key in [`EDD_HTML_Elements::select`](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/master/includes/class-edd-html-elements.php#L449) method
args is array which fails when there is no value provided on
call method.

Example: `includes/admin/settings/register-settings.php#1924`

Passing an empty value to `selected` key when no rates are defined.