### PR TITLE
issue/5918 - Strict in_array() comparison for Settings API Select Multiple

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1796,7 +1796,7 @@ function edd_select_callback($args) {
 			$html .= '<option value="' . esc_attr( $option ) . '" ' . $selected . '>' . esc_html( $name ) . '</option>';
 		} else {
 			// Do an in_array() check to output selected attribute for Multiple
-			$html .= '<option value="' . esc_attr( $option ) . '" ' . ( ( in_array( $option, $value ) ) ? 'selected="true"' : '' ) . '>' . esc_html( $name ) . '</option>';
+			$html .= '<option value="' . esc_attr( $option ) . '" ' . ( ( in_array( $option, $value, true ) ) ? 'selected="true"' : '' ) . '>' . esc_html( $name ) . '</option>';
 		}
 		
 	}


### PR DESCRIPTION
Unless you do a strict comparison for `in_array()` it can cause unexpected `<option>`s to be selected once the callback function completes.

For example, if a Setting has the following saved:

```
$value = array(
    '15-1',
);
```

And the following is available as `$args['options']`:

```
$args['options'] = array(
    '15' => 'Should NOT be selected',
    '15-1' => 'Should be selected',
    '15-2' => 'Does not get selected',
)
```

The`<option>`s with values `15` AND `15-1` get selected. I suppose this is due to `15` not containing any _different_ characters than `15-1` while `15-2` does contain different characters. According to the [PHP Docs](http://php.net/manual/en/function.in-array.php), setting it to a Strict Comparison is meant to check against the Type of the Needle but it also forces it to match the entire String it would seem.

#5918