### PR TITLE
Avoid PHP Warnings in 7.1 when a customer has no address.

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -470,6 +470,10 @@ function edd_get_customer_address( $user_id = 0 ) {
 
 	$address = get_user_meta( $user_id, '_edd_user_address', true );
 
+	if ( ! $address || ! is_array( $address ) || empty( $address ) ) {
+		$address = array();
+	}
+
 	if( ! isset( $address['line1'] ) )
 		$address['line1'] = '';
 


### PR DESCRIPTION
See #5342 

Submitted against release/2.7 since there isn't a release/2.7.3 branch. 