### PR TITLE
Update payment date during recovery. #5520

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -168,6 +168,8 @@ function edd_insert_payment( $payment_data = array() ) {
 
 	if ( $resume_payment ) {
 
+		$payment->date = date( 'Y-m-d G:i:s', current_time( 'timestamp' ) );
+
 		$payment->add_note( __( 'Payment recovery processed', 'easy-digital-downloads' ) );
 
 		// Since things could have been added/removed since we first crated this...rebuild the cart details.


### PR DESCRIPTION
#5520 

This ensures that earnings reports properly reflect recovered payments from past days, weeks, months, years.