### PR TITLE
Return expected array when cart contents are empty, not false

### DIFF
--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -216,7 +216,7 @@ class EDD_Cart {
 		global $edd_is_last_cart_item, $edd_flat_discount_total;
 
 		if ( empty( $this->contents ) ) {
-			return false;
+			return array();
 		}
 
 		$details = array();


### PR DESCRIPTION
Caused an error for me when I doing `reset( $content )` when the cart is empty because it returned `false`. 

Checking the EDD core code it only does `empty( $contents )` and ` if ( $contents )` type of checks, which should all react the same for returning `array()` as returning `false`

