### PR TITLE
Make Download Log IP addresses clickable to ARIN website

### DIFF
--- a/includes/admin/reporting/class-file-downloads-logs-list-table.php
+++ b/includes/admin/reporting/class-file-downloads-logs-list-table.php
@@ -128,7 +128,7 @@ class EDD_File_Downloads_Log_Table extends WP_List_Table {
 			case 'payment_id' :
 				return $item['payment_id'] !== false ? '<a href="' . admin_url( 'edit.php?post_type=download&page=edd-payment-history&view=view-order-details&id=' . $item['payment_id'] ) . '">' . edd_get_payment_number( $item['payment_id'] ) . '</a>' : '';
 			case 'ip' :
-				return '<a href="http://whois.arin.net/rest/ip/' . $item['ip']  . '" target="_blank" rel="noopener noreferrer">' . $item['ip']  . '</a>';		
+				return '<a href="https://ipinfo.io/' . $item['ip']  . '" target="_blank" rel="noopener noreferrer">' . $item['ip']  . '</a>';		
 			default:
 				return $item[ $column_name ];
 		}

--- a/includes/admin/reporting/class-file-downloads-logs-list-table.php
+++ b/includes/admin/reporting/class-file-downloads-logs-list-table.php
@@ -128,7 +128,7 @@ class EDD_File_Downloads_Log_Table extends WP_List_Table {
 			case 'payment_id' :
 				return $item['payment_id'] !== false ? '<a href="' . admin_url( 'edit.php?post_type=download&page=edd-payment-history&view=view-order-details&id=' . $item['payment_id'] ) . '">' . edd_get_payment_number( $item['payment_id'] ) . '</a>' : '';
 			case 'ip' :
-				return '<a href="http://whois.arin.net/rest/ip/' . $item['ip']  . '" target="_blank">' . $item['ip']  . '</a>';			
+				return '<a href="http://whois.arin.net/rest/ip/' . $item['ip']  . '" target="_blank" rel="noopener noreferrer">' . $item['ip']  . '</a>';		
 			default:
 				return $item[ $column_name ];
 		}

--- a/includes/admin/reporting/class-file-downloads-logs-list-table.php
+++ b/includes/admin/reporting/class-file-downloads-logs-list-table.php
@@ -127,6 +127,8 @@ class EDD_File_Downloads_Log_Table extends WP_List_Table {
 				return '<a href="' . add_query_arg( 'user', $item[ 'customer' ]->email ) . '">' . $item['customer']->name . '</a>';
 			case 'payment_id' :
 				return $item['payment_id'] !== false ? '<a href="' . admin_url( 'edit.php?post_type=download&page=edd-payment-history&view=view-order-details&id=' . $item['payment_id'] ) . '">' . edd_get_payment_number( $item['payment_id'] ) . '</a>' : '';
+			case 'ip' :
+				return '<a href="http://whois.arin.net/rest/ip/' . $item['ip']  . '" target="_blank">' . $item['ip']  . '</a>';			
 			default:
 				return $item[ $column_name ];
 		}


### PR DESCRIPTION
As per the title, make the file download log IP addresses clickable through to the ARIN website.