### PR TITLE
Fix get_user_by function $field param

### DIFF
--- a/includes/admin/import/class-batch-import-downloads.php
+++ b/includes/admin/import/class-batch-import-downloads.php
@@ -113,11 +113,11 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 
 	 				// Check all forms of possible user inputs, email, ID, login.
 	 				if ( is_email( $args['post_author'] ) ) {
-	 					$user = get_user_by( 'user_email', $args['post_author'] );
+	 					$user = get_user_by( 'email', $args['post_author'] );
 	 				} elseif ( is_numeric( $args['post_author'] ) ) {
 	 					$user = get_user_by( 'ID', $args['post_author'] );
 	 				} else {
-	 					$user = get_user_by( 'user_login', $args['post_author'] );
+	 					$user = get_user_by( 'login', $args['post_author'] );
 	 				}
 
 	 				// If we don't find one, resort to the logged in user.

--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -196,7 +196,7 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 
 			} else {
 
-				$user = get_user_by( 'user_login', $user_id );
+				$user = get_user_by( 'login', $user_id );
 
 			}
 


### PR DESCRIPTION
In the ```EDD_Batch_Payments_Import``` and ```EDD_Batch_Downloads_Import``` classes the ```get_user_by``` function $field param was using the ```user_login``` and ```user_email``` field instead of the ```login``` and ```email``` field. 


