### PR TITLE
Fix link to iOS addon

### DIFF
--- a/includes/admin/payments/payments-history.php
+++ b/includes/admin/payments/payments-history.php
@@ -59,7 +59,7 @@ function edd_payment_history_page() {
 function edd_payment_history_mobile_link() {
 	?>
 	<p class="edd-mobile-link">
-		<a href="https://easydigitaldownloads.com/downloads/ios-sales-earnings-tracker/?utm_source=payments&utm_medium=mobile-link&utm_campaign=admin" target="_blank">
+		<a href="https://easydigitaldownloads.com/downloads/ios-app/?utm_source=payments&utm_medium=mobile-link&utm_campaign=admin" target="_blank">
 			<img src="<?php echo EDD_PLUGIN_URL . 'assets/images/icons/iphone.png'; ?>" alt="<?php _e( 'Easy Digital Downloads iOS App', 'easy-digital-downloads' ); ?>"/>
 			<?php _e( 'Get the EDD Sales / Earnings tracker for iOS', 'easy-digital-downloads' ); ?>
 		</a>


### PR DESCRIPTION
The link to the iOS addon is incorrect. This simply fixes that typo