### PR TITLE
Fix #5440 - Allow TLDs to be added to the 'banned emails' list

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -97,11 +97,11 @@ function edd_tools_banned_emails_display() {
 	<div class="postbox">
 		<h3><span><?php _e( 'Banned Emails', 'easy-digital-downloads' ); ?></span></h3>
 		<div class="inside">
-			<p><?php _e( 'Emails placed in the box below will not be allowed to make purchases. To ban an entire domain, enter the domain starting with "@".', 'easy-digital-downloads' ); ?></p>
+			<p><?php _e( 'Emails placed in the box below will not be allowed to make purchases.', 'easy-digital-downloads' ); ?></p>
 			<form method="post" action="<?php echo admin_url( 'edit.php?post_type=download&page=edd-tools&tab=general' ); ?>">
 				<p>
 					<textarea name="banned_emails" rows="10" class="large-text"><?php echo implode( "\n", edd_get_banned_emails() ); ?></textarea>
-					<span class="description"><?php _e( 'Enter emails and/or domains (starting with @) to disallow, one per line.', 'easy-digital-downloads' ); ?></span>
+					<span class="description"><?php _e( 'Enter emails and/or domains (starting with "@") and/or TLDs (starting with ".") to disallow, one per line.', 'easy-digital-downloads' ); ?></span>
 				</p>
 				<p>
 					<input type="hidden" name="edd_action" value="save_banned_emails" />
@@ -395,10 +395,8 @@ function edd_tools_banned_emails_save() {
 		$emails = array_map( 'sanitize_text_field', $emails );
 
 		foreach( $emails as $id => $email ) {
-			if( ! is_email( $email ) ) {
-				if( $email[0] != '@' ) {
-					unset( $emails[$id] );
-				}
+			if( ! is_email( $email ) && $email[0] != '@' && $email[0] != '.' ) {
+				unset( $emails[$id] );
 			}
 		}
 	} else {

--- a/includes/checkout/functions.php
+++ b/includes/checkout/functions.php
@@ -259,10 +259,12 @@ function edd_get_banned_emails() {
  * Determines if an email is banned
  *
  * @since       2.0
- * @return      bool
+ * @param string $email Email to check if is banned.
+ * @return bool
  */
 function edd_is_email_banned( $email = '' ) {
 
+	$email = trim( $email );
 	if( empty( $email ) ) {
 		return false;
 	}
@@ -273,19 +275,22 @@ function edd_is_email_banned( $email = '' ) {
 		return false;
 	}
 
+	$return = false;
 	foreach( $banned_emails as $banned_email ) {
 		if( is_email( $banned_email ) ) {
-			$ret = ( $banned_email == trim( $email ) ? true : false );
+			$return = ( $banned_email == $email ? true : false );
+		} elseif ( strpos( $banned_email, '.' ) === 0 ) { // Domains only
+			$return = ( substr( $email, ( strlen( $banned_email ) * -1 ) ) == $banned_email ) ? true : false;
 		} else {
-			$ret = ( stristr( trim( $email ), $banned_email ) ? true : false );
+			$return = ( stristr( $email, $banned_email ) ? true : false );
 		}
 
-		if( true === $ret ) {
+		if( true === $return ) {
 			break;
 		}
 	}
 
-	return apply_filters( 'edd_is_email_banned', $ret, $email );
+	return apply_filters( 'edd_is_email_banned', $return, $email );
 }
 
 /**

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -1067,47 +1067,36 @@ function edd_purchase_form_validate_cc_zip( $zip = 0, $country_code = '' ) {
  * @return      void
  */
 function edd_check_purchase_email( $valid_data, $posted ) {
-	$is_banned = false;
 	$banned    = edd_get_banned_emails();
 
 	if( empty( $banned ) ) {
 		return;
 	}
 
+	$user_emails = array( $posted['edd_email'] );
 	if( is_user_logged_in() ) {
 
 		// The user is logged in, check that their account email is not banned
 		$user_data = get_userdata( get_current_user_id() );
-		if( edd_is_email_banned( $user_data->user_email ) ) {
-
-			$is_banned = true;
-		}
-
-		if( edd_is_email_banned( $posted['edd_email'] ) ) {
-			$is_banned = true;
-		}
+		$user_emails[] = $user_data->user_email;
 
 	} elseif( isset( $posted['edd-purchase-var'] ) && $posted['edd-purchase-var'] == 'needs-to-login' ) {
 
 		// The user is logging in, check that their email is not banned
-		$user_data = get_user_by( 'login', $posted['edd_user_login'] );
-		if( $user_data && edd_is_email_banned( $user_data->user_email ) ) {
-			$is_banned = true;
-		}
-
-	} else {
-
-		// Guest purchase, check that the email is not banned
-		if( edd_is_email_banned( $posted['edd_email'] ) ) {
-			$is_banned = true;
+		if( $user_data = get_user_by( 'login', $posted['edd_user_login'] ) ) {
+			$user_emails[] = $user_data->user_email;
 		}
 
 	}
 
-	if( $is_banned ) {
-		// Set an error and give the customer a general error (don't alert them that they were banned)
-		edd_set_error( 'email_banned', __( 'An internal error has occurred, please try again or contact support.', 'easy-digital-downloads' ) );
+	foreach ( $user_emails as $email ) {
+		if ( edd_is_email_banned( $email ) ) {
+			// Set an error and give the customer a general error (don't alert them that they were banned)
+			edd_set_error( 'email_banned', __( 'An internal error has occurred, please try again or contact support.', 'easy-digital-downloads' ) );
+			break;
+		}
 	}
+
 }
 add_action( 'edd_checkout_error_checks', 'edd_check_purchase_email', 10, 2 );
 

--- a/tests/tests-checkout.php
+++ b/tests/tests-checkout.php
@@ -92,14 +92,17 @@ class Tests_Checkout extends EDD_UnitTestCase {
 	public function test_edd_is_email_banned() {
 
 		$emails = array();
-		$emails[] = 'john@test.com';
-		$emails[] = 'test2.com';
+		$emails[] = 'john@test.com'; // Banned email
+		$emails[] = 'test2.com'; // Banned domain
+		$emails[] = '.zip'; // Banned TLD
 
 		edd_update_option( 'banned_emails', $emails );
 
 		$this->assertTrue( edd_is_email_banned( 'john@test.com' ) );
 		$this->assertTrue( edd_is_email_banned( 'john@test2.com' ) );
 		$this->assertFalse( edd_is_email_banned( 'john2@test.com' ) );
+		$this->assertTrue( edd_is_email_banned( 'john2@test.zip' ) );
+		$this->assertFalse( edd_is_email_banned( 'john.zip@test.com' ) );
 	}
 
 	/**


### PR DESCRIPTION
Add the feature to allow TLDs in the 'Banned emails' setting.
Includes unit tests to verify its working.

#5440