### PR TITLE
Add download attribute to file download links. See #5259

### DIFF
--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -427,7 +427,7 @@ function edd_email_tag_download_list( $payment_id ) {
 					if ( $show_links ) {
 						$download_list .= '<div>';
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $item['id'], $price_id );
-							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
+							$download_list .= '<a href="' . esc_url( $file_url ) . '" download>' . edd_get_file_name( $file ) . '</a>';
 							$download_list .= '</div>';
 					} else {
 						$download_list .= '<div>';
@@ -451,7 +451,7 @@ function edd_email_tag_download_list( $payment_id ) {
 						if ( $show_links ) {
 							$download_list .= '<div>';
 							$file_url = edd_get_download_file_url( $payment_data['key'], $email, $filekey, $bundle_item, $price_id );
-							$download_list .= '<a href="' . esc_url( $file_url ) . '">' . edd_get_file_name( $file ) . '</a>';
+							$download_list .= '<a href="' . esc_url( $file_url ) . '" download>' . edd_get_file_name( $file ) . '</a>';
 							$download_list .= '</div>';
 						} else {
 							$download_list .= '<div>';

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -554,7 +554,7 @@ function edd_get_purchase_download_links( $payment_id = 0 ) {
 			if ( is_array( $files ) ) {
 				foreach ( $files as $filekey => $file ) {
 					$links .= '<div class="edd_download_link_file">';
-						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '">';
+						$links .= '<a href="' . esc_url( edd_get_download_file_url( $payment_key, $email, $filekey, $download['id'], $price_id ) ) . '" download>';
 						$links .= edd_get_file_name( $file );
 						$links .= '</a>';
 					$links .= '</div>';

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -62,7 +62,7 @@ if ( $purchases ) :
 											?>
 
 											<div class="edd_download_file">
-												<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link">
+												<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link" download>
 													<?php echo edd_get_file_name( $file ); ?>
 												</a>
 											</div>

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -169,7 +169,7 @@ $status    = edd_get_payment_status( $payment, true );
 									$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $item['id'], $price_id );
 									?>
 									<li class="edd_download_file">
-										<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
+										<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link" download><?php echo edd_get_file_name( $file ); ?></a>
 									</li>
 									<?php
 									do_action( 'edd_receipt_files', $filekey, $file, $item['id'], $payment->ID, $meta );
@@ -192,7 +192,7 @@ $status    = edd_get_payment_status( $payment, true );
 
 													$download_url = edd_get_download_file_url( $meta['key'], $email, $filekey, $bundle_item, $price_id ); ?>
 													<li class="edd_download_file">
-														<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link"><?php echo edd_get_file_name( $file ); ?></a>
+														<a href="<?php echo esc_url( $download_url ); ?>" class="edd_download_file_link" download><?php echo edd_get_file_name( $file ); ?></a>
 													</li>
 													<?php
 													do_action( 'edd_receipt_bundle_files', $filekey, $file, $item['id'], $bundle_item, $payment->ID, $meta );


### PR DESCRIPTION
As EDD already seems to already default to a clean file name, I opted to only use the `download` attribute without the optional filename override.

See: http://www.w3schools.com/TAgs/att_a_download.asp

#5259 