### PR TITLE
Offer a filter to customize the default date range

### DIFF
--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -772,7 +772,7 @@ function edd_get_report_dates() {
 
 	$current_time = current_time( 'timestamp' );
 
-	$dates['range'] = isset( $_GET['range'] ) ? $_GET['range'] : apply_filters( 'edd_get_report_dates_default_range', last_30_days' );
+	$dates['range'] = isset( $_GET['range'] ) ? $_GET['range'] : apply_filters( 'edd_get_report_dates_default_range', 'last_30_days' );
 
 	if ( 'custom' !== $dates['range'] ) {
 		$dates['year']       = isset( $_GET['year'] )    ? $_GET['year']    : date( 'Y' );

--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -772,7 +772,7 @@ function edd_get_report_dates() {
 
 	$current_time = current_time( 'timestamp' );
 
-	$dates['range'] = isset( $_GET['range'] ) ? $_GET['range'] : 'last_30_days';
+	$dates['range'] = isset( $_GET['range'] ) ? $_GET['range'] : apply_filters( 'edd_get_report_dates_default_range', last_30_days' );
 
 	if ( 'custom' !== $dates['range'] ) {
 		$dates['year']       = isset( $_GET['year'] )    ? $_GET['year']    : date( 'Y' );


### PR DESCRIPTION
Adds a filter to let people customize the default date range, solving a backward incompatible change in EDD.

EDD changed this to "last 30 days" from "this month" in the last major release, and there's currently no way for anyone to change it back or to use a different default range. This filter allows for both cases.

Note, edits for pr is on in case someone has a better name for the filter.