### PR TITLE
Add "required" attribute to the email input field

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -5,7 +5,7 @@
  * Description: The easiest way to sell digital products with WordPress.
  * Author: Easy Digital Downloads
  * Author URI: https://easydigitaldownloads.com
- * Version: 2.6.12
+ * Version: 2.6.13
  * Text Domain: easy-digital-downloads
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EDD
  * @category Core
  * @author Pippin Williamson
- * @version 2.6.12
+ * @version 2.6.13
  */
 
 // Exit if accessed directly.
@@ -196,7 +196,7 @@ final class Easy_Digital_Downloads {
 
 		// Plugin version.
 		if ( ! defined( 'EDD_VERSION' ) ) {
-			define( 'EDD_VERSION', '2.6.12' );
+			define( 'EDD_VERSION', '2.6.13' );
 		}
 
 		// Plugin Folder Path.

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -183,7 +183,7 @@ function edd_user_info_fields() {
 				<?php } ?>
 			</label>
 			<span class="edd-description"><?php _e( 'We will send the purchase receipt to this address.', 'easy-digital-downloads' ); ?></span>
-			<input class="edd-input required" type="email" name="edd_email" placeholder="<?php _e( 'Email address', 'easy-digital-downloads' ); ?>" id="edd-email" value="<?php echo esc_attr( $customer['email'] ); ?>"/>
+			<input class="edd-input required" type="email" name="edd_email" placeholder="<?php _e( 'Email address', 'easy-digital-downloads' ); ?>" id="edd-email" value="<?php echo esc_attr( $customer['email'] ); ?>"<?php if( edd_field_is_required( 'edd_email' ) ) {  echo ' required '; } ?>/>
 		</p>
 		<?php do_action( 'edd_purchase_form_after_email' ); ?>
 		<p id="edd-first-name-wrap">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-digital-downloads",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "private": true,
   "devDependencies": {
     "grunt": "^1.0.1",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: https://easydigitaldownloads.com/donate/
 Tags: download, downloads, e-store, eshop, digital downloads, e-commerce, wp-ecommerce, wp ecommerce
 Requires at least: 4.0
 Tested up to: 4.7
-Stable Tag: 2.6.12
+Stable Tag: 2.6.13
 
 License: GNU Version 2 or Any Later Version
 
@@ -186,6 +186,9 @@ Yes, through the addition of one or more of the add-on payment gateways, you can
 9. Checkout screen
 
 == Changelog ==
+
+= 2.6.13, November 21, 2016 =
+* Fix: Custom payment meta items were not being saved correctly.
 
 = 2.6.12, November 17, 2016 =
 * New: Added new hooks to the profile editor form.


### PR DESCRIPTION
The email field is required by default, just like the first name, but the first name input field has the "required" attribute and the email input doesn't. This PR just adds the missing "required" attribute to the email input field.