### PR TITLE
fix for PHP 7.2 fatal error if return value is null

### DIFF
--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -190,7 +190,7 @@ function edd_email_tag_exists( $tag ) {
  * @return array
  */
 function edd_get_email_tags() {
-	return EDD()->email_tags->get_tags();
+	return (array) EDD()->email_tags->get_tags();
 }
 
 /**


### PR DESCRIPTION
Not sure which branch to make this against. #6317 