### PR TITLE
fixes 0 length downloads for larger files

### DIFF
--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -753,7 +753,7 @@ function edd_readfile_chunked( $file, $retbytes = true ) {
 	$cnt       = 0;
 	$handle    = @fopen( $file, 'rb' );
 
-	if ( $size = @filesize( $file ) ) {
+	if ( $size = intval(sprintf("%u", @filesize($file))) ) {
 		header("Content-Length: " . $size );
 	}
 
@@ -763,7 +763,9 @@ function edd_readfile_chunked( $file, $retbytes = true ) {
 
 	while ( ! @feof( $handle ) ) {
 		$buffer = @fread( $handle, $chunksize );
-		echo $buffer;
+		print($buffer);
+		ob_flush();
+		flush();
 
 		if ( $retbytes ) {
 			$cnt += strlen( $buffer );


### PR DESCRIPTION
We used to have problems with files of more than 50MB in size; for direct download method, users would receive a file with 0 bytes. The patch adresses this issue by making shure that the buffer is being flushed to the client during chunked downloads.