### PR TITLE
Call query modifiers directly in EDD_Get_Payments

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -113,7 +113,7 @@ class EDD_Payments_Query extends EDD_Stats {
 	}
 
 	/**
-	 * Modify the query/query arguments before we retrieve payments.
+	 * Nothing here at the moment.
 	 *
 	 * @access public
 	 * @since 1.8
@@ -121,20 +121,6 @@ class EDD_Payments_Query extends EDD_Stats {
 	 */
 	public function init() {
 
-		add_action( 'edd_pre_get_payments', array( $this, 'date_filter_pre' ) );
-		add_action( 'edd_post_get_payments', array( $this, 'date_filter_post' ) );
-
-		add_action( 'edd_pre_get_payments', array( $this, 'orderby' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'status' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'month' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'per_page' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'page' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'user' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'customer' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'search' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'mode' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'children' ) );
-		add_action( 'edd_pre_get_payments', array( $this, 'download' ) );
 	}
 
 	/**
@@ -149,6 +135,21 @@ class EDD_Payments_Query extends EDD_Stats {
 	 * @return object
 	 */
 	public function get_payments() {
+
+		// Modify the query/query arguments before we retrieve payments.
+		$this->date_filter_pre();
+		$this->date_filter_post();
+		$this->orderby();
+		$this->status();
+		$this->month();
+		$this->per_page();
+		$this->page();
+		$this->user();
+		$this->customer();
+		$this->search();
+		$this->mode();
+		$this->children();
+		$this->download();
 
 		do_action( 'edd_pre_get_payments', $this );
 


### PR DESCRIPTION
Instead of hooking to edd_pre_get_payments, call the query modifiers directly.