### PR TITLE
Correct docblocks for EDD_Session get() and set() methods

### DIFF
--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -156,7 +156,7 @@ class EDD_Session {
 	 * @access public
 	 * @since 1.5
 	 * @param string $key Session key
-	 * @return string Session variable
+	 * @return mixed Session variable
 	 */
 	public function get( $key ) {
 		$key = sanitize_key( $key );
@@ -169,8 +169,8 @@ class EDD_Session {
 	 * @since 1.5
 	 *
 	 * @param string $key Session key
-	 * @param integer $value Session variable
-	 * @return string Session variable
+	 * @param int|string|array $value Session variable
+	 * @return mixed Session variable
 	 */
 	public function set( $key, $value ) {
 


### PR DESCRIPTION
As `maybe_unserialize()` returns `mixed`, so should `EDD_Session()->get()`.

`EDD_Session()->set()` can accept strings and arrays as well as integers.