### PR TITLE
Ensure edd_update_payment_status uses EDD_Payment for hooks

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -268,10 +268,7 @@ function edd_update_payment_status( $payment_id = 0, $new_status = 'publish' ) {
 	$payment = new EDD_Payment( $payment_id );
 
 	if( $payment && $payment->ID > 0 ) {
-
-		$payment->status = $new_status;
-		$updated = $payment->save();
-
+		$updated = $payment->update_status( $new_status );
 	}
 
 	return $updated;


### PR DESCRIPTION
Heya!

I noticed in regards of one of my plugins that not always the payment status update hooks were triggered that are available in the `EDD_Payment()->update_status()` method. 

This ensures it goes through the right route so it triggers those hooks