### PR TITLE
Fix last text domain replacement

### DIFF
--- a/templates/shortcode-profile-editor.php
+++ b/templates/shortcode-profile-editor.php
@@ -142,7 +142,7 @@ if ( is_user_logged_in() ):
 					<?php endforeach; ?>
 				</select>
 				<br/>
-				<label for="edd_address_state"><?php _e( 'State / Province', 'edd' ); ?></label>
+				<label for="edd_address_state"><?php _e( 'State / Province', 'easy-digital-downloads' ); ?></label>
 				<?php
 			        if( ! empty( $states ) ) : ?>
 			        <select name="edd_address_state" id="edd_address_state" class="select edd-select">


### PR DESCRIPTION
I was creating an online store and I was wondering why this string wasn't getting translated like the others. This one seems to have slipped through the cracks in the last text-domain change operation.