### PR TITLE
Allow an `edd_ajax` field to be sent to registration processing

### DIFF
--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -143,6 +143,8 @@ function edd_process_register_form( $data ) {
 		return;
 	}
 
+	$is_ajax = isset( $_POST['edd_ajax'] );
+
 	do_action( 'edd_pre_process_register_form' );
 
 	if( empty( $data['edd_user_login'] ) ) {
@@ -193,6 +195,12 @@ function edd_process_register_form( $data ) {
 			'user_registered' => date( 'Y-m-d H:i:s' ),
 			'role'            => get_option( 'default_role' )
 		) );
+
+		if ( $is_ajax ) {
+			return wp_send_json_success( array(
+				'redirect' => $redirect,
+			) );
+		}
 
 		wp_redirect( $redirect );
 		edd_die();


### PR DESCRIPTION
to avoid a forced redirect. See #5086