### PR TITLE
Add text to clarify when discount codes expire

### DIFF
--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -131,7 +131,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 				</th>
 				<td>
 					<input name="expiration" id="edd-expiration" type="text" class="edd_datepicker"/>
-					<p class="description"><?php _e( 'Enter the expiration date for this discount code in the format of mm/dd/yyyy. For no expiration, leave blank.', 'easy-digital-downloads' ); ?></p>
+					<p class="description"><?php _e( 'Enter the expiration date for this discount code in the format of mm/dd/yyyy. The discount code will expire at the end of the day selected. For no expiration, leave blank.', 'easy-digital-downloads' ); ?></p>
 				</td>
 			</tr>
 			<?php do_action( 'edd_add_discount_form_before_min_cart_amount' ); ?>

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -146,7 +146,7 @@ $condition_display = empty( $product_reqs ) ? ' style="display:none;"' : '';
 				</th>
 				<td>
 					<input name="expiration" id="edd-expiration" type="text" value="<?php echo esc_attr( edd_get_discount_expiration( $discount_id ) ); ?>"  class="edd_datepicker"/>
-					<p class="description"><?php _e( 'Enter the expiration date for this discount code in the format of mm/dd/yyyy. For no expiration, leave blank', 'easy-digital-downloads' ); ?></p>
+					<p class="description"><?php _e( 'Enter the expiration date for this discount code in the format of mm/dd/yyyy. The discount code will expire at the end of the day selected. For no expiration, leave blank', 'easy-digital-downloads' ); ?></p>
 				</td>
 			</tr>
 			<?php do_action( 'edd_edit_discount_form_before_max_uses', $discount_id, $discount ); ?>


### PR DESCRIPTION
Without this text, the time a discount code expires is rather ambiguous.
If you choose a date with the datepicker, you don't see until coming
back to edit the discount code that in fact a date and time (the last second of the
day) have been saved. This new text explicitly states that the discount
code will expire at the end of the day chosen.