### PR TITLE
Remove HHVM from unit tests tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
   include:
     - php: 5.3
       env: WP_VERSION=latest WP_MULTISITE=1
-  exclude:
-    - php: hhvm
-      env: WP_VERSION=4.0 WP_MULTISITE=0
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
@@ -39,7 +36,7 @@ before_script:
     fi
 
 script:
-- if [[ $TRAVIS_PHP_VERSION != 'hhvm' && ( $TRAVIS_PHP_VERSION != '5.5'|| $WP_VERSION != 'latest'
+- if [[ ( $TRAVIS_PHP_VERSION != '5.5'|| $WP_VERSION != 'latest'
   || $WP_MULTISITE != '0' ) ]]; then phpenv config-rm xdebug.ini; fi
 - if [[ $TRAVIS_PHP_VERSION = '5.5' && $WP_VERSION = 'latest' && $WP_MULTISITE = '0'
   ]]; then phpunit --coverage-clover=coverage.clover; else phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
 - 5.5
 - 5.6
 - 7.0
-- hhvm
 
 env:
 - WP_VERSION=latest WP_MULTISITE=0


### PR DESCRIPTION
I'd suggest to follow WordPress' lead here and remove HHVM from the unit tests. 
So far I've only seen them give issues and make the tests fail. Would be neat to actually see accurate Travis results in the PR overview.

https://make.wordpress.org/core/2017/05/25/hhvm-no-longer-part-of-wordpress-cores-testing-infrastructure/