### PR TITLE
Fixing unit tests for useage of _delete_all_data

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -84,7 +84,7 @@ function edd_run_install() {
 	$current_options = get_option( 'edd_settings', array() );
 
 	// Checks if the purchase page option exists
-	if ( ! array_key_exists( 'purchase_page', $current_options ) ) {
+	if ( ! array_key_exists( 'purchase_page', $current_options ) || empty( get_post( $current_options['purchase_page'] ) ) ) {
 		// Checkout Page
 		$checkout = wp_insert_post(
 			array(
@@ -100,7 +100,9 @@ function edd_run_install() {
 		$options['purchase_page'] = $checkout;
 	}
 
-	if ( ! array_key_exists( 'success_page', $current_options ) ) {
+	$checkout = isset( $checkout ) ? $checkout : $current_options['purchase_page'];
+
+	if ( ! array_key_exists( 'success_page', $current_options ) || empty( get_post( $current_options['success_page'] ) ) ) {
 		// Purchase Confirmation (Success) Page
 		$success = wp_insert_post(
 			array(
@@ -117,7 +119,7 @@ function edd_run_install() {
 		$options['success_page'] = $success;
 	}
 
-	if ( ! array_key_exists( 'failure_page', $current_options ) ) {
+	if ( ! array_key_exists( 'failure_page', $current_options ) || empty( get_post( $current_options['failure_page'] ) ) ) {
 		// Failed Purchase Page
 		$failed = wp_insert_post(
 			array(
@@ -134,7 +136,7 @@ function edd_run_install() {
 		$options['failure_page'] = $failed;
 	}
 
-	if ( ! array_key_exists( 'purchase_history_page', $current_options ) ) {
+	if ( ! array_key_exists( 'purchase_history_page', $current_options ) || empty( get_post( $current_options['purchase_history_page'] ) ) ) {
 		// Purchase History (History) Page
 		$history = wp_insert_post(
 			array(

--- a/includes/install.php
+++ b/includes/install.php
@@ -84,7 +84,8 @@ function edd_run_install() {
 	$current_options = get_option( 'edd_settings', array() );
 
 	// Checks if the purchase page option exists
-	if ( ! array_key_exists( 'purchase_page', $current_options ) || empty( get_post( $current_options['purchase_page'] ) ) ) {
+	$purchase_page = array_key_exists( 'purchase_page', $current_options ) ? get_post( $current_options['purchase_page'] ) : false;
+	if ( empty( $purchase_page ) ) {
 		// Checkout Page
 		$checkout = wp_insert_post(
 			array(
@@ -102,7 +103,8 @@ function edd_run_install() {
 
 	$checkout = isset( $checkout ) ? $checkout : $current_options['purchase_page'];
 
-	if ( ! array_key_exists( 'success_page', $current_options ) || empty( get_post( $current_options['success_page'] ) ) ) {
+	$success_page = array_key_exists( 'success_page', $current_options ) ? get_post( $current_options['success_page'] ) : false;
+	if ( empty( $success_page ) ) {
 		// Purchase Confirmation (Success) Page
 		$success = wp_insert_post(
 			array(
@@ -119,7 +121,8 @@ function edd_run_install() {
 		$options['success_page'] = $success;
 	}
 
-	if ( ! array_key_exists( 'failure_page', $current_options ) || empty( get_post( $current_options['failure_page'] ) ) ) {
+	$failure_page = array_key_exists( 'failure_page', $current_options ) ? get_post( $current_options['failure_page'] ) : false;
+	if ( empty( $failure_page ) ) {
 		// Failed Purchase Page
 		$failed = wp_insert_post(
 			array(
@@ -136,7 +139,8 @@ function edd_run_install() {
 		$options['failure_page'] = $failed;
 	}
 
-	if ( ! array_key_exists( 'purchase_history_page', $current_options ) || empty( get_post( $current_options['purchase_history_page'] ) ) ) {
+	$history_page = array_key_exists( 'purchase_history_page', $current_options ) ? get_post( $current_options['purchase_history_page'] ) : false;
+	if ( empty( $history_page ) ) {
 		// Purchase History (History) Page
 		$history = wp_insert_post(
 			array(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -45,3 +45,4 @@ require_once 'helpers/shims.php';
 require_once 'helpers/class-helper-download.php';
 require_once 'helpers/class-helper-payment.php';
 require_once 'helpers/class-helper-discount.php';
+require_once 'helpers/class-edd-unittestcase.php';

--- a/tests/helpers/class-edd-unittestcase.php
+++ b/tests/helpers/class-edd-unittestcase.php
@@ -1,0 +1,7 @@
+<?php
+
+class EDD_UnitTestCase extends WP_UnitTestCase {
+	public static function wpSetUpBeforeClass() {
+		edd_install();
+	}
+}

--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -18,8 +18,8 @@ class Tests_API extends WP_UnitTestCase {
 
 	protected $_user_id = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 	}
 
 	public function setUp() {

--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -3,7 +3,7 @@
 /**
  * @group edd_api
  */
-class Tests_API extends WP_UnitTestCase {
+class Tests_API extends EDD_UnitTestCase {
 	protected $_rewrite = null;
 
 	protected $query = null;
@@ -17,10 +17,6 @@ class Tests_API extends WP_UnitTestCase {
 	protected $_api_output_sales = null;
 
 	protected $_user_id = null;
-
-	public static function wpSetUpBeforeClass() {
-
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-cart.php
+++ b/tests/tests-cart.php
@@ -9,8 +9,8 @@ class Test_Cart extends WP_UnitTestCase {
 	protected $_post = null;
 	protected $_discount = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-cart.php
+++ b/tests/tests-cart.php
@@ -3,16 +3,11 @@
 /**
  * @group edd_cart
  */
-class Test_Cart extends WP_UnitTestCase {
+class Test_Cart extends EDD_UnitTestCase {
 	protected $_rewrite = null;
 
 	protected $_post = null;
 	protected $_discount = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-checkout.php
+++ b/tests/tests-checkout.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_checkout
  */
-class Tests_Checkout extends WP_UnitTestCase {
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
-
+class Tests_Checkout extends EDD_UnitTestCase {
 	public function setUp() {
 
 		parent::setUp();

--- a/tests/tests-checkout.php
+++ b/tests/tests-checkout.php
@@ -5,8 +5,8 @@
  * @group edd_checkout
  */
 class Tests_Checkout extends WP_UnitTestCase {
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-customer-meta.php
+++ b/tests/tests-customer-meta.php
@@ -1,13 +1,8 @@
 <?php
-class Tests_Customer_Meta extends WP_UnitTestCase {
+class Tests_Customer_Meta extends EDD_UnitTestCase {
 
 	protected $_customer;
 	protected $_customer_id = 0;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	function setUp() {
 		parent::setUp();

--- a/tests/tests-customer-meta.php
+++ b/tests/tests-customer-meta.php
@@ -4,8 +4,8 @@ class Tests_Customer_Meta extends WP_UnitTestCase {
 	protected $_customer;
 	protected $_customer_id = 0;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-customers-db.php
+++ b/tests/tests-customers-db.php
@@ -11,8 +11,8 @@ class Tests_Customers_DB extends WP_UnitTestCase {
 
 	protected $_customer_id = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-customers-db.php
+++ b/tests/tests-customers-db.php
@@ -3,18 +3,13 @@
 /**
  * @group edd_customers
  */
-class Tests_Customers_DB extends WP_UnitTestCase {
+class Tests_Customers_DB extends EDD_UnitTestCase {
 
 	protected $_post_id = null;
 
 	protected $_user_id = null;
 
 	protected $_customer_id = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-customers.php
+++ b/tests/tests-customers.php
@@ -3,18 +3,13 @@
 /**
  * @group edd_customers
  */
-class Tests_Customers extends WP_UnitTestCase {
+class Tests_Customers extends EDD_UnitTestCase {
 
 	protected $_post_id = null;
 
 	protected $_user_id = null;
 
 	protected $_customer_id = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-customers.php
+++ b/tests/tests-customers.php
@@ -11,8 +11,8 @@ class Tests_Customers extends WP_UnitTestCase {
 
 	protected $_customer_id = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-discounts.php
+++ b/tests/tests-discounts.php
@@ -4,17 +4,12 @@
 /**
  * @group edd_discounts
  */
-class Tests_Discounts extends WP_UnitTestCase {
+class Tests_Discounts extends EDD_UnitTestCase {
 	protected $_post = null;
 	protected $_post_id = null;
 	protected $_download = null;
 	protected $_flat_post_id = null;
 	protected $_negative_post_id = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 

--- a/tests/tests-discounts.php
+++ b/tests/tests-discounts.php
@@ -11,8 +11,8 @@ class Tests_Discounts extends WP_UnitTestCase {
 	protected $_flat_post_id = null;
 	protected $_negative_post_id = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-downloads.php
+++ b/tests/tests-downloads.php
@@ -4,17 +4,12 @@
 /**
  * @group edd_downloads
  */
-class Tests_Downloads extends WP_UnitTestCase {
+class Tests_Downloads extends EDD_UnitTestCase {
 	protected $_post = null;
 
 	protected $_variable_pricing = null;
 
 	protected $_download_files = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-downloads.php
+++ b/tests/tests-downloads.php
@@ -11,8 +11,8 @@ class Tests_Downloads extends WP_UnitTestCase {
 
 	protected $_download_files = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-easy-digital-downloads.php
+++ b/tests/tests-easy-digital-downloads.php
@@ -1,13 +1,8 @@
 <?php
 
 
-class Tests_EDD extends WP_UnitTestCase {
+class Tests_EDD extends EDD_UnitTestCase {
 	protected $object;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-easy-digital-downloads.php
+++ b/tests/tests-easy-digital-downloads.php
@@ -4,8 +4,8 @@
 class Tests_EDD extends WP_UnitTestCase {
 	protected $object;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-emails.php
+++ b/tests/tests-emails.php
@@ -3,16 +3,11 @@
 /**
  * @group edd_emails
  */
-class Tests_Emails extends WP_UnitTestCase {
+class Tests_Emails extends EDD_UnitTestCase {
 
 	protected $_tags;
 
 	protected $payment_id;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-emails.php
+++ b/tests/tests-emails.php
@@ -9,8 +9,8 @@ class Tests_Emails extends WP_UnitTestCase {
 
 	protected $payment_id;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-errors.php
+++ b/tests/tests-errors.php
@@ -6,8 +6,8 @@
  */
 class Tests_Errors extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-errors.php
+++ b/tests/tests-errors.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_errors
  */
-class Tests_Errors extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Errors extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-fees.php
+++ b/tests/tests-fees.php
@@ -7,8 +7,8 @@
 class Tests_Fee extends WP_UnitTestCase {
 	protected $_post = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-fees.php
+++ b/tests/tests-fees.php
@@ -4,13 +4,8 @@
 /**
  * @group edd_fees
  */
-class Tests_Fee extends WP_UnitTestCase {
+class Tests_Fee extends EDD_UnitTestCase {
 	protected $_post = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 

--- a/tests/tests-filters.php
+++ b/tests/tests-filters.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_filters
  */
-class Tests_Filters extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Filters extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-filters.php
+++ b/tests/tests-filters.php
@@ -6,8 +6,8 @@
  */
 class Tests_Filters extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-formatting.php
+++ b/tests/tests-formatting.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_formatting
  */
-class Tests_Formatting extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Formatting extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-formatting.php
+++ b/tests/tests-formatting.php
@@ -6,8 +6,8 @@
  */
 class Tests_Formatting extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-gateways.php
+++ b/tests/tests-gateways.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_gateways
  */
-class Test_Gateways extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Test_Gateways extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-gateways.php
+++ b/tests/tests-gateways.php
@@ -6,8 +6,8 @@
  */
 class Test_Gateways extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-html-elements.php
+++ b/tests/tests-html-elements.php
@@ -8,8 +8,8 @@ class Test_HTML_Elements extends WP_UnitTestCase {
 	protected $_post_id = null;
 
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-html-elements.php
+++ b/tests/tests-html-elements.php
@@ -4,14 +4,8 @@
 /**
  * @group edd_html
  */
-class Test_HTML_Elements extends WP_UnitTestCase {
+class Test_HTML_Elements extends EDD_UnitTestCase {
 	protected $_post_id = null;
-
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-install.php
+++ b/tests/tests-install.php
@@ -4,13 +4,7 @@
 /**
  * @group edd_activation
  */
-class Tests_Activation extends WP_UnitTestCase {
-
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Activation extends EDD_UnitTestCase {
 
 	/**
 	 * SetUp test class.

--- a/tests/tests-install.php
+++ b/tests/tests-install.php
@@ -7,8 +7,8 @@
 class Tests_Activation extends WP_UnitTestCase {
 
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-languages.php
+++ b/tests/tests-languages.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_languages
  */
-class Tests_Languages extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Languages extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-languages.php
+++ b/tests/tests-languages.php
@@ -6,8 +6,8 @@
  */
 class Tests_Languages extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-logging.php
+++ b/tests/tests-logging.php
@@ -4,13 +4,8 @@
 /**
  * @group edd_logging
  */
-class Tests_Logging extends WP_UnitTestCase {
+class Tests_Logging extends EDD_UnitTestCase {
 	protected $_object = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-logging.php
+++ b/tests/tests-logging.php
@@ -7,8 +7,8 @@
 class Tests_Logging extends WP_UnitTestCase {
 	protected $_object = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-login-register.php
+++ b/tests/tests-login-register.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_login_register
  */
-class Tests_Login_Register extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Login_Register extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-login-register.php
+++ b/tests/tests-login-register.php
@@ -6,8 +6,8 @@
  */
 class Tests_Login_Register extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-mime.php
+++ b/tests/tests-mime.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_mime
  */
-class Tests_Mime extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Mime extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-mime.php
+++ b/tests/tests-mime.php
@@ -6,8 +6,8 @@
  */
 class Tests_Mime extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -6,8 +6,7 @@
  */
 class Test_Misc extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
 		edd_install();
 	}
 
@@ -544,7 +543,7 @@ class Test_Misc extends WP_UnitTestCase {
 		EDD_Helper_Download::delete_download( $post->ID );
 		remove_filter( 'edd_is_caching_plugin_active', '__return_true' );
 
-		$this->go_to( get_permalink( edd_get_option( 'purchase_page', false ) ) );
+		$this->go_to( get_permalink( $edd_options['purchase_page'] ) );
 		$this->assertEquals( edd_get_checkout_uri(), edd_get_current_page_url() );
 
 		add_filter( 'edd_is_caching_plugin_active', '__return_true' );
@@ -571,7 +570,7 @@ class Test_Misc extends WP_UnitTestCase {
 
 		$remove_url = edd_remove_item_url( $item_position );
 
-		$this->assertContains( 'page_id=3', $remove_url );
+		$this->assertContains( 'page_id=' . $edd_options['purchase_page'], $remove_url );
 		$this->assertContains( 'edd_action=remove', $remove_url );
 		$this->assertContains( 'nocache=true', $remove_url );
 		$this->assertContains( 'cart_item=' . $item_position, $remove_url );
@@ -580,7 +579,7 @@ class Test_Misc extends WP_UnitTestCase {
 		unset( $edd_options['no_cache_checkout'] );
 		$remove_url = edd_remove_item_url( $item_position );
 
-		$this->assertContains( 'page_id=3', $remove_url );
+		$this->assertContains( 'page_id=' . $edd_options['purchase_page'], $remove_url );
 		$this->assertContains( 'edd_action=remove', $remove_url );
 		$this->assertContains( 'cart_item=' . $item_position, $remove_url );
 		$this->assertNotContains( 'nocache=true', $remove_url );

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -4,11 +4,7 @@
 /**
  * @group edd_misc
  */
-class Test_Misc extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-		edd_install();
-	}
+class Test_Misc extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-payment-class.php
+++ b/tests/tests-payment-class.php
@@ -3,17 +3,12 @@
 /**
  * @group edd_payments
  */
-class Tests_Payment_Class extends WP_UnitTestCase {
+class Tests_Payment_Class extends EDD_UnitTestCase {
 
 	protected $_payment_id = null;
 	protected $_key = null;
 	protected $_post = null;
 	protected $_payment_key = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 

--- a/tests/tests-payment-class.php
+++ b/tests/tests-payment-class.php
@@ -10,8 +10,8 @@ class Tests_Payment_Class extends WP_UnitTestCase {
 	protected $_post = null;
 	protected $_payment_key = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-payments.php
+++ b/tests/tests-payments.php
@@ -10,8 +10,7 @@ class Tests_Payments extends WP_UnitTestCase {
 	protected $_post = null;
 	protected $_payment_key = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
 		edd_install();
 	}
 

--- a/tests/tests-payments.php
+++ b/tests/tests-payments.php
@@ -3,16 +3,12 @@
 /**
  * @group edd_payments
  */
-class Tests_Payments extends WP_UnitTestCase {
+class Tests_Payments extends EDD_UnitTestCase {
 
 	protected $_payment_id = null;
 	protected $_key = null;
 	protected $_post = null;
 	protected $_payment_key = null;
-
-	public static function wpSetUpBeforeClass() {
-		edd_install();
-	}
 
 	public function setUp() {
 

--- a/tests/tests-plugin-compatibility.php
+++ b/tests/tests-plugin-compatibility.php
@@ -3,7 +3,7 @@
 /**
  * @group plugin_compatibility
  */
-class Tests_Plugin_Compatibility extends WP_UnitTestCase {
+class Tests_Plugin_Compatibility extends EDD_UnitTestCase {
 
 	/**
 	 * Test that the filter exists of the function.

--- a/tests/tests-post-type-labels.php
+++ b/tests/tests-post-type-labels.php
@@ -6,8 +6,8 @@
  */
 class Tests_Post_Type_Labels extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-post-type-labels.php
+++ b/tests/tests-post-type-labels.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_cpt
  */
-class Tests_Post_Type_Labels extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Post_Type_Labels extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-post-types.php
+++ b/tests/tests-post-types.php
@@ -6,8 +6,8 @@
  */
 class Tests_Post_Types extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-post-types.php
+++ b/tests/tests-post-types.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_cpt
  */
-class Tests_Post_Types extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Post_Types extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-process-dowload.php
+++ b/tests/tests-process-dowload.php
@@ -4,13 +4,7 @@
 /**
  * @group edd_downloads
  */
-class Tests_Process_Download extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
-
+class Tests_Process_Download extends EDD_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 	}

--- a/tests/tests-process-dowload.php
+++ b/tests/tests-process-dowload.php
@@ -6,8 +6,8 @@
  */
 class Tests_Process_Download extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-query-filters.php
+++ b/tests/tests-query-filters.php
@@ -3,7 +3,7 @@
 /**
  * @group query_filters
  */
-class Tests_Query_Filters extends WP_UnitTestCase {
+class Tests_Query_Filters extends EDD_UnitTestCase {
 
 	/**
 	 * Test that the actions exists for the edd_block_attachments() function.

--- a/tests/tests-register-meta.php
+++ b/tests/tests-register-meta.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_meta
  */
-class Tests_Register_Meta extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Register_Meta extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-register-meta.php
+++ b/tests/tests-register-meta.php
@@ -6,8 +6,8 @@
  */
 class Tests_Register_Meta extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-roles.php
+++ b/tests/tests-roles.php
@@ -7,8 +7,8 @@ class Tests_Roles extends WP_UnitTestCase {
 
 	protected $_roles;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-roles.php
+++ b/tests/tests-roles.php
@@ -3,14 +3,9 @@
 /**
  * @group edd_roles
  */
-class Tests_Roles extends WP_UnitTestCase {
+class Tests_Roles extends EDD_UnitTestCase {
 
 	protected $_roles;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-scripts.php
+++ b/tests/tests-scripts.php
@@ -5,6 +5,10 @@
  */
 class Tests_Scripts extends WP_UnitTestCase {
 
+	public static function wpSetUpBeforeClass() {
+		edd_install();
+	}
+
 	/**
 	 * Test if all the file hooks are working.
 	 *
@@ -25,9 +29,10 @@ class Tests_Scripts extends WP_UnitTestCase {
 	 * @since 2.3.6
 	 */
 	public function test_load_scripts_checkout() {
+		global $edd_options;
 
 		// Prepare test
-		$this->go_to( get_permalink( edd_get_option( 'purchase_page' ) ) );
+		$this->go_to( get_permalink( $edd_options['purchase_page'] ) );
 		edd_load_scripts();
 
 		$this->assertTrue( wp_script_is( 'creditCardValidator', 'enqueued' ) );

--- a/tests/tests-scripts.php
+++ b/tests/tests-scripts.php
@@ -3,11 +3,7 @@
 /**
  * @group scripts
  */
-class Tests_Scripts extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-		edd_install();
-	}
+class Tests_Scripts extends EDD_UnitTestCase {
 
 	/**
 	 * Test if all the file hooks are working.

--- a/tests/tests-session.php
+++ b/tests/tests-session.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_session
  */
-class Tests_Session extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Session extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-session.php
+++ b/tests/tests-session.php
@@ -6,8 +6,8 @@
  */
 class Tests_Session extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-shortcodes.php
+++ b/tests/tests-shortcodes.php
@@ -12,8 +12,8 @@ class Tests_Shortcode extends WP_UnitTestCase {
 
 	protected $_payment_key = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-shortcodes.php
+++ b/tests/tests-shortcodes.php
@@ -4,18 +4,13 @@
 /**
  * @group edd_shortcode
  */
-class Tests_Shortcode extends WP_UnitTestCase {
+class Tests_Shortcode extends EDD_UnitTestCase {
 
 	protected $_payment_id = null;
 
 	protected $_post = null;
 
 	protected $_payment_key = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-stats.php
+++ b/tests/tests-stats.php
@@ -9,8 +9,8 @@ class Tests_Stats extends WP_UnitTestCase {
 	protected $_stats;
 	protected $_payment_stats;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-stats.php
+++ b/tests/tests-stats.php
@@ -3,16 +3,11 @@
 /**
  * @group edd_stats
  */
-class Tests_Stats extends WP_UnitTestCase {
+class Tests_Stats extends EDD_UnitTestCase {
 
 	protected $_post;
 	protected $_stats;
 	protected $_payment_stats;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-tax.php
+++ b/tests/tests-tax.php
@@ -4,16 +4,11 @@
 /**
  * @group edd_tax
  */
-class Tests_Taxes extends WP_UnitTestCase {
+class Tests_Taxes extends EDD_UnitTestCase {
 
 	protected $_payment_id = null;
 
 	protected $_post = null;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-tax.php
+++ b/tests/tests-tax.php
@@ -10,8 +10,8 @@ class Tests_Taxes extends WP_UnitTestCase {
 
 	protected $_post = null;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-templates.php
+++ b/tests/tests-templates.php
@@ -8,8 +8,8 @@ class Tests_Templates extends WP_UnitTestCase {
 
 	protected $_post;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-templates.php
+++ b/tests/tests-templates.php
@@ -4,14 +4,9 @@
 /**
  * @group edd_mime
  */
-class Tests_Templates extends WP_UnitTestCase {
+class Tests_Templates extends EDD_UnitTestCase {
 
 	protected $_post;
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-theme-compatibility.php
+++ b/tests/tests-theme-compatibility.php
@@ -3,7 +3,7 @@
 /**
  * @group theme_compatibility
  */
-class Tests_Theme_Compatibility extends WP_UnitTestCase {
+class Tests_Theme_Compatibility extends EDD_UnitTestCase {
 
 	/**
 	 * Test that the filter exists of the function.

--- a/tests/tests-tools.php
+++ b/tests/tests-tools.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_tools
  */
-class Tests_Tools extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Tools extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-tools.php
+++ b/tests/tests-tools.php
@@ -6,8 +6,8 @@
  */
 class Tests_Tools extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-upgrades.php
+++ b/tests/tests-upgrades.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_upgrades
  */
-class Tests_Upgrades extends WP_UnitTestCase {
-
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
+class Tests_Upgrades extends EDD_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/tests-upgrades.php
+++ b/tests/tests-upgrades.php
@@ -6,8 +6,8 @@
  */
 class Tests_Upgrades extends WP_UnitTestCase {
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-url.php
+++ b/tests/tests-url.php
@@ -4,12 +4,7 @@
 /**
  * @group edd_url
  */
-class Tests_URL extends WP_UnitTestCase {
-	public static function wpSetUpBeforeClass() {
-
-		edd_install();
-	}
-
+class Tests_URL extends EDD_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 	}

--- a/tests/tests-url.php
+++ b/tests/tests-url.php
@@ -5,8 +5,8 @@
  * @group edd_url
  */
 class Tests_URL extends WP_UnitTestCase {
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function wpSetUpBeforeClass() {
+
 		edd_install();
 	}
 

--- a/tests/tests-widgets.php
+++ b/tests/tests-widgets.php
@@ -4,10 +4,7 @@
 /**
  * @group edd_widgets
  */
-class Tests_Widgets extends WP_UnitTestCase {
-	public static function wpSetUpBeforeClass() {
-		edd_install();
-	}
+class Tests_Widgets extends EDD_UnitTestCase {
 
 	/**
 	 * Test that the hooks in the file are good.

--- a/tests/tests-widgets.php
+++ b/tests/tests-widgets.php
@@ -5,6 +5,9 @@
  * @group edd_widgets
  */
 class Tests_Widgets extends WP_UnitTestCase {
+	public static function wpSetUpBeforeClass() {
+		edd_install();
+	}
 
 	/**
 	 * Test that the hooks in the file are good.


### PR DESCRIPTION
@sunnyratilal @pippinsplugins would love you two to look this over. It fixes the Unit tests for WordPress 4.7. They introduced a `_delete_all_data` which runs after each class is completed, so naturally, we have to run `edd_install()` before each class starts it's run.

While doing this, I found a unique case where the installer wouldn't install a missing page, since all we did was check if the `purchase_page` was set, so I did a little work and made `edd_install()` check each of our pages individually and crates them if any number of them are missing in the options, it also makes sure that the ID set for the page, exists. If not it recreates a page