### PR TITLE
Save page permalinks for performance #6369

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -2357,3 +2357,35 @@ function edd_add_setting_tooltip( $html, $args ) {
 	return $html;
 }
 add_filter( 'edd_after_setting_output', 'edd_add_setting_tooltip', 10, 2 );
+
+/**
+ * Save permalinks to save permalink only gueries in the future.
+ *
+ * @since 2.9.0
+ *
+ * @param mixed $value Current option value.
+ * @param mixed $old_value Old option value.
+ * @return mixed Updated option value.
+ */
+function edd_update_page_permalinks( $value, $old_value ) {
+
+	if ( ! isset( $old_value['purchase_page_permalink'] ) || $old_value['purchase_page'] !== $value['purchase_page'] ) {
+		$value['purchase_page_permalink'] = get_permalink( $value['purchase_page'] );
+	}
+
+	if ( ! isset( $old_value['success_page_permalink'] ) || $old_value['success_page'] !== $value['success_page'] ) {
+		$value['success_page_permalink'] = get_permalink( $value['success_page'] );
+	}
+
+	if ( ! isset( $old_value['failure_page_permalink'] ) || $old_value['failure_page'] !== $value['failure_page'] ) {
+		$value['failure_page_permalink'] = get_permalink( $value['failure_page'] );
+	}
+
+	if ( ! isset( $old_value['purchase_history_page_permalink'] ) || $old_value['purchase_history_page'] !== $value['purchase_history_page'] ) {
+		$value['purchase_history_page_permalink'] = get_permalink( $value['purchase_history_page'] );
+	}
+
+	return $value;
+
+}
+add_filter( 'pre_update_option_edd_settings', 'edd_update_page_permalinks', 10, 2 );

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -1163,3 +1163,16 @@ function edd_v26_upgrades() {
 	@EDD()->customers->create_table();
 	@EDD()->customer_meta->create_table();
 }
+
+/**
+ * 2.9 Upgrade routine to prevent additional queries in the future.
+ *
+ * @since  2.9
+ * @return void
+ */
+function edd_v29_upgrades() {
+	edd_update_option( 'purchase_page_permalink', get_permalink( 'purchase_page' ) );
+	edd_update_option( 'purchase_history_page_permalink', get_permalink( 'purchase_history_page' ) );
+	edd_update_option( 'failure_page_permalink', get_permalink( 'failure_page' ) );
+	edd_update_option( 'success_page_permalink', get_permalink( 'success_page' ) );
+}

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -30,6 +30,12 @@ function edd_do_automatic_upgrades() {
 
 	}
 
+	if( version_compare( $edd_version, '2.9', '<' ) ) {
+
+		edd_v29_upgrades();
+
+	}
+
 	if( version_compare( $edd_version, EDD_VERSION, '<' ) ) {
 
 		// Let us know that an upgrade has happened

--- a/includes/checkout/functions.php
+++ b/includes/checkout/functions.php
@@ -61,10 +61,7 @@ function edd_can_checkout() {
  * @return      string
 */
 function edd_get_success_page_uri( $query_string = null ) {
-	$page_id = edd_get_option( 'success_page', 0 );
-	$page_id = absint( $page_id );
-
-	$success_page = get_permalink( $page_id );
+	$success_page = edd_get_option( 'success_page_permalink', get_permalink( edd_get_option( 'success_page', 0 ) ) );
 
 	if ( $query_string ) {
 		$success_page .= $query_string;
@@ -116,7 +113,7 @@ function edd_send_to_success_page( $query_string = null ) {
  * @return mixed Full URL to the checkout page, if present | null if it doesn't exist
  */
 function edd_get_checkout_uri( $args = array() ) {
-	$uri = edd_get_option( 'purchase_page', false );
+	$uri = edd_get_option( 'purchase_page_permalink', false );
 	$uri = isset( $uri ) ? get_permalink( $uri ) : NULL;
 
 	if ( ! empty( $args ) ) {
@@ -180,8 +177,8 @@ function edd_send_back_to_checkout( $args = array() ) {
  * @return mixed|void Full URL to the Transaction Failed page, if present, home page if it doesn't exist
  */
 function edd_get_failed_transaction_uri( $extras = false ) {
-	$uri = edd_get_option( 'failure_page', '' );
-	$uri = ! empty( $uri ) ? trailingslashit( get_permalink( $uri ) ) : home_url();
+	$uri = edd_get_option( 'failure_page_permalink', get_permalink( edd_get_option( 'failure_page', '' ) ) );
+	$uri = ! empty( $uri ) ? trailingslashit( $uri ) : home_url();
 
 	if ( $extras )
 		$uri .= $extras;

--- a/includes/install.php
+++ b/includes/install.php
@@ -99,6 +99,7 @@ function edd_run_install() {
 		);
 
 		$options['purchase_page'] = $checkout;
+		$options['purchase_page_permalink'] = get_permalink( $checkout );
 	}
 
 	$checkout = isset( $checkout ) ? $checkout : $current_options['purchase_page'];
@@ -119,6 +120,7 @@ function edd_run_install() {
 		);
 
 		$options['success_page'] = $success;
+		$options['success_page_permalink'] = get_permalink( $success );
 	}
 
 	$failure_page = array_key_exists( 'failure_page', $current_options ) ? get_post( $current_options['failure_page'] ) : false;
@@ -137,6 +139,7 @@ function edd_run_install() {
 		);
 
 		$options['failure_page'] = $failed;
+		$options['failure_page_permalink'] = get_permalink( $failed );
 	}
 
 	$history_page = array_key_exists( 'purchase_history_page', $current_options ) ? get_post( $current_options['purchase_history_page'] ) : false;
@@ -155,6 +158,7 @@ function edd_run_install() {
 		);
 
 		$options['purchase_history_page'] = $history;
+		$options['purchase_history_page_permalink'] = get_permalink( $history );
 	}
 
 	// Populate some default values

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -189,15 +189,7 @@ function edd_login_form_shortcode( $atts, $content = null ) {
 	}
 
 	if ( empty( $redirect ) ) {
-		$purchase_history = edd_get_option( 'purchase_history_page', 0 );
-
-		if ( ! empty( $purchase_history ) ) {
-			$redirect = get_permalink( $purchase_history );
-		}
-	}
-
-	if ( empty( $redirect ) ) {
-		$redirect = home_url();
+		$redirect = edd_get_option( 'purchase_history_page_permalink', edd_get_option( 'purchase_history_page', home_url() ) );
 	}
 
 	return edd_login_form( $redirect );

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -980,12 +980,7 @@ add_action( 'edd_verify_user', 'edd_process_user_account_verification' );
  * @return string The base URL to use for account verification
  */
 function edd_get_user_verification_page() {
-	$url              = home_url();
-	$purchase_history = edd_get_option( 'purchase_history_page', 0 );
-
-	if ( ! empty( $purchase_history ) ) {
-		$url = get_permalink( $purchase_history );
-	}
+	$url = edd_get_option( 'purchase_history_page_permalink', edd_get_option( 'purchase_history_page', home_url() ) );
 
 	return apply_filters( 'edd_user_verification_base_url', $url );
 }


### PR DESCRIPTION
Hi Guys!

In the opportunity to reduce DB queries I've found that a `get_post` call was done every pageload if a cart widget is shown somewhere to get the permalink of the checkout page. I've worked to make a workaround for that by saving the permalinks in the settings instead and use that when possible.

Should be fully BC and nicely save the settings during the upgrade process.

PS. the other settings/pages didn't make a call by default, but for consistency I did also save those permalinks

Addresses #6369