### PR TITLE
Prevent extreme duplicate SQL queries

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -35,7 +35,7 @@ function edd_get_discounts( $args = array() ) {
 	$discounts_hash = md5( json_encode( $args ) );
 	if ( ! $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' ) ) {
 		$discounts = get_posts( $args );
-		wp_cache_set( $discounts_hash, $discounts, 'edd-discounts' );
+		wp_cache_set( $discounts_hash, $discounts, 'edd-discounts', HOUR_IN_SECONDS );
 	}
 
 
@@ -53,7 +53,7 @@ function edd_get_discounts( $args = array() ) {
 		$discounts_hash = md5( json_encode( $args ) );
 		if ( ! $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' ) ) {
 			$discounts = get_posts( $args );
-			wp_cache_set( $discounts_hash, $discounts, 'edd-discounts' );
+			wp_cache_set( $discounts_hash, $discounts, 'edd-discounts', HOUR_IN_SECONDS );
 		}
 	}
 

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -33,7 +33,7 @@ function edd_get_discounts( $args = array() ) {
 	$args = wp_parse_args( $args, $defaults );
 
 	$discounts_hash = md5( json_encode( $args ) );
-	$discounts = $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' );
+	$discounts = wp_cache_get( $discounts_hash, 'edd-discounts' );
 	if ( false === $discounts ) {
 		$discounts = get_posts( $args );
 		wp_cache_set( $discounts_hash, $discounts, 'edd-discounts', HOUR_IN_SECONDS );

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -33,7 +33,8 @@ function edd_get_discounts( $args = array() ) {
 	$args = wp_parse_args( $args, $defaults );
 
 	$discounts_hash = md5( json_encode( $args ) );
-	if ( ! $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' ) ) {
+	$discounts = $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' );
+	if ( false === $discounts ) {
 		$discounts = get_posts( $args );
 		wp_cache_set( $discounts_hash, $discounts, 'edd-discounts', HOUR_IN_SECONDS );
 	}
@@ -51,7 +52,8 @@ function edd_get_discounts( $args = array() ) {
 		unset( $args['s'] );
 
 		$discounts_hash = md5( json_encode( $args ) );
-		if ( ! $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' ) ) {
+		$discounts = wp_cache_get( $discounts_hash, 'edd-discounts' );
+		if ( false === $discounts ) {
 			$discounts = get_posts( $args );
 			wp_cache_set( $discounts_hash, $discounts, 'edd-discounts', HOUR_IN_SECONDS );
 		}

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -32,19 +32,29 @@ function edd_get_discounts( $args = array() ) {
 
 	$args = wp_parse_args( $args, $defaults );
 
-	$discounts = get_posts( $args );
+	$discounts_hash = md5( json_encode( $args ) );
+	if ( ! $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' ) ) {
+		$discounts = get_posts( $args );
+		wp_cache_set( $discounts_hash, $discounts, 'edd-discounts' );
+	}
+
 
 	if ( $discounts ) {
 		return $discounts;
 	}
 
+	// If no discounts are found and we are searching, re-query with a meta key to find discounts by code
 	if( ! $discounts && ! empty( $args['s'] ) ) {
-		// If no discounts are found and we are searching, re-query with a meta key to find discounts by code
 		$args['meta_key']     = '_edd_discount_code';
 		$args['meta_value']   = $args['s'];
 		$args['meta_compare'] = 'LIKE';
 		unset( $args['s'] );
-		$discounts = get_posts( $args );
+
+		$discounts_hash = md5( json_encode( $args ) );
+		if ( ! $discounts = wp_cache_get( $discounts_hash, 'edd-discounts' ) ) {
+			$discounts = get_posts( $args );
+			wp_cache_set( $discounts_hash, $discounts, 'edd-discounts' );
+		}
 	}
 
 	if( $discounts ) {
@@ -116,10 +126,10 @@ function edd_get_discount( $discount_id = 0 ) {
  * @since 2.7 Updated to use EDD_Discount object
  *
  * @param string $code Discount code.
- * @return mixed object|bool EDD_Discount object or false if not found.
+ * @return EDD_Discount|bool EDD_Discount object or false if not found.
  */
 function edd_get_discount_by_code( $code = '' ) {
-	$discount =  new EDD_Discount( $code, true );
+	$discount = new EDD_Discount( $code, true );
 
 	if ( ! $discount->ID > 0 ) {
 		return false;


### PR DESCRIPTION
When a discount is applied to the cart it will call the `edd_get_discounts` a lot of times. This function calls the WP_Query which causes duplicate queries. When there's only one product in the cart its 'only' 82 queries instead of ~32. When there's more it will multiply quickly and with a test of 9 products in the cart it will send 500+ duplicate queries to the DB.

https://cl.ly/262J0O1i0X2V

--------

I've also investigated the roots of it being called that many times; this is something else that I'd like to discuss sometime soon. The results of some quick tests seem very promising for improvements in the checkout page speed. 

Before going from 2.2~2.3 seconds (with pretty regular peeks of ~5+ seconds); going to 1.4-1.6 seconds without those spikes.