### PR TITLE
CSS Class Argument for Settings API Fields

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -198,6 +198,7 @@ function edd_register_settings() {
 				    'faux'          => false,
 				    'tooltip_title' => false,
 				    'tooltip_desc'  => false,
+				    'class'         => '',
 				) );
 
 				add_settings_field(
@@ -1321,10 +1322,22 @@ function edd_checkbox_callback( $args ) {
 	} else {
 		$name = 'name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$checked  = ! empty( $edd_option ) ? checked( 1, $edd_option, false ) : '';
 	$html     = '<input type="hidden"' . $name . ' value="-1" />';
-	$html    .= '<input type="checkbox" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"' . $name . ' value="1" ' . $checked . '/>';
+	$html    .= '<input type="checkbox" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"' . $name . ' value="1" ' . $checked . ' class="' . $class . '"/>';
 	$html    .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
 
 	echo apply_filters( 'edd_after_setting_output', $html, $args );
@@ -1342,13 +1355,25 @@ function edd_checkbox_callback( $args ) {
  */
 function edd_multicheck_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$html = '';
 	if ( ! empty( $args['options'] ) ) {
 		$html .= '<input type="hidden" name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" value="-1" />';
 		foreach( $args['options'] as $key => $option ):
 			if( isset( $edd_option[ $key ] ) ) { $enabled = $option; } else { $enabled = NULL; }
-			$html .= '<input name="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" type="checkbox" value="' . esc_attr( $option ) . '" ' . checked($option, $enabled, false) . '/>&nbsp;';
+			$html .= '<input name="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" class="' . $class . '" type="checkbox" value="' . esc_attr( $option ) . '" ' . checked($option, $enabled, false) . '/>&nbsp;';
 			$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']">' . wp_kses_post( $option ) . '</label><br/>';
 		endforeach;
 		$html .= '<p class="description">' . $args['desc'] . '</p>';
@@ -1367,6 +1392,18 @@ function edd_multicheck_callback( $args ) {
  */
 function edd_payment_icons_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$html = '<input type="hidden" name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" value="-1" />';
 	if ( ! empty( $args['options'] ) ) {
@@ -1380,7 +1417,7 @@ function edd_payment_icons_callback( $args ) {
 
 			$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" style="margin-right:10px;line-height:16px;height:16px;display:inline-block;">';
 
-				$html .= '<input name="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" type="checkbox" value="' . esc_attr( $option ) . '" ' . checked( $option, $enabled, false ) . '/>&nbsp;';
+				$html .= '<input name="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" class="' . $class . '" type="checkbox" value="' . esc_attr( $option ) . '" ' . checked( $option, $enabled, false ) . '/>&nbsp;';
 
 				if( edd_string_is_image_url( $key ) ) {
 
@@ -1438,6 +1475,18 @@ function edd_radio_callback( $args ) {
 	$edd_options = edd_get_option( $args['id'] );
 
 	$html = '';
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	foreach ( $args['options'] as $key => $option ) :
 		$checked = false;
@@ -1447,7 +1496,7 @@ function edd_radio_callback( $args ) {
 		elseif( isset( $args['std'] ) && $args['std'] == $key && ! $edd_options )
 			$checked = true;
 
-		$html .= '<input name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" type="radio" value="' . edd_sanitize_key( $key ) . '" ' . checked(true, $checked, false) . '/>&nbsp;';
+		$html .= '<input name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" class="' . $class . '" type="radio" value="' . edd_sanitize_key( $key ) . '" ' . checked(true, $checked, false) . '/>&nbsp;';
 		$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']">' . esc_html( $option ) . '</label><br/>';
 	endforeach;
 
@@ -1468,6 +1517,18 @@ function edd_radio_callback( $args ) {
  */
 function edd_gateways_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$html = '<input type="hidden" name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" value="-1" />';
 
@@ -1477,7 +1538,7 @@ function edd_gateways_callback( $args ) {
 		else
 			$enabled = null;
 
-		$html .= '<input name="edd_settings[' . esc_attr( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" type="checkbox" value="1" ' . checked('1', $enabled, false) . '/>&nbsp;';
+		$html .= '<input name="edd_settings[' . esc_attr( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']" class="' . $class . '" type="checkbox" value="1" ' . checked('1', $enabled, false) . '/>&nbsp;';
 		$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . '][' . edd_sanitize_key( $key ) . ']">' . esc_html( $option['admin_label'] ) . '</label><br/>';
 	endforeach;
 
@@ -1496,10 +1557,22 @@ function edd_gateways_callback( $args ) {
  */
 function edd_gateway_select_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$html = '';
 
-	$html .= '<select name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']">';
+	$html .= '<select name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" class="' . $class . '">';
 
 	foreach ( $args['options'] as $key => $option ) :
 		$selected = isset( $edd_option ) ? selected( $key, $edd_option, false ) : '';
@@ -1538,10 +1611,22 @@ function edd_text_callback( $args ) {
 	} else {
 		$name = 'name="edd_settings[' . esc_attr( $args['id'] ) . ']"';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$readonly = $args['readonly'] === true ? ' readonly="readonly"' : '';
 	$size     = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
-	$html     = '<input type="text" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" ' . $name . ' value="' . esc_attr( stripslashes( $value ) ) . '"' . $readonly . '/>';
+	$html     = '<input type="text" class="' . $class . ' ' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" ' . $name . ' value="' . esc_attr( stripslashes( $value ) ) . '"' . $readonly . '/>';
 	$html    .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
 
 	echo apply_filters( 'edd_after_setting_output', $html, $args );
@@ -1573,13 +1658,25 @@ function edd_number_callback( $args ) {
 	} else {
 		$name = 'name="edd_settings[' . esc_attr( $args['id'] ) . ']"';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$max  = isset( $args['max'] ) ? $args['max'] : 999999;
 	$min  = isset( $args['min'] ) ? $args['min'] : 0;
 	$step = isset( $args['step'] ) ? $args['step'] : 1;
 
 	$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
-	$html = '<input type="number" step="' . esc_attr( $step ) . '" max="' . esc_attr( $max ) . '" min="' . esc_attr( $min ) . '" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" ' . $name . ' value="' . esc_attr( stripslashes( $value ) ) . '"/>';
+	$html = '<input type="number" step="' . esc_attr( $step ) . '" max="' . esc_attr( $max ) . '" min="' . esc_attr( $min ) . '" class="' . $class . ' ' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" ' . $name . ' value="' . esc_attr( stripslashes( $value ) ) . '"/>';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
 
 	echo apply_filters( 'edd_after_setting_output', $html, $args );
@@ -1603,8 +1700,20 @@ function edd_textarea_callback( $args ) {
 	} else {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
-	$html = '<textarea class="large-text" cols="50" rows="5" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']">' . esc_textarea( stripslashes( $value ) ) . '</textarea>';
+	$html = '<textarea class="' . $class . ' large-text" cols="50" rows="5" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']">' . esc_textarea( stripslashes( $value ) ) . '</textarea>';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
 
 	echo apply_filters( 'edd_after_setting_output', $html, $args );
@@ -1628,9 +1737,21 @@ function edd_password_callback( $args ) {
 	} else {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
-	$html = '<input type="password" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( $value ) . '"/>';
+	$html = '<input type="password" class="' . $class . ' ' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( $value ) . '"/>';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> ' . wp_kses_post( $args['desc'] ) . '</label>';
 
 	echo apply_filters( 'edd_after_setting_output', $html, $args );
@@ -1676,14 +1797,24 @@ function edd_select_callback($args) {
 	} else {
 		$placeholder = '';
 	}
-
-	if ( isset( $args['chosen'] ) ) {
-		$chosen = 'class="edd-chosen"';
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
 	} else {
-		$chosen = '';
+		$class = '';
 	}
 
-	$html = '<select id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" ' . $chosen . 'data-placeholder="' . esc_html( $placeholder ) . '" />';
+	if ( isset( $args['chosen'] ) ) {
+		$class .= ' edd-chosen';
+	}
+
+	$html = '<select id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" class="' . $class . '" data-placeholder="' . esc_html( $placeholder ) . '" />';
 
 	foreach ( $args['options'] as $option => $name ) {
 		$selected = selected( $option, $value, false );
@@ -1714,8 +1845,20 @@ function edd_color_select_callback( $args ) {
 	} else {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
-	$html = '<select id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']"/>';
+	$html = '<select id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" class="' . $class . '" name="edd_settings[' . esc_attr( $args['id'] ) . ']"/>';
 
 	foreach ( $args['options'] as $option => $color ) {
 		$selected = selected( $option, $value, false );
@@ -1751,9 +1894,20 @@ function edd_rich_editor_callback( $args ) {
 
 	$rows = isset( $args['size'] ) ? $args['size'] : 20;
 
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	ob_start();
-	wp_editor( stripslashes( $value ), 'edd_settings_' . esc_attr( $args['id'] ), array( 'textarea_name' => 'edd_settings[' . esc_attr( $args['id'] ) . ']', 'textarea_rows' => absint( $rows ) ) );
+	wp_editor( stripslashes( $value ), 'edd_settings_' . esc_attr( $args['id'] ), array( 'textarea_name' => 'edd_settings[' . esc_attr( $args['id'] ) . ']', 'textarea_rows' => absint( $rows ), 'editor_class' => $class ) );
 	$html = ob_get_clean();
 
 	$html .= '<br/><label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> ' . wp_kses_post( $args['desc'] ) . '</label>';
@@ -1779,9 +1933,21 @@ function edd_upload_callback( $args ) {
 	} else {
 		$value = isset($args['std']) ? $args['std'] : '';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
-	$html = '<input type="text" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( stripslashes( $value ) ) . '"/>';
+	$html = '<input type="text" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" clas="' . $class . '" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( stripslashes( $value ) ) . '"/>';
 	$html .= '<span>&nbsp;<input type="button" class="edd_settings_upload_button button-secondary" value="' . __( 'Upload File', 'easy-digital-downloads' ) . '"/></span>';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> ' . wp_kses_post( $args['desc'] ) . '</label>';
 
@@ -1809,8 +1975,20 @@ function edd_color_callback( $args ) {
 	}
 
 	$default = isset( $args['std'] ) ? $args['std'] : '';
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
-	$html = '<input type="text" class="edd-color-picker" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( $value ) . '" data-default-color="' . esc_attr( $default ) . '" />';
+	$html = '<input type="text" class="' . $class . ' edd-color-picker" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( $value ) . '" data-default-color="' . esc_attr( $default ) . '" />';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
 
 	echo apply_filters( 'edd_after_setting_output', $html, $args );
@@ -1834,11 +2012,29 @@ function edd_shop_states_callback($args) {
 	} else {
 		$placeholder = '';
 	}
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
 
 	$states = edd_get_shop_states();
-
-	$chosen = ( $args['chosen'] ? ' edd-chosen' : '' );
-	$class = empty( $states ) ? ' class="edd-no-states' . $chosen . '"' : 'class="' . $chosen . '"';
+    
+	if ( $args['chosen'] ) {
+		$class .= ' edd-chosen';
+	}
+    
+	if ( empty( $states ) ) {
+		$class .= ' edd-no-states';
+	}
+    
 	$html = '<select id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']"' . $class . 'data-placeholder="' . esc_html( $placeholder ) . '"/>';
 
 	foreach ( $states as $option => $name ) {
@@ -1863,9 +2059,22 @@ function edd_shop_states_callback($args) {
  */
 function edd_tax_rates_callback($args) {
 	$rates = edd_get_tax_rates();
+    
+	if ( isset( $args['class'] ) ) {
+        
+		if ( is_string( $args['class'] ) ) {
+			$class = $args['class'];
+		} else if ( is_array( $args['class'] ) ) {
+			$class = implode( ' ', $args['class'] );
+		}
+        
+	} else {
+		$class = '';
+	}
+    
 	ob_start(); ?>
 	<p><?php echo $args['desc']; ?></p>
-	<table id="edd_tax_rates" class="wp-list-table widefat fixed posts">
+	<table id="edd_tax_rates" class="wp-list-table widefat fixed posts <?php echo $class; ?>">
 		<thead>
 			<tr>
 				<th scope="col" class="edd_tax_country"><?php _e( 'Country', 'easy-digital-downloads' ); ?></th>
@@ -2141,6 +2350,16 @@ if ( ! function_exists( 'edd_license_key_callback' ) ) {
 			);
 
 			$license_status = null;
+		}
+        
+		if ( isset( $args['class'] ) ) {
+        
+			if ( is_string( $args['class'] ) ) {
+				$class .= $args['class'];
+			} else if ( is_array( $args['class'] ) ) {
+				$class .= implode( ' ', $args['class'] );
+			}
+        
 		}
 
 		$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -198,7 +198,7 @@ function edd_register_settings() {
 				    'faux'          => false,
 				    'tooltip_title' => false,
 				    'tooltip_desc'  => false,
-				    'class'         => '',
+				    'field_class'         => '',
 				) );
 
 				add_settings_field(
@@ -1323,12 +1323,12 @@ function edd_checkbox_callback( $args ) {
 		$name = 'name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1356,12 +1356,12 @@ function edd_checkbox_callback( $args ) {
 function edd_multicheck_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1393,12 +1393,12 @@ function edd_multicheck_callback( $args ) {
 function edd_payment_icons_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1476,12 +1476,12 @@ function edd_radio_callback( $args ) {
 
 	$html = '';
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1518,12 +1518,12 @@ function edd_radio_callback( $args ) {
 function edd_gateways_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1558,12 +1558,12 @@ function edd_gateways_callback( $args ) {
 function edd_gateway_select_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1612,12 +1612,12 @@ function edd_text_callback( $args ) {
 		$name = 'name="edd_settings[' . esc_attr( $args['id'] ) . ']"';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1659,12 +1659,12 @@ function edd_number_callback( $args ) {
 		$name = 'name="edd_settings[' . esc_attr( $args['id'] ) . ']"';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1701,12 +1701,12 @@ function edd_textarea_callback( $args ) {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1738,12 +1738,12 @@ function edd_password_callback( $args ) {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1798,12 +1798,12 @@ function edd_select_callback($args) {
 		$placeholder = '';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1846,12 +1846,12 @@ function edd_color_select_callback( $args ) {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1894,12 +1894,12 @@ function edd_rich_editor_callback( $args ) {
 
 	$rows = isset( $args['size'] ) ? $args['size'] : 20;
 
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1934,12 +1934,12 @@ function edd_upload_callback( $args ) {
 		$value = isset($args['std']) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -1976,12 +1976,12 @@ function edd_color_callback( $args ) {
 
 	$default = isset( $args['std'] ) ? $args['std'] : '';
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -2013,12 +2013,12 @@ function edd_shop_states_callback($args) {
 		$placeholder = '';
 	}
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -2060,12 +2060,12 @@ function edd_shop_states_callback($args) {
 function edd_tax_rates_callback($args) {
 	$rates = edd_get_tax_rates();
     
-	if ( isset( $args['class'] ) ) {
+	if ( isset( $args['field_class'] ) ) {
         
-		if ( is_string( $args['class'] ) ) {
-			$class = $args['class'];
-		} else if ( is_array( $args['class'] ) ) {
-			$class = implode( ' ', $args['class'] );
+		if ( is_string( $args['field_class'] ) ) {
+			$class = $args['field_class'];
+		} else if ( is_array( $args['field_class'] ) ) {
+			$class = implode( ' ', $args['field_class'] );
 		}
         
 	} else {
@@ -2352,12 +2352,12 @@ if ( ! function_exists( 'edd_license_key_callback' ) ) {
 			$license_status = null;
 		}
         
-		if ( isset( $args['class'] ) ) {
+		if ( isset( $args['field_class'] ) ) {
         
-			if ( is_string( $args['class'] ) ) {
-				$class .= $args['class'];
-			} else if ( is_array( $args['class'] ) ) {
-				$class .= implode( ' ', $args['class'] );
+			if ( is_string( $args['field_class'] ) ) {
+				$class .= $args['field_class'];
+			} else if ( is_array( $args['field_class'] ) ) {
+				$class .= implode( ' ', $args['field_class'] );
 			}
         
 		}

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -198,7 +198,7 @@ function edd_register_settings() {
 				    'faux'          => false,
 				    'tooltip_title' => false,
 				    'tooltip_desc'  => false,
-				    'field_class'         => '',
+				    'field_class'   => '',
 				) );
 
 				add_settings_field(
@@ -1161,6 +1161,26 @@ function edd_sanitize_text_field( $input ) {
 add_filter( 'edd_settings_sanitize_text', 'edd_sanitize_text_field' );
 
 /**
+ * Sanitize HTML Class Names
+ * 
+ * @since 2.6.11
+ * @param  string|array $class HTML Class Name(s)
+ * @return string $class
+ */
+function edd_sanitize_html_class( $class = '' ) {
+        
+	if ( is_string( $class ) ) {
+		$class = sanitize_html_class( $class );
+	} else if ( is_array( $class ) ) {
+		$class = array_values( array_map( 'sanitize_html_class', $class ) );
+		$class = implode( ' ', array_unique( $class ) );
+	}
+    
+	return $class;
+    
+}
+
+/**
  * Retrieve settings tabs
  *
  * @since 1.8
@@ -1323,17 +1343,7 @@ function edd_checkbox_callback( $args ) {
 		$name = 'name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$checked  = ! empty( $edd_option ) ? checked( 1, $edd_option, false ) : '';
 	$html     = '<input type="hidden"' . $name . ' value="-1" />';
@@ -1356,17 +1366,7 @@ function edd_checkbox_callback( $args ) {
 function edd_multicheck_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$html = '';
 	if ( ! empty( $args['options'] ) ) {
@@ -1393,17 +1393,7 @@ function edd_multicheck_callback( $args ) {
 function edd_payment_icons_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$html = '<input type="hidden" name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" value="-1" />';
 	if ( ! empty( $args['options'] ) ) {
@@ -1476,17 +1466,7 @@ function edd_radio_callback( $args ) {
 
 	$html = '';
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	foreach ( $args['options'] as $key => $option ) :
 		$checked = false;
@@ -1518,17 +1498,7 @@ function edd_radio_callback( $args ) {
 function edd_gateways_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$html = '<input type="hidden" name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" value="-1" />';
 
@@ -1558,17 +1528,7 @@ function edd_gateways_callback( $args ) {
 function edd_gateway_select_callback( $args ) {
 	$edd_option = edd_get_option( $args['id'] );
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$html = '';
 
@@ -1612,17 +1572,7 @@ function edd_text_callback( $args ) {
 		$name = 'name="edd_settings[' . esc_attr( $args['id'] ) . ']"';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$readonly = $args['readonly'] === true ? ' readonly="readonly"' : '';
 	$size     = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
@@ -1659,17 +1609,7 @@ function edd_number_callback( $args ) {
 		$name = 'name="edd_settings[' . esc_attr( $args['id'] ) . ']"';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$max  = isset( $args['max'] ) ? $args['max'] : 999999;
 	$min  = isset( $args['min'] ) ? $args['min'] : 0;
@@ -1701,17 +1641,7 @@ function edd_textarea_callback( $args ) {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$html = '<textarea class="' . $class . ' large-text" cols="50" rows="5" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']">' . esc_textarea( stripslashes( $value ) ) . '</textarea>';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
@@ -1738,17 +1668,7 @@ function edd_password_callback( $args ) {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
 	$html = '<input type="password" class="' . $class . ' ' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( $value ) . '"/>';
@@ -1798,17 +1718,7 @@ function edd_select_callback($args) {
 		$placeholder = '';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	if ( isset( $args['chosen'] ) ) {
 		$class .= ' edd-chosen';
@@ -1846,17 +1756,7 @@ function edd_color_select_callback( $args ) {
 		$value = isset( $args['std'] ) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$html = '<select id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" class="' . $class . '" name="edd_settings[' . esc_attr( $args['id'] ) . ']"/>';
 
@@ -1894,17 +1794,7 @@ function edd_rich_editor_callback( $args ) {
 
 	$rows = isset( $args['size'] ) ? $args['size'] : 20;
 
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	ob_start();
 	wp_editor( stripslashes( $value ), 'edd_settings_' . esc_attr( $args['id'] ), array( 'textarea_name' => 'edd_settings[' . esc_attr( $args['id'] ) . ']', 'textarea_rows' => absint( $rows ), 'editor_class' => $class ) );
@@ -1934,17 +1824,7 @@ function edd_upload_callback( $args ) {
 		$value = isset($args['std']) ? $args['std'] : '';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
 	$html = '<input type="text" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" clas="' . $class . '" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( stripslashes( $value ) ) . '"/>';
@@ -1976,17 +1856,7 @@ function edd_color_callback( $args ) {
 
 	$default = isset( $args['std'] ) ? $args['std'] : '';
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$html = '<input type="text" class="' . $class . ' edd-color-picker" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . esc_attr( $args['id'] ) . ']" value="' . esc_attr( $value ) . '" data-default-color="' . esc_attr( $default ) . '" />';
 	$html .= '<label for="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']"> '  . wp_kses_post( $args['desc'] ) . '</label>';
@@ -2013,17 +1883,7 @@ function edd_shop_states_callback($args) {
 		$placeholder = '';
 	}
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	$states = edd_get_shop_states();
     
@@ -2060,17 +1920,7 @@ function edd_shop_states_callback($args) {
 function edd_tax_rates_callback($args) {
 	$rates = edd_get_tax_rates();
     
-	if ( isset( $args['field_class'] ) ) {
-        
-		if ( is_string( $args['field_class'] ) ) {
-			$class = $args['field_class'];
-		} else if ( is_array( $args['field_class'] ) ) {
-			$class = implode( ' ', $args['field_class'] );
-		}
-        
-	} else {
-		$class = '';
-	}
+	$class = edd_sanitize_html_class( $args['field_class'] );
     
 	ob_start(); ?>
 	<p><?php echo $args['desc']; ?></p>
@@ -2352,15 +2202,7 @@ if ( ! function_exists( 'edd_license_key_callback' ) ) {
 			$license_status = null;
 		}
         
-		if ( isset( $args['field_class'] ) ) {
-        
-			if ( is_string( $args['field_class'] ) ) {
-				$class .= $args['field_class'];
-			} else if ( is_array( $args['field_class'] ) ) {
-				$class .= implode( ' ', $args['field_class'] );
-			}
-        
-		}
+		$class .= ' ' . edd_sanitize_html_class( $args['field_class'] );
 
 		$size = ( isset( $args['size'] ) && ! is_null( $args['size'] ) ) ? $args['size'] : 'regular';
 		$html = '<input type="text" class="' . sanitize_html_class( $size ) . '-text" id="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" name="edd_settings[' . edd_sanitize_key( $args['id'] ) . ']" value="' . esc_attr( $value ) . '"/>';


### PR DESCRIPTION
Needed to add extra Class Names to Settings API Fields for CSS/JavaScript needs. This should allow that for every field, even the more specific ones like the callback for Tax Rates.

The `field_class` argument accepts both Strings and a basic Array.

Examples

`$args['field_class'] = super awesome class-name;`

```
$args['field_class'] = array(
    'super',
    'awesome',
    'class-name'
);
```

In cases where Chosen or something else would normally place a Class Name onto the Field this still works just fine. The additional Class Names just become appended to the String that gets created.