### PR TITLE
Check _edd_download_limit exists before trying to access it in superglobal on metabox save routine

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -116,7 +116,7 @@ function edd_download_meta_box_save( $post_id, $post ) {
 
 		// Accept blank or "0"
 		if ( '_edd_download_limit' == $field ) {
-			if ( ! empty( $_POST[ $field ] ) || strlen( $_POST[ $field ] ) === 0 || "0" === $_POST[ $field ] ) {
+			if ( ! empty( $_POST[ $field ] ) || ( isset( $_POST[ $field ] ) && ( $_POST[ $field ] ) === 0 ) || ( isset( $_POST[ $field ] ) && "0" === $_POST[ $field ] ) ) {
 
 				$global_limit = edd_get_option( 'file_download_limit' );
 				$new_limit    = apply_filters( 'edd_metabox_save_' . $field, $_POST[ $field ] );

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -116,7 +116,7 @@ function edd_download_meta_box_save( $post_id, $post ) {
 
 		// Accept blank or "0"
 		if ( '_edd_download_limit' == $field ) {
-			if ( ! empty( $_POST[ $field ] ) || ( isset( $_POST[ $field ] ) && ( $_POST[ $field ] ) === 0 ) || ( isset( $_POST[ $field ] ) && "0" === $_POST[ $field ] ) ) {
+			if ( ! empty( $_POST[ $field ] ) || ( isset( $_POST[ $field ] ) && strlen( $_POST[ $field ] ) === 0 ) || ( isset( $_POST[ $field ] ) && "0" === $_POST[ $field ] ) ) {
 
 				$global_limit = edd_get_option( 'file_download_limit' );
 				$new_limit    = apply_filters( 'edd_metabox_save_' . $field, $_POST[ $field ] );


### PR DESCRIPTION
 Solves #5140 
In the save routine for the downloads metabox, _edd_download_limit isn't checked for existence before attempting to access it on line 119