### PR TITLE
Show country and state name instead of codes for better UX

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -231,8 +231,8 @@ function edd_customers_view( $customer ) {
 						<span class="info-item" data-key="line1"><?php echo $address['line1']; ?></span>
 						<span class="info-item" data-key="line2"><?php echo $address['line2']; ?></span>
 						<span class="info-item" data-key="city"><?php echo $address['city']; ?></span>
-						<span class="info-item" data-key="state"><?php echo $address['state']; ?></span>
-						<span class="info-item" data-key="country"><?php echo $address['country']; ?></span>
+						<span class="info-item" data-key="state"><?php echo edd_get_state_name( $address['state'] ); ?></span>
+						<span class="info-item" data-key="country"><?php echo edd_get_country_name( $address['country'] ); ?></span>
 						<span class="info-item" data-key="zip"><?php echo $address['zip']; ?></span>
 					</span>
 
@@ -266,7 +266,7 @@ function edd_customers_view( $customer ) {
 							?>
 						</select>
 						<?php else : ?>
-						<input type="text" size="6" data-key="state" name="customerinfo[state]" id="card_state" class="card_state edd-input info-item" placeholder="<?php _e( 'State / Province', 'easy-digital-downloads' ); ?>"/>
+						<input type="text" data-key="state" name="customerinfo[state]" id="card_state" class="card_state edd-input info-item" placeholder="<?php _e( 'State / Province', 'easy-digital-downloads' ); ?>" value="<?php echo $address['state']; ?>"/>
 						<?php endif; ?>
 						<input class="info-item" type="text" data-key="zip" name="customerinfo[zip]" placeholder="<?php _e( 'Postal', 'easy-digital-downloads' ); ?>" value="<?php echo $address['zip']; ?>" />
 					</span>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -231,7 +231,7 @@ function edd_customers_view( $customer ) {
 						<span class="info-item" data-key="line1"><?php echo $address['line1']; ?></span>
 						<span class="info-item" data-key="line2"><?php echo $address['line2']; ?></span>
 						<span class="info-item" data-key="city"><?php echo $address['city']; ?></span>
-						<span class="info-item" data-key="state"><?php echo edd_get_state_name( $address['state'] ); ?></span>
+						<span class="info-item" data-key="state"><?php echo edd_get_state_name( $address['country'], $address['state'] ); ?></span>
 						<span class="info-item" data-key="country"><?php echo edd_get_country_name( $address['country'] ); ?></span>
 						<span class="info-item" data-key="zip"><?php echo $address['zip']; ?></span>
 					</span>


### PR DESCRIPTION
The customer view displayed the ISO codes instead of the country and state names, making it somewhat confusing to users unfamiliar with ISO codes.

I have submitted PR (#6130) that aligns with this PR and adds a new `edd_get_state_name` function to the `country-functions.php` file that will return the state name when supplied with country and state codes.

Additionally a bug existed where manually entered "states" that had no pre-defined list, the name wasn't displayed when editing the customer record. I have fixed this bug and the size of the input box which was also incorrectly set.