### PR TITLE
Fixes issue #5171 about determining if main section for a tab is empty

### DIFF
--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -47,7 +47,7 @@ function edd_options_page() {
 	
 	// Check for old non-sectioned settings (see #4211 and #5171)
 	if ( ! $has_main_settings ) {
-		foreach( $all_settings as $sid => $stitle ) {
+		foreach( $all_settings[ $active_tab ] as $sid => $stitle ) {
 			if ( is_string( $sid ) && is_array( $sections ) && in_array( $sid, $sections ) ) {
 				continue;
 			} else {

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -46,7 +46,6 @@ function edd_options_page() {
 	}
 	
 	// Check for old non-sectioned settings (see #4211 and #5171)
-	$nonsectioned_settings = array();
 	if ( ! $has_main_settings ) {
 		foreach( $all_settings as $sid => $stitle ) {
 			if ( is_string( $sid ) && is_array( $sections ) && in_array( $sid, $sections ) ) {

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -44,11 +44,11 @@ function edd_options_page() {
 	if ( empty( $all_settings[ $active_tab ]['main'] ) ) {
 		$has_main_settings = false;
 	}
-	
+
 	// Check for old non-sectioned settings (see #4211 and #5171)
 	if ( ! $has_main_settings ) {
 		foreach( $all_settings[ $active_tab ] as $sid => $stitle ) {
-			if ( is_string( $sid ) && is_array( $sections ) && in_array( $sid, $sections ) ) {
+			if ( is_string( $sid ) && is_array( $sections ) && array_key_exists( $sid, $sections ) ) {
 				continue;
 			} else {
 				$has_main_settings = true;

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -44,6 +44,19 @@ function edd_options_page() {
 	if ( empty( $all_settings[ $active_tab ]['main'] ) ) {
 		$has_main_settings = false;
 	}
+	
+	// Check for old non-sectioned settings (see #4211 and #5171)
+	$nonsectioned_settings = array();
+	if ( ! $has_main_settings ) {
+		foreach( $all_settings as $sid => $stitle ) {
+			if ( is_string( $sid ) && is_array( $sections ) && in_array( $sid, $sections ) ) {
+				continue;
+			} else {
+				$has_main_settings = true;
+				break;
+			}
+		}
+	}
 
 	$override = false;
 	if ( false === $has_main_settings ) {

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -40,10 +40,10 @@ function edd_options_page() {
 	$all_settings = edd_get_registered_settings();
 
 	// Let's verify we have a 'main' section to show
-	ob_start();
-	do_settings_sections( 'edd_settings_' . $active_tab . '_main' );
-	$has_main_settings = strlen( ob_get_contents() ) > 0;
-	ob_end_clean();
+	$has_main_settings = true;
+	if ( empty( $all_settings[ $active_tab ]['main'] ) ) {
+		$has_main_settings = false;
+	}
 
 	$override = false;
 	if ( false === $has_main_settings ) {


### PR DESCRIPTION
Implement a better way of determining if the main settings section is empty for a tab.

Solves #5171

The change basically changes the part that determines if the `main` section is empty, and makes it use the same code we use a couple lines down for finding the first non-empty section to replace it with.