### PR TITLE
Adding payments to before/after purchase history action

### DIFF
--- a/templates/history-purchases.php
+++ b/templates/history-purchases.php
@@ -10,7 +10,7 @@ endif;
 if ( is_user_logged_in() ):
 	$payments = edd_get_users_purchases( get_current_user_id(), 20, true, 'any' );
 	if ( $payments ) :
-		do_action( 'edd_before_purchase_history' ); ?>
+		do_action( 'edd_before_purchase_history', $payments ); ?>
 		<table id="edd_user_history" class="edd-table">
 			<thead>
 				<tr class="edd_purchase_row">
@@ -56,7 +56,7 @@ if ( is_user_logged_in() ):
 			) );
 			?>
 		</div>
-		<?php do_action( 'edd_after_purchase_history' ); ?>
+		<?php do_action( 'edd_after_purchase_history', $payments ); ?>
 		<?php wp_reset_postdata(); ?>
 	<?php else : ?>
 		<p class="edd-no-purchases"><?php _e('You have not made any purchases','easy-digital-downloads' ); ?></p>


### PR DESCRIPTION
Avoids a second query when using the action, where access to the payments would normally be needed