### PR TITLE
Fix incorrect upgrade total steps rounding issue

### DIFF
--- a/includes/admin/upgrades/upgrades.php
+++ b/includes/admin/upgrades/upgrades.php
@@ -25,7 +25,10 @@ function edd_upgrades_screen() {
 	$custom = isset( $_GET['custom'] )      ? absint( $_GET['custom'] )                   : 0;
 	$number = isset( $_GET['number'] )      ? absint( $_GET['number'] )                   : 100;
 	$steps  = round( ( $total / $number ), 0 );
-
+	if ( ( $steps * 100 ) < $total ) {
+		$steps++;
+	}
+	
 	$doing_upgrade_args = array(
 		'page'        => 'edd-upgrades',
 		'edd-upgrade' => $action,

--- a/includes/admin/upgrades/upgrades.php
+++ b/includes/admin/upgrades/upgrades.php
@@ -25,7 +25,7 @@ function edd_upgrades_screen() {
 	$custom = isset( $_GET['custom'] )      ? absint( $_GET['custom'] )                   : 0;
 	$number = isset( $_GET['number'] )      ? absint( $_GET['number'] )                   : 100;
 	$steps  = round( ( $total / $number ), 0 );
-	if ( ( $steps * 100 ) < $total ) {
+	if ( ( $steps * $number ) < $total ) {
 		$steps++;
 	}
 	


### PR DESCRIPTION
Right now we round the total number of steps using this:
$total_steps = round( ( $total / 100 ), 0 );

The problem is that if you round like that, what happens in the upgrades is if you have 102 items, it says "Running step 1 of 1 total" and then since there's more meta IDs to process, it redirects to finish the other 2 left and says "Running step 2 of 2 total". It looks like an extra step came out of nowhere.

This fix correctly tests + rounds the total of number of steps so this rounding error doesn't happen.

Proof of concept code:

``` php
<?php
$total       = 102;
$total_steps = round( ( $total / 100 ), 0 );

var_dump( "Total steps: " . $total_steps ); // <-- You'll incorrectly get 1 here
var_dump( "Total: " . $total );
// below is the new code additions to fix the issue
if ( $total_steps * 100 < $total ) {
    $total_steps++;
}
var_dump( "Total steps: " . $total_steps ); // <-- You'll correctly get 2 here
```

#5194