### PR TITLE
Only run number_format if rate is 0, non-zero, and not an empty string - issue/6407

### DIFF
--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -94,7 +94,7 @@ function edd_get_tax_rate( $country = false, $state = false ) {
 					}
 
 					$state_rate = $tax_rate['rate'];
-					if( 0 !== $state_rate || ! empty( $state_rate ) ) {
+					if( ( 0 !== $state_rate || ! empty( $state_rate ) ) && '' !== $state_rate ) {
 						$rate = number_format( $state_rate, 4 );
 					}
 				}


### PR DESCRIPTION
#6407