### PR TITLE
Introduce class `EDD_Customer_Query`

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -259,6 +259,7 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-db.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-db-customers.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-db-customer-meta.php';
+		require_once EDD_PLUGIN_DIR . 'includes/class-edd-customer-query.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-customer.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-discount.php';
 		require_once EDD_PLUGIN_DIR . 'includes/class-edd-download.php';

--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -637,3 +637,7 @@ function edd_include_single_customer_recount_tool_batch_processer( $class ) {
 	}
 
 }
+
+add_action( 'added_customer_meta', array( EDD()->customers, 'set_last_changed' ) );
+add_action( 'updated_customer_meta', array( EDD()->customers, 'set_last_changed' ) );
+add_action( 'deleted_customer_meta', array( EDD()->customers, 'set_last_changed' ) );

--- a/includes/class-edd-customer-query.php
+++ b/includes/class-edd-customer-query.php
@@ -1,0 +1,742 @@
+<?php
+/**
+ * Customer query class
+ *
+ * This class should be used for querying customers.
+ *
+ * @package     EDD
+ * @subpackage  Classes/Customer Query
+ * @copyright   Copyright (c) 2015, Pippin Williamson
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       2.8
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+class EDD_Customer_Query {
+
+	/**
+	 * SQL for database query.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    string
+	 */
+	public $request;
+
+	/**
+	 * Date query container.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    object WP_Date_Query
+	 */
+	public $date_query = false;
+
+	/**
+	 * Meta query container.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    object WP_Meta_Query
+	 */
+	public $meta_query = false;
+
+	/**
+	 * Query vars set by the user.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    array
+	 */
+	public $query_vars;
+
+	/**
+	 * Default values for query vars.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    array
+	 */
+	public $query_var_defaults;
+
+	/**
+	 * List of customers located by the query.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    array
+	 */
+	public $items;
+
+	/**
+	 * The amount of found customers for the current query.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    int
+	 */
+	public $found_items = 0;
+
+	/**
+	 * The number of pages.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var    int
+	 */
+	public $max_num_pages = 0;
+
+	/**
+	 * SQL query clauses.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var    array
+	 */
+	protected $sql_clauses = array(
+		'select'  => '',
+		'from'    => '',
+		'where'   => array(),
+		'groupby' => '',
+		'orderby' => '',
+		'limits'  => '',
+	);
+
+	/**
+	 * Metadata query clauses.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var array
+	 */
+	protected $meta_query_clauses = array();
+
+	/**
+	 * EDD_DB_Customers instance.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var EDD_DB_Customers
+	 */
+	protected $edd_db_customers;
+
+	/**
+	 * The name of our database table.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var    string
+	 */
+	protected $table_name;
+
+	/**
+	 * The meta type.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var    string
+	 */
+	protected $meta_type;
+
+	/**
+	 * The name of the primary column.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var    string
+	 */
+	protected $primary_key;
+
+	/**
+	 * The name of the date column.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var    string
+	 */
+	protected $date_key;
+
+	/**
+	 * The name of the cache group.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 * @var    string
+	 */
+	protected $cache_group;
+
+	/**
+	 * Constructor.
+	 *
+	 * Sets up the customer query defaults and optionally runs a query.
+	 *
+	 * @access public
+	 * @since  2.8
+	 *
+	 * @param string|array $query {
+	 *     Optional. Array or query string of customer query parameters. Default empty.
+	 *
+	 *     @type int          $number        Maximum number of customers to retrieve. Default 20.
+	 *     @type int          $offset        Number of customers to offset the query. Default 0.
+	 *     @type string|array $orderby       Customer status or array of statuses. To use 'meta_value'
+	 *                                       or 'meta_value_num', `$meta_key` must also be provided.
+	 *                                       To sort by a specific `$meta_query` clause, use that
+	 *                                       clause's array key. Accepts 'id', 'user_id', 'name',
+	 *                                       'email', 'payment_ids', 'purchase_value', 'purchase_count',
+	 *                                       'notes', 'date_created', 'meta_value', 'meta_value_num',
+	 *                                       the value of `$meta_key`, and the array keys of `$meta_query`.
+	 *                                       Also accepts false, an empty array, or 'none' to disable the
+	 *                                       `ORDER BY` clause. Default 'id'.
+	 *     @type string       $order         How to order retrieved customers. Accepts 'ASC', 'DESC'.
+	 *                                       Default 'DESC'.
+	 *     @type string|array $include       String or array of customer IDs to include. Default empty.
+	 *     @type string|array $exclude       String or array of customer IDs to exclude. Default empty.
+	 *     @type string|array $users_include String or array of customer user IDs to include. Default
+	 *                                       empty.
+	 *     @type string|array $users_exclude String or array of customer user IDs to exclude. Default
+	 *                                       empty.
+	 *     @type string|array $email         Limit results to those customers affiliated with one of
+	 *                                       the given emails. Default empty.
+	 *     @type string       $search        Search term(s) to retrieve matching customers for. Searches
+	 *                                       through customer names. Default empty.
+	 *     @type string       $meta_key      Include customers with a matching customer meta key.
+	 *                                       Default empty.
+	 *     @type string       $meta_value    Include customers with a matching customer meta value.
+	 *                                       Requires `$meta_key` to be set. Default empty.
+	 *     @type array        $meta_query    Meta query clauses to limit retrieved customers by.
+	 *                                       See `WP_Meta_Query`. Default empty.
+	 *     @type array        $date_query    Date query clauses to limit retrieved customers by.
+	 *                                       See `WP_Date_Query`. Default empty.
+	 *     @type bool         $count         Whether to return a count (true) instead of an array of
+	 *                                       customer objects. Default false.
+	 *     @type bool         $no_found_rows Whether to disable the `SQL_CALC_FOUND_ROWS` query.
+	 *                                       Default true.
+	 * }
+	 */
+	public function __construct( $query = '', $edd_db_customers = null ) {
+		if ( $edd_db_customers ) {
+			$this->edd_db_customers = $edd_db_customers;
+		} else {
+			$this->edd_db_customers = EDD()->customers;
+		}
+
+		$this->table_name       = $this->edd_db_customers->table_name;
+		$this->meta_type        = $this->edd_db_customers->meta_type;
+		$this->primary_key      = $this->edd_db_customers->primary_key;
+		$this->date_key         = $this->edd_db_customers->date_key;
+		$this->cache_group      = $this->edd_db_customers->cache_group;
+
+		$this->query_var_defaults = array(
+			'number'        => 20,
+			'offset'        => 0,
+			'orderby'       => 'id',
+			'order'         => 'DESC',
+			'include'       => '',
+			'exclude'       => '',
+			'users_include' => '',
+			'users_exclude' => '',
+			'email'         => '',
+			'search'        => '',
+			'meta_key'      => '',
+			'meta_value'    => '',
+			'meta_query'    => '',
+			'date_query'    => null,
+			'count'         => false,
+			'no_found_rows' => true,
+		);
+
+		if ( ! empty( $query ) ) {
+			$this->query( $query );
+		}
+	}
+
+	/**
+	 * Sets up the query for retrieving customers.
+	 *
+	 * @access public
+	 * @since  2.8
+	 *
+	 * @see EDD_Customer_Query::__construct()
+	 *
+	 * @param string|array $query Array or query string of parameters. See EDD_Customer_Query::__construct().
+	 * @return array|int List of customers, or number of customers when 'count' is passed as a query var.
+	 */
+	public function query( $query ) {
+		$this->query_vars = wp_parse_args( $query );
+
+		return $this->get_items();
+	}
+
+	/**
+	 * Parses arguments passed to the customer query with default query parameters.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 */
+	protected function parse_query() {
+		$this->query_vars = wp_parse_args( $this->query_vars, $this->query_var_defaults );
+
+		if ( $this->query_vars['number'] < 1 ) {
+			$this->query_vars['number'] = 999999999999;
+		}
+
+		$this->query_vars['offset'] = absint( $this->query_vars['offset'] );
+
+		if ( ! empty( $this->query_vars['date_query'] ) && is_array( $this->query_vars['date_query'] ) ) {
+			$this->date_query = new WP_Date_Query( $this->query_vars['date_query'], $this->date_key );
+		}
+
+		$this->meta_query = new WP_Meta_Query();
+		$this->meta_query->parse_query_vars( $this->query_vars );
+
+		if ( ! empty( $this->meta_query->queries ) ) {
+			$this->meta_query_clauses = $this->meta_query->get_sql( $this->meta_type, $this->table_name, $this->primary_key, $this );
+		}
+
+		/**
+		 * Fires after the customer query vars have been parsed.
+		 *
+		 * @since 2.8
+		 *
+		 * @param EDD_Customer_Query &$this The EDD_Customer_Query instance (passed by reference).
+		 */
+		do_action_ref_array( 'edd_parse_customer_query', array( &$this ) );
+	}
+
+	/**
+	 * Retrieves a list of customers matching the query vars.
+	 *
+	 * Tries to use a cached value and otherwise uses `EDD_Customer_Query::query_items()`.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return array|int List of customers, or number of customers when 'count' is passed as a query var.
+	 */
+	protected function get_items() {
+		$this->parse_query();
+
+		/**
+		 * Fires before customers are retrieved.
+		 *
+		 * @since 2.8
+		 *
+		 * @param EDD_Customer_Query &$this Current instance of EDD_Customer_Query, passed by reference.
+		 */
+		do_action_ref_array( 'edd_pre_get_customers', array( &$this ) );
+
+		// $args can include anything. Only use the args defined in the query_var_defaults to compute the key.
+		$key = md5( serialize( wp_array_slice_assoc( $this->query_vars, array_keys( $this->query_var_defaults ) ) ) );
+
+		$last_changed = $this->edd_db_customers->get_last_changed();
+
+		$cache_key = "query:$key:$last_changed";
+		$cache_value = wp_cache_get( $cache_key, $this->cache_group );
+
+		if ( false === $cache_value ) {
+			$items = $this->query_items();
+			if ( $items ) {
+				$this->set_found_items();
+			}
+
+			$cache_value = array(
+				'items'       => $items,
+				'found_items' => $this->found_items,
+			);
+			wp_cache_add( $cache_key, $cache_value, $this->cache_group );
+		} else {
+			$items = $cache_value['items'];
+			$this->found_items = $cache_value['found_items'];
+		}
+
+		if ( $this->found_items && $this->query_vars['number'] ) {
+			$this->max_num_pages = ceil( $this->found_items / $this->query_vars['number'] );
+		}
+
+		// If querying for a count only, there's nothing more to do.
+		if ( $this->query_vars['count'] ) {
+			// $items is actually a count in this case.
+			return intval( $items );
+		}
+
+		$this->items = $items;
+
+		return $this->items;
+	}
+
+	/**
+	 * Runs a database query to retrieve customers.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 *
+	 * @return @return array|int List of customers, or number of customers when 'count' is passed as a query var.
+	 */
+	protected function query_items() {
+		global $wpdb;
+
+		$fields = $this->construct_request_fields();
+		$join = $this->construct_request_join();
+
+		$this->sql_clauses['where'] = $this->construct_request_where();
+
+		$orderby = $this->construct_request_orderby();
+		$limits = $this->construct_request_limits();
+		$groupby = $this->construct_request_groupby();
+
+		$found_rows = ! $this->query_vars['no_found_rows'] ? 'SQL_CALC_FOUND_ROWS' : '';
+
+		$where = implode( ' AND ', $this->sql_clauses['where'] );
+
+		if ( $where ) {
+			$where = "WHERE $where";
+		}
+
+		if ( $orderby ) {
+			$orderby = "ORDER BY $orderby";
+		}
+
+		if ( $groupby ) {
+			$groupby = "GROUP BY $groupby";
+		}
+
+		$this->sql_clauses['select']  = "SELECT $found_rows $fields";
+		$this->sql_clauses['from']    = "FROM $this->table_name $join";
+		$this->sql_clauses['groupby'] = $groupby;
+		$this->sql_clauses['orderby'] = $orderby;
+		$this->sql_clauses['limits']  = $limits;
+
+		$this->request = "{$this->sql_clauses['select']} {$this->sql_clauses['from']} {$where} {$this->sql_clauses['groupby']} {$this->sql_clauses['orderby']} {$this->sql_clauses['limits']}";
+
+		return $wpdb->get_results( $this->request );
+	}
+
+	/**
+	 * Populates the found_items property for the current query if the limit clause was used.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
+	 */
+	protected function set_found_items() {
+		global $wpdb;
+
+		if ( $this->query_vars['number'] && ! $this->query_vars['no_found_rows'] ) {
+			/**
+			 * Filters the query used to retrieve the count of found customers.
+			 *
+			 * @since 2.8
+			 *
+			 * @param string             $found_customers_query SQL query. Default 'SELECT FOUND_ROWS()'.
+			 * @param EDD_Customer_Query $customer_query        The `EDD_Customer_Query` instance.
+			 */
+			$found_items_query = apply_filters( 'edd_found_customers_query', 'SELECT FOUND_ROWS()', $this );
+
+			$this->found_items = (int) $wpdb->get_var( $found_items_query );
+		}
+	}
+
+	/**
+	 * Constructs the fields segment of the SQL request.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return string SQL fields segment.
+	 */
+	protected function construct_request_fields() {
+		if ( $this->query_vars['count'] ) {
+			return 'COUNT(*)';
+		}
+
+		return '*';
+	}
+
+	/**
+	 * Constructs the join segment of the SQL request.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return string SQL join segment.
+	 */
+	protected function construct_request_join() {
+		$join = '';
+
+		if ( ! empty( $this->meta_query_clauses['join'] ) ) {
+			$join .= $this->meta_query_clauses['join'];
+		}
+
+		if ( ! empty( $this->query_vars['email'] ) && ! is_array( $this->query_vars['email'] ) ) {
+			$meta_table = _get_meta_table( $this->meta_type );
+
+			$join_type = false !== strpos( $join, 'LEFT JOIN' ) ? 'LEFT JOIN' : 'INNER JOIN';
+
+			$join .= " $join_type $meta_table AS email_mt ON $this->table_name.$this->primary_key = $meta_table.{$this->meta_type}_id";
+		}
+
+		return $join;
+	}
+
+	/**
+	 * Constructs the where segment of the SQL request.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return string SQL where segment.
+	 */
+	protected function construct_request_where() {
+		global $wpdb;
+
+		$where = array();
+
+		if ( ! empty( $this->query_vars['include'] ) ) {
+			$include_ids = implode( ',', wp_parse_id_list( $this->query_vars['include'] ) );
+			$where['include'] = "$this->primary_key IN ( $include_ids )";
+		}
+
+		if ( ! empty( $this->query_vars['exclude'] ) ) {
+			$exclude_ids = implode( ',', wp_parse_id_list( $this->query_vars['exclude'] ) );
+			$where['exclude'] = "$this->primary_key NOT IN ( $exclude_ids )";
+		}
+
+		if ( ! empty( $this->query_vars['users_include'] ) ) {
+			$users_include_ids = implode( ',', wp_parse_id_list( $this->query_vars['users_include'] ) );
+			$where['users_include'] = "user_id IN ( $users_include_ids )";
+		}
+
+		if ( ! empty( $this->query_vars['users_exclude'] ) ) {
+			$users_exclude_ids = implode( ',', wp_parse_id_list( $this->query_vars['users_exclude'] ) );
+			$where['users_exclude'] = "user_id NOT IN ( $users_exclude_ids )";
+		}
+
+		if ( ! empty( $this->query_vars['email'] ) ) {
+			if ( is_array( $this->query_vars['email'] ) ) {
+				$email_placeholders = implode( ', ', array_fill( 0, count( $this->query_vars['email'] ), '%s' ) );
+
+				$where['email'] = $wpdb->prepare( "email IN( $email_placeholders )", $this->query_vars['email'] );
+			} else {
+				$where['email'] = $wpdb->prepare( "( ( email_mt.meta_key = 'additional_email' AND email_mt.meta_value = %s ) OR email = %s )", $this->query_vars['email'], $this->query_vars['email'] );
+			}
+		}
+
+		if ( strlen( $this->query_vars['search'] ) ) {
+			$search_columns = array( 'name' );
+
+			$where['search'] = $this->get_search_sql( $this->query_vars['search'], $search_columns );
+		}
+
+		if ( $this->date_query ) {
+			$where['date_query'] = preg_replace( '/^\s*AND\s*/', '', $this->date_query->get_sql() );
+		}
+
+		if ( ! empty( $this->meta_query_clauses['where'] ) ) {
+			$where['meta_query'] = preg_replace( '/^\s*AND\s*/', '', $this->meta_query_clauses['where'] );
+		}
+
+		return $where;
+	}
+
+	/**
+	 * Constructs the orderby segment of the SQL request.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return string SQL orderby segment.
+	 */
+	protected function construct_request_orderby() {
+		if ( in_array( $this->query_vars['orderby'], array( 'none', array(), false ), true ) ) {
+			return '';
+		}
+
+		if ( empty( $this->query_vars['orderby'] ) ) {
+			return $this->primary_key . ' ' . $this->parse_order_string( $this->query_vars['order'] );
+		}
+
+		if ( is_string( $this->query_vars['orderby'] ) ) {
+			$ordersby = array( $this->query_vars['orderby'] => $this->query_vars['order'] );
+		} else {
+			$ordersby = $this->query_vars['orderby'];
+		}
+
+		$orderby_array = array();
+
+		foreach ( $ordersby as $orderby => $order ) {
+			$parsed_orderby = $this->parse_orderby_string( $orderby );
+			if ( ! $parsed_orderby ) {
+				continue;
+			}
+
+			$parsed_order = $this->parse_order_string( $order, $orderby );
+
+			if ( $parsed_order ) {
+				$orderby_array[] = $parsed_orderby . ' ' . $parsed_order;
+			} else {
+				$orderby_array[] = $parsed_orderby;
+			}
+		}
+
+		return implode( ', ', $orderby_array );
+	}
+
+	/**
+	 * Constructs the limits segment of the SQL request.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return string SQL limits segment.
+	 */
+	protected function construct_request_limits() {
+		if ( $this->query_vars['number'] ) {
+			if ( $this->query_vars['offset'] ) {
+				return "LIMIT {$this->query_vars['offset']},{$this->query_vars['number']}";
+			}
+
+			return "LIMIT {$this->query_vars['number']}";
+		}
+
+		return '';
+	}
+
+	/**
+	 * Constructs the groupby segment of the SQL request.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return string SQL groupby segment.
+	 */
+	protected function construct_request_groupby() {
+		if ( ! empty( $this->meta_query_clauses['join'] ) || ( ! empty( $this->query_vars['email'] ) && ! is_array( $this->query_vars['email'] ) ) ) {
+			return "$this->table_name.$this->primary_key";
+		}
+
+		return '';
+	}
+
+	/**
+	 * Used internally to generate an SQL string for searching across multiple columns.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @global wpdb  $wpdb WordPress database abstraction object.
+	 *
+	 * @param string $string  Search string.
+	 * @param array  $columns Columns to search.
+	 * @return string Search SQL.
+	 */
+	protected function get_search_sql( $string, $columns ) {
+		global $wpdb;
+
+		if ( false !== strpos( $string, '*' ) ) {
+			$like = '%' . implode( '%', array_map( array( $wpdb, 'esc_like' ), explode( '*', $string ) ) ) . '%';
+		} else {
+			$like = '%' . $wpdb->esc_like( $string ) . '%';
+		}
+
+		$searches = array();
+		foreach ( $columns as $column ) {
+			$searches[] = $wpdb->prepare( "$column LIKE %s", $like );
+		}
+
+		return '(' . implode( ' OR ', $searches ) . ')';
+	}
+
+	/**
+	 * Parses a single orderby string.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @param string $orderby Orderby string.
+	 * @return string Parsed orderby string to use in the SQL request, or an empty string.
+	 */
+	protected function parse_orderby_string( $orderby ) {
+		if ( 'include' === $orderby ) {
+			if ( empty( $this->query_vars['include'] ) ) {
+				return '';
+			}
+
+			$ids = implode( ',', wp_parse_id_list( $this->query_vars['include'] ) );
+
+			return "FIELD( $this->table_name.$this->primary_key, $ids )";
+		}
+
+		if ( ! empty( $this->meta_query_clauses['where'] ) ) {
+			$meta_table = _get_meta_table( $this->meta_type );
+
+			if ( $this->query_vars['meta_key'] === $orderby || 'meta_value' === $orderby ) {
+				return "$meta_table.meta_value";
+			}
+
+			if ( 'meta_value_num' === $orderby ) {
+				return "$meta_table.meta_value+0";
+			}
+
+			$meta_query_clauses = $this->meta_query->get_clauses();
+
+			if ( isset( $meta_query_clauses[ $orderby ] ) ) {
+				return sprintf( "CAST(%s.meta_value AS %s)", esc_sql( $meta_query_clauses[ $orderby ]['alias'] ), esc_sql( $meta_query_clauses[ $orderby ]['cast'] ) );
+			}
+		}
+
+		$allowed_keys = $this->get_allowed_orderby_keys();
+
+		if ( in_array( $orderby, $allowed_keys, true ) ) {
+			/* This column needs special handling here. */
+			if ( 'purchase_value' === $orderby ) {
+				return "$this->table_name.purchase_value+0";
+			}
+
+			return "$this->table_name.$orderby";
+		}
+
+		return '';
+	}
+
+	/**
+	 * Parses a single order string.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @param string $orderby Order string.
+	 * @return string Parsed order string to use in the SQL request, or an empty string.
+	 */
+	protected function parse_order_string( $order, $orderby ) {
+		if ( 'include' === $orderby ) {
+			return '';
+		}
+
+		if ( ! is_string( $order ) || empty( $order ) ) {
+			return 'DESC';
+		}
+
+		if ( 'ASC' === strtoupper( $order ) ) {
+			return 'ASC';
+		} else {
+			return 'DESC';
+		}
+	}
+
+	/**
+	 * Returns the basic allowed keys to use for the orderby clause.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @return array Allowed keys.
+	 */
+	protected function get_allowed_orderby_keys() {
+		return array_keys( $this->edd_db_customers->get_columns() );
+	}
+}

--- a/includes/class-edd-customer-query.php
+++ b/includes/class-edd-customer-query.php
@@ -477,7 +477,7 @@ class EDD_Customer_Query {
 
 			$join_type = false !== strpos( $join, 'LEFT JOIN' ) ? 'LEFT JOIN' : 'INNER JOIN';
 
-			$join .= " $join_type $meta_table AS email_mt ON $this->table_name.$this->primary_key = $meta_table.{$this->meta_type}_id";
+			$join .= " $join_type $meta_table AS email_mt ON $this->table_name.$this->primary_key = email_mt.{$this->meta_type}_id";
 		}
 
 		return $join;

--- a/includes/class-edd-customer-query.php
+++ b/includes/class-edd-customer-query.php
@@ -285,7 +285,7 @@ class EDD_Customer_Query {
 		$this->query_vars['offset'] = absint( $this->query_vars['offset'] );
 
 		if ( ! empty( $this->query_vars['date_query'] ) && is_array( $this->query_vars['date_query'] ) ) {
-			$this->date_query = new WP_Date_Query( $this->query_vars['date_query'], $this->date_key );
+			$this->date_query = new WP_Date_Query( $this->query_vars['date_query'], $this->table_name . '.' . $this->date_key );
 		}
 
 		$this->meta_query = new WP_Meta_Query();

--- a/includes/class-edd-customer-query.php
+++ b/includes/class-edd-customer-query.php
@@ -451,10 +451,10 @@ class EDD_Customer_Query {
 	 */
 	protected function construct_request_fields() {
 		if ( $this->query_vars['count'] ) {
-			return 'COUNT(*)';
+			return "COUNT(*)";
 		}
 
-		return '*';
+		return "$this->table_name.*";
 	}
 
 	/**

--- a/includes/class-edd-db-customers.php
+++ b/includes/class-edd-db-customers.php
@@ -22,6 +22,33 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class EDD_DB_Customers extends EDD_DB  {
 
 	/**
+	 * The metadata type.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var string
+	 */
+	public $meta_type = 'customer';
+
+	/**
+	 * The name of the date column.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var string
+	 */
+	public $date_key = 'date_created';
+
+	/**
+	 * The name of the cache group.
+	 *
+	 * @access public
+	 * @since  2.8
+	 * @var string
+	 */
+	public $cache_group = 'customers';
+
+	/**
 	 * Get things started
 	 *
 	 * @access  public
@@ -138,6 +165,40 @@ class EDD_DB_Customers extends EDD_DB  {
 	}
 
 	/**
+	 * Insert a new customer
+	 *
+	 * @access  public
+	 * @since   2.1
+	 * @return  int
+	 */
+	public function insert( $data, $type = '' ) {
+		$result = parent::insert( $data, $type );
+
+		if ( $result ) {
+			$this->set_last_changed();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Update a customer
+	 *
+	 * @access  public
+	 * @since   2.1
+	 * @return  bool
+	 */
+	public function update( $row_id, $data = array(), $where = '' ) {
+		$result = parent::update( $row_id, $data, $where );
+
+		if ( $result ) {
+			$this->set_last_changed();
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Delete a customer
 	 *
 	 * NOTE: This should not be called directly as it does not make necessary changes to
@@ -158,7 +219,14 @@ class EDD_DB_Customers extends EDD_DB  {
 		if ( $customer->id > 0 ) {
 
 			global $wpdb;
-			return $wpdb->delete( $this->table_name, array( 'id' => $customer->id ), array( '%d' ) );
+
+			$result = $wpdb->delete( $this->table_name, array( 'id' => $customer->id ), array( '%d' ) );
+
+			if ( $result ) {
+				$this->set_last_changed();
+			}
+
+			return $result;
 
 		} else {
 			return false;
@@ -319,8 +387,6 @@ class EDD_DB_Customers extends EDD_DB  {
 	 * @return mixed          Upon success, an object of the customer. Upon failure, NULL
 	 */
 	public function get_customer_by( $field = 'id', $value = 0 ) {
-		global $wpdb;
-
 		if ( empty( $field ) || empty( $value ) ) {
 			return NULL;
 		}
@@ -351,40 +417,32 @@ class EDD_DB_Customers extends EDD_DB  {
 			return false;
 		}
 
+		$args = array( 'number' => 1 );
+
 		switch ( $field ) {
 			case 'id':
 				$db_field = 'id';
+				$args['include'] = array( $value );
 				break;
 			case 'email':
-				$value    = sanitize_text_field( $value );
-				$db_field = 'email';
+				$args['email'] = sanitize_text_field( $value );
 				break;
 			case 'user_id':
-				$db_field = 'user_id';
+				$args['users_include'] = array( $value );
 				break;
 			default:
 				return false;
 		}
 
-		if ( ! $customer = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $this->table_name WHERE $db_field = %s LIMIT 1", $value ) ) ) {
+		$query = new EDD_Customer_Query( '', $this );
 
-			// Look for customer from an additional email
-			if( 'email' === $field ) {
+		$results = $query->query( $args );
 
-				$meta_table  = EDD()->customer_meta->table_name;
-				$customer_id = $wpdb->get_var( $wpdb->prepare( "SELECT customer_id FROM $meta_table WHERE meta_key = 'additional_email' AND meta_value = '%s' LIMIT 1", $value ) );
-
-				if( ! empty( $customer_id ) ) {
-					return $this->get( $customer_id );
-				}
-
-			}
-
-
+		if ( empty( $results ) ) {
 			return false;
 		}
 
-		return $customer;
+		return array_shift( $results );
 	}
 
 	/**
@@ -394,129 +452,12 @@ class EDD_DB_Customers extends EDD_DB  {
 	 * @since   2.1
 	*/
 	public function get_customers( $args = array() ) {
+		$args = $this->prepare_customer_query_args( $args );
+		$args['count'] = false;
 
-		global $wpdb;
+		$query = new EDD_Customer_Query( '', $this );
 
-		$defaults = array(
-			'number'       => 20,
-			'offset'       => 0,
-			'user_id'      => 0,
-			'orderby'      => 'id',
-			'order'        => 'DESC',
-		);
-
-		$args  = wp_parse_args( $args, $defaults );
-
-		if( $args['number'] < 1 ) {
-			$args['number'] = 999999999999;
-		}
-
-		$join  = '';
-		$where = ' WHERE 1=1 ';
-
-		// specific customers
-		if( ! empty( $args['id'] ) ) {
-
-			if( is_array( $args['id'] ) ) {
-				$ids = implode( ',', array_map('intval', $args['id'] ) );
-			} else {
-				$ids = intval( $args['id'] );
-			}
-
-			$where .= " AND `id` IN( {$ids} ) ";
-
-		}
-
-		// customers for specific user accounts
-		if( ! empty( $args['user_id'] ) ) {
-
-			if( is_array( $args['user_id'] ) ) {
-				$user_ids = implode( ',', array_map('intval', $args['user_id'] ) );
-			} else {
-				$user_ids = intval( $args['user_id'] );
-			}
-
-			$where .= " AND `user_id` IN( {$user_ids} ) ";
-
-		}
-
-		//specific customers by email
-		if( ! empty( $args['email'] ) ) {
-
-			if( is_array( $args['email'] ) ) {
-
-				$emails_count       = count( $args['email'] );
-				$emails_placeholder = array_fill( 0, $emails_count, '%s' );
-				$emails             = implode( ', ', $emails_placeholder );
-
-				$where .= $wpdb->prepare( " AND `email` IN( $emails ) ", $args['email'] );
-			} else {
-				$meta_table      = $wpdb->prefix . 'edd_customermeta';
-				$customers_table = $this->table_name;
-
-				$join  .= " LEFT JOIN $meta_table ON $customers_table.id = $meta_table.customer_id";
-				$where .= $wpdb->prepare( " AND ( ( `meta_key` = 'additional_email' AND `meta_value` = %s ) OR `email` = %s )", $args['email'], $args['email'] );
-			}
-		}
-
-		// specific customers by name
-		if( ! empty( $args['name'] ) ) {
-			$where .= $wpdb->prepare( " AND `name` LIKE '%%%%" . '%s' . "%%%%' ", $args['name'] );
-		}
-
-		// Customers created for a specific date or in a date range
-		if( ! empty( $args['date'] ) ) {
-
-			if( is_array( $args['date'] ) ) {
-
-				if( ! empty( $args['date']['start'] ) ) {
-
-					$start = date( 'Y-m-d 00:00:00', strtotime( $args['date']['start'] ) );
-					$where .= " AND `date_created` >= '{$start}'";
-
-				}
-
-				if( ! empty( $args['date']['end'] ) ) {
-
-					$end = date( 'Y-m-d 23:59:59', strtotime( $args['date']['end'] ) );
-					$where .= " AND `date_created` <= '{$end}'";
-
-				}
-
-			} else {
-
-				$year  = date( 'Y', strtotime( $args['date'] ) );
-				$month = date( 'm', strtotime( $args['date'] ) );
-				$day   = date( 'd', strtotime( $args['date'] ) );
-
-				$where .= " AND $year = YEAR ( date_created ) AND $month = MONTH ( date_created ) AND $day = DAY ( date_created )";
-			}
-
-		}
-
-		$args['orderby'] = ! array_key_exists( $args['orderby'], $this->get_columns() ) ? 'id' : $args['orderby'];
-
-		if( 'purchase_value' == $args['orderby'] ) {
-			$args['orderby'] = 'purchase_value+0';
-		}
-
-		$cache_key = md5( 'edd_customers_' . serialize( $args ) );
-
-		$customers = wp_cache_get( $cache_key, 'customers' );
-
-		$args['orderby'] = esc_sql( $args['orderby'] );
-		$args['order']   = esc_sql( $args['order'] );
-
-		$customers = false;
-
-		if( $customers === false ) {
-			$query     = $wpdb->prepare( "SELECT * FROM  $this->table_name $join $where GROUP BY $this->primary_key ORDER BY {$args['orderby']} {$args['order']} LIMIT %d,%d;", absint( $args['offset'] ), absint( $args['number'] ) );
-			$customers = $wpdb->get_results( $query );
-			wp_cache_set( $cache_key, $customers, 'customers', 3600 );
-		}
-
-		return $customers;
-
+		return $query->query( $args );
 	}
 
 
@@ -527,104 +468,105 @@ class EDD_DB_Customers extends EDD_DB  {
 	 * @since   2.1
 	*/
 	public function count( $args = array() ) {
+		$args = $this->prepare_customer_query_args( $args );
+		$args['count'] = true;
 
-		global $wpdb;
+		$query = new EDD_Customer_Query( '', $this );
 
-		$join  = '';
-		$where = ' WHERE 1=1 ';
+		return $query->query( $args );
+	}
 
-		// specific customers
-		if( ! empty( $args['id'] ) ) {
+	/**
+	 * Prepare query arguments for `EDD_Customer_Query`.
+	 *
+	 * This method ensures that old arguments transition seamlessly to the new system.
+	 *
+	 * @access protected
+	 * @since  2.8
+	 *
+	 * @param array $args Arguments for `EDD_Customer_Query`.
+	 * @return array Prepared arguments.
+	 */
+	protected function prepare_customer_query_args( $args ) {
+		if ( ! empty( $args['id'] ) ) {
+			$args['include'] = $args['id'];
+			unset( $args['id'] );
+		}
 
-			if( is_array( $args['id'] ) ) {
-				$ids = implode( ',', array_map('intval', $args['id'] ) );
+		if ( ! empty( $args['user_id'] ) ) {
+			$args['users_include'] = $args['user_id'];
+			unset( $args['user_id'] );
+		}
+
+		if ( ! empty( $args['name'] ) ) {
+			$args['search'] = '***' . $args['name'] . '***';
+			unset( $args['name'] );
+		}
+
+		if ( ! empty( $args['date'] ) ) {
+			$date_query = array( 'relation' => 'AND' );
+
+			if ( is_array( $args['date'] ) ) {
+				$date_query[] = array(
+					'after'     => date( 'Y-m-d 00:00:00', strtotime( $args['date']['start'] ) ),
+					'inclusive' => true,
+				);
+				$date_query[] = array(
+					'before'    => date( 'Y-m-d 23:59:59', strtotime( $args['date']['end'] ) ),
+					'inclusive' => true,
+				);
 			} else {
-				$ids = intval( $args['id'] );
+				$date_query[] = array(
+					'year'  => date( 'Y', strtotime( $args['date'] ) ),
+					'month' => date( 'm', strtotime( $args['date'] ) ),
+					'day'   => date( 'd', strtotime( $args['date'] ) ),
+				);
 			}
 
-			$where .= " AND `id` IN( {$ids} ) ";
-
-		}
-
-		// customers for specific user accounts
-		if( ! empty( $args['user_id'] ) ) {
-
-			if( is_array( $args['user_id'] ) ) {
-				$user_ids = implode( ',', array_map('intval', $args['user_id'] ) );
+			if ( empty( $args['date_query'] ) ) {
+				$args['date_query'] = $date_query;
 			} else {
-				$user_ids = intval( $args['user_id'] );
+				$args['date_query'] = array(
+					'relation' => 'AND',
+					$date_query,
+					$args['date_query'],
+				);
 			}
 
-			$where .= " AND `user_id` IN( {$user_ids} ) ";
-
+			unset( $args['date'] );
 		}
 
-		//specific customers by email
-		if( ! empty( $args['email'] ) ) {
+		return $args;
+	}
 
-			if( is_array( $args['email'] ) ) {
+	/**
+	 * Sets the last_changed cache key for customers.
+	 *
+	 * @access public
+	 * @since  2.8
+	 */
+	public function set_last_changed() {
+		wp_cache_set( 'last_changed', microtime(), $this->cache_group );
+	}
 
-				$emails_count       = count( $args['email'] );
-				$emails_placeholder = array_fill( 0, $emails_count, '%s' );
-				$emails             = implode( ', ', $emails_placeholder );
-
-				$where .= $wpdb->prepare( " AND `email` IN( $emails ) ", $args['email'] );
-			} else {
-				$meta_table      = $wpdb->prefix . 'edd_customermeta';
-				$customers_table = $this->table_name;
-
-				$join  .= " LEFT JOIN $meta_table ON $customers_table.id = $meta_table.customer_id";
-				$where .= $wpdb->prepare( " AND ( ( `meta_key` = 'additional_email' AND `meta_value` = %s ) OR `email` = %s )", $args['email'], $args['email'] );
-			}
+	/**
+	 * Retrieves the value of the last_changed cache key for customers.
+	 *
+	 * @access public
+	 * @since  2.8
+	 */
+	public function get_last_changed() {
+		if ( function_exists( 'wp_cache_get_last_changed' ) ) {
+			return wp_cache_get_last_changed( $this->cache_group );
 		}
 
-		// specific customers by name
-		if( ! empty( $args['name'] ) ) {
-			$where .= $wpdb->prepare( " AND `name` LIKE '%%%%" . '%s' . "%%%%' ", $args['name'] );
+		$last_changed = wp_cache_get( 'last_changed', $this->cache_group );
+		if ( ! $last_changed ) {
+			$last_changed = microtime();
+			wp_cache_set( 'last_changed', $last_changed, $this->cache_group );
 		}
 
-		// Customers created for a specific date or in a date range
-		if( ! empty( $args['date'] ) ) {
-
-			if( is_array( $args['date'] ) ) {
-
-				if( ! empty( $args['date']['start'] ) ) {
-
-					$start = date( 'Y-m-d 00:00:00', strtotime( $args['date']['start'] ) );
-					$where .= " AND `date_created` >= '{$start}'";
-
-				}
-
-				if( ! empty( $args['date']['end'] ) ) {
-
-					$end = date( 'Y-m-d 23:59:59', strtotime( $args['date']['end'] ) );
-					$where .= " AND `date_created` <= '{$end}'";
-
-				}
-
-			} else {
-
-				$year  = date( 'Y', strtotime( $args['date'] ) );
-				$month = date( 'm', strtotime( $args['date'] ) );
-				$day   = date( 'd', strtotime( $args['date'] ) );
-
-				$where .= " AND $year = YEAR ( date_created ) AND $month = MONTH ( date_created ) AND $day = DAY ( date_created )";
-			}
-
-		}
-
-		$cache_key = md5( 'edd_customers_count' . serialize( $args ) );
-
-		$count = wp_cache_get( $cache_key, 'customers' );
-
-		if( $count === false ) {
-			$query = "SELECT COUNT($this->primary_key) FROM " . $this->table_name . "{$join} {$where};";
-			$count = $wpdb->get_var( $query);
-			wp_cache_set( $cache_key, $count, 'customers', 3600 );
-		}
-
-		return absint( $count );
-
+		return $last_changed;
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces the new `EDD_Customer_Query` class (as described in #5448 before) and makes use of it in the `EDD_DB_Customers` methods `get_customer_by()`, `get_customers()` and `count()`.

The class uses a simple caching layer for its queries to boost performance, therefore a bit of other related functionality has been introduced as well (in particular the methods `set_last_changed()` and `get_last_changed()` in `EDD_DB_Customers`. A few new properties on the `EDD_DB_Customers` class have been introduced as well.

I tried to make the query class more flexible than the current query method, thus handled a few query variables differently. However, when creating a query instance through one of the methods that already existed before, all the arguments are automatically "translated" to the `EDD_Customer_Query` ones so that things are backward-compatible.

I did not do extensive testing yet, only basic tests in EDD, so that still needs to be done. So there still needs to be some work done for this PR, but I already opened it for first review/feedback.