### PR TITLE
Change home_url() to site_url() for WPML compatibility

### DIFF
--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -366,10 +366,10 @@ function edd_deliver_download( $file = '', $redirect = false ) {
  * @return bool                   If the file is hosted locally or not
  */
 function edd_is_local_file( $requested_file ) {
-	$home_url       = preg_replace('#^https?://#', '', home_url() );
+	$site_url       = preg_replace('#^https?://#', '', site_url() );
 	$requested_file = preg_replace('#^(https?|file)://#', '', $requested_file );
 
-	$is_local_url  = strpos( $requested_file, $home_url ) === 0;
+	$is_local_url  = strpos( $requested_file, $site_url ) === 0;
 	$is_local_path = strpos( $requested_file, '/' ) === 0;
 
 	return ( $is_local_url || $is_local_path );


### PR DESCRIPTION
The function edd_is_local_file() uses home_url() to check if a file is local.

Most of the times home_url() and site_url() are the same, but when they are different the correct function is site_url(). site_url() returns the URL for WordPress core files (like for example the uploads folder):
https://codex.wordpress.org/Function_Reference/site_url

This little difference makes WPML fail this check because home_url() has the language code attached while site_url() doesn't have it.

The problem was originally reported here:
https://wpml.org/forums/topic/edd-frontend-submission-form-translation-wrong-behaviour/