### PR TITLE
Add hooks before and after downloads shortcode item

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -579,11 +579,16 @@ function edd_downloads_query( $atts, $content = null ) {
 		$wrapper_class = 'edd_download_columns_' . $atts['columns'];
 		ob_start(); ?>
 		<div class="edd_downloads_list <?php echo apply_filters( 'edd_downloads_list_wrapper_class', $wrapper_class, $atts ); ?>">
+			
+			<?php do_action( 'edd_download_shortcode_item_before', $atts, $i ); ?>
+			
 			<?php while ( $downloads->have_posts() ) : $downloads->the_post(); ?>
 				<?php do_action( 'edd_download_shortcode_item', $atts, $i ); ?>
 			<?php $i++; endwhile; ?>
 
 			<?php wp_reset_postdata(); ?>
+			
+			<?php do_action( 'edd_download_shortcode_item_after', $atts, $i ); ?>
 
 			<?php if ( filter_var( $atts['pagination'], FILTER_VALIDATE_BOOLEAN ) ) : ?>
 


### PR DESCRIPTION
If it's not too much trouble, I added two new hooks;
`edd_download_shortcode_item_before` & `edd_download_shortcode_item_before`
inside the `edd_downloads_query` function. With these two new hooks I (and others) can add extra code before and after the loop.