### PR TITLE
issue/6049 – Use a valid status in the payments create command docs.

### DIFF
--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -495,7 +495,7 @@ class EDD_CLI extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 * wp edd payments create --number=10 --status=completed
+	 * wp edd payments create --number=10 --status=complete
 	 * wp edd payments create --number=10 --id=103
 	 */
 	public function payments( $args, $assoc_args ) {


### PR DESCRIPTION
Issue: #6049