### PR TITLE
PHP 7.1 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 - 5.5
 - 5.6
 - 7.0
+- 7.1
 - hhvm
 
 env:
@@ -27,6 +28,20 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
   exclude:
     - php: hhvm
+      env: WP_VERSION=4.0 WP_MULTISITE=0
+    - php: 7.1
+      env: WP_VERSION=4.6 WP_MULTISITE=0
+    - php: 7.1
+      env: WP_VERSION=4.5 WP_MULTISITE=0
+    - php: 7.1
+      env: WP_VERSION=4.4 WP_MULTISITE=0
+    - php: 7.1
+      env: WP_VERSION=4.3 WP_MULTISITE=0      
+    - php: 7.1
+      env: WP_VERSION=4.2 WP_MULTISITE=0
+    - php: 7.1
+      env: WP_VERSION=4.1 WP_MULTISITE=0
+    - php: 7.1
       env: WP_VERSION=4.0 WP_MULTISITE=0
 
 before_script:


### PR DESCRIPTION
This excludes versions that have a bug related to wp_scripts.

I close the other PR that was without the excludes.

I saw you want to drop tests for the older WP versions to that long exclude list can be lowered then obviously.

I have saw in the last PR that there were actually a lot of errors. Thats really concerning to me as I have a bug that EDD counts that 2 months of earnings together as one month. That may be related to this.