### PR TITLE
Confusing wrap ID

### DIFF
--- a/templates/shortcode-profile-editor.php
+++ b/templates/shortcode-profile-editor.php
@@ -199,7 +199,7 @@ if ( is_user_logged_in() ):
 				<input name="edd_new_user_pass1" id="edd_new_user_pass1" class="password edd-input" type="password"/>
 			</p>
 
-			<p id="edd_profile_billing_address_wrap">
+			<p id="edd_profile_pass2_wrap">
 				<label for="edd_user_pass"><?php _e( 'Re-enter Password', 'easy-digital-downloads' ); ?></label>
 				<input name="edd_new_user_pass2" id="edd_new_user_pass2" class="password edd-input" type="password"/>
 				<?php do_action( 'edd_profile_editor_password' ); ?>


### PR DESCRIPTION
Changed "edd_profile_billing_address_wrap" to "edd_profile_pass2_wrap", since it's the wrap for edd_new_user_pass2, not for the billing address.