### PR TITLE
Typo: "succesfully" instead of "successfully"

### DIFF
--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -2033,7 +2033,7 @@ class EDD_API {
 	 * @since 2.0.0
 	 * @param int $user_id User ID the key is being generated for
 	 * @param boolean $regenerate Regenerate the key for the user
-	 * @return boolean True if (re)generated succesfully, false otherwise.
+	 * @return boolean True if (re)generated successfully, false otherwise.
 	 */
 	public function generate_api_key( $user_id = 0, $regenerate = false ) {
 

--- a/includes/class-edd-customer.php
+++ b/includes/class-edd-customer.php
@@ -727,7 +727,7 @@ class EDD_Customer {
 	 *
 	 * @since  2.3
 	 * @param string $note The note to add
-	 * @return string|boolean The new note if added succesfully, false otherwise
+	 * @return string|boolean The new note if added successfully, false otherwise
 	 */
 	public function add_note( $note = '' ) {
 

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -494,7 +494,7 @@ class Test_Misc extends EDD_UnitTestCase {
 
 		$updated = edd_update_option( $key, $value );
 
-		// The option should have succesfully updated
+		// The option should have successfully updated
 		$this->assertTrue( $updated );
 
 		// The option retrieve should be equal to the one we set


### PR DESCRIPTION
Just a tiny misspelling. Three lines with "succesfully" instead of "successfully".