### PR TITLE
Add ability to filter post_status for product dropdown #5884

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -525,7 +525,7 @@ function edd_ajax_download_search() {
 	if ( ! current_user_can( 'edit_products' ) ) {
 		$status = apply_filters( 'edd_product_dropdown_status_nopriv', array( 'publish' ) );
 	} else {
-		$status = apply_filters( 'edd_product_dropdown_status', array( 'publish' ) );
+		$status = apply_filters( 'edd_product_dropdown_status', array( 'publish', 'draft', 'private', 'future' ) );
 	}
 
 	if ( is_array( $status ) && ! empty( $status ) ) {

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -522,9 +522,22 @@ function edd_ajax_download_search() {
 		$where .= "AND `ID` NOT IN (" . $exclude . ") ";
 	}
 
-	// If the user can't edit products, limit to just published items
-	if( ! current_user_can( 'edit_products' ) ) {
-		$where .= "AND `post_status` = 'publish' ";
+	if ( ! current_user_can( 'edit_products' ) ) {
+		$status = apply_filters( 'edd_product_dropdown_status_nopriv', array( 'publish' ) );
+	} else {
+		$status = apply_filters( 'edd_product_dropdown_status', array( 'publish' ) );
+	}
+
+	if ( is_array( $status ) && ! empty( $status ) ) {
+
+		$status     = array_map( 'sanitize_text_field', $status );
+		$status_in  = join( "', '", $status );
+		$where     .= "AND `post_status` IN ({$status_in}) ";
+
+	} else {
+
+		$where .= "AND `post_status` = `publish` ";
+
 	}
 
 	// Limit the result sets

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -531,7 +531,7 @@ function edd_ajax_download_search() {
 	if ( is_array( $status ) && ! empty( $status ) ) {
 
 		$status     = array_map( 'sanitize_text_field', $status );
-		$status_in  = join( "', '", $status );
+		$status_in  = "'" . join( "', '", $status ) . "'";
 		$where     .= "AND `post_status` IN ({$status_in}) ";
 
 	} else {

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -54,8 +54,26 @@ class EDD_HTML_Elements {
 			'post_type'      => 'download',
 			'orderby'        => 'title',
 			'order'          => 'ASC',
-			'posts_per_page' => $args['number']
+			'posts_per_page' => $args['number'],
 		);
+
+		if ( ! current_user_can( 'edit_products' ) ) {
+			$product_args['status'] = apply_filters( 'edd_product_dropdown_status_nopriv', array( 'publish' ) );
+		} else {
+			$product_args['status'] = apply_filters( 'edd_product_dropdown_status', array( 'publish' ) );
+		}
+
+		if ( is_array( $product_args['status'] ) ) {
+
+			// Given the array, sanitize them.
+			$product_args['status'] = array_map( 'sanitize_text_field', $product_args['status'] );
+
+		} else {
+
+			// If we didn't get an array, fallback to 'publish'.
+			$product_args['status'] = array( 'publish' );
+
+		}
 
 		// Maybe disable bundles
 		if( ! $args['bundles'] ) {
@@ -68,6 +86,8 @@ class EDD_HTML_Elements {
 				)
 			);
 		}
+
+		$product_args = apply_filters( 'edd_product_dropdown_args', $product_args );
 
 		$products     = get_posts( $product_args );
 		$existing_ids = wp_list_pluck( $products, 'ID' );

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -58,20 +58,20 @@ class EDD_HTML_Elements {
 		);
 
 		if ( ! current_user_can( 'edit_products' ) ) {
-			$product_args['status'] = apply_filters( 'edd_product_dropdown_status_nopriv', array( 'publish' ) );
+			$product_args['post_status'] = apply_filters( 'edd_product_dropdown_status_nopriv', array( 'publish' ) );
 		} else {
-			$product_args['status'] = apply_filters( 'edd_product_dropdown_status', array( 'publish', 'draft', 'private', 'future' ) );
+			$product_args['post_status'] = apply_filters( 'edd_product_dropdown_status', array( 'publish', 'draft', 'private', 'future' ) );
 		}
 
-		if ( is_array( $product_args['status'] ) ) {
+		if ( is_array( $product_args['post_status'] ) ) {
 
 			// Given the array, sanitize them.
-			$product_args['status'] = array_map( 'sanitize_text_field', $product_args['status'] );
+			$product_args['post_status'] = array_map( 'sanitize_text_field', $product_args['post_status'] );
 
 		} else {
 
 			// If we didn't get an array, fallback to 'publish'.
-			$product_args['status'] = array( 'publish' );
+			$product_args['post_status'] = array( 'publish' );
 
 		}
 

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -60,7 +60,7 @@ class EDD_HTML_Elements {
 		if ( ! current_user_can( 'edit_products' ) ) {
 			$product_args['status'] = apply_filters( 'edd_product_dropdown_status_nopriv', array( 'publish' ) );
 		} else {
-			$product_args['status'] = apply_filters( 'edd_product_dropdown_status', array( 'publish' ) );
+			$product_args['status'] = apply_filters( 'edd_product_dropdown_status', array( 'publish', 'draft', 'private', 'future' ) );
 		}
 
 		if ( is_array( $product_args['status'] ) ) {


### PR DESCRIPTION
Resolves #5884 

This does a couple things:
1) Introduces two filters `edd_product_dropdown_status_nopriv` and `edd_product_dropdown_status`
2) Users who cannot `edit_products`, default to `publish`
3) Users who _can_ `edit_products`, default to `publish, draft, private, future`
4) If, after allowing the filters through we run `sanitize_text_field` to be sure we don't get a bad value
5) If what we get back is not an array, we default back to `publish` only, no matter privs.