### PR TITLE
Add support for user admin locales

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -381,7 +381,21 @@ final class Easy_Digital_Downloads {
 		$edd_lang_dir  = apply_filters( 'edd_languages_directory', $edd_lang_dir );
 
 		// Traditional WordPress plugin locale filter.
-		$locale        = apply_filters( 'plugin_locale',  get_locale(), 'easy-digital-downloads' );
+
+		$get_locale = get_locale();
+
+		if ( $wp_version >= 4.7 ) {
+
+			$get_locale = get_user_locale();
+		}
+
+		/**
+		 * Defines the plugin language locale used in AffiliateWP.
+		 *
+		 * @var $get_locale The locale to use. Uses get_user_locale()` in WordPress 4.7 or greater,
+		 *                  otherwise uses `get_locale()`.
+		 */
+		$locale        = apply_filters( 'plugin_locale',  $get_locale, 'easy-digital-downloads' );
 		$mofile        = sprintf( '%1$s-%2$s.mo', 'easy-digital-downloads', $locale );
 
 		// Look for wp-content/languages/edd/easy-digital-downloads-{lang}_{country}.mo

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -355,6 +355,7 @@ final class Easy_Digital_Downloads {
 	 * @return void
 	 */
 	public function load_textdomain() {
+		global $wp_version;
 
 		/*
 		 * Due to the introduction of language packs through translate.wordpress.org, loading our textdomain is complex.

--- a/includes/admin/tracking.php
+++ b/includes/admin/tracking.php
@@ -101,7 +101,7 @@ class EDD_Tracking {
 		$data['inactive_plugins'] = $plugins;
 		$data['products']         = wp_count_posts( 'download' )->publish;
 		$data['download_label']   = edd_get_label_singular( true );
-		$data['locale']           = get_locale();
+		$data['locale']           = ( $data['wp_version'] >= 4.7 ) ? get_user_locale() : get_locale();
 
 		$this->data = $data;
 	}


### PR DESCRIPTION
Adds support for user locales:
- The primary EDD `load_textdomain()` loader
- EDD_Tracking::setup_data()
- Related inline hook doc

#5247