### PR TITLE
Add sales and earnings orderby support to [downloads] shortcode

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -366,6 +366,18 @@ function edd_downloads_query( $atts, $content = null ) {
 			$query['meta_key'] = 'edd_price';
 			$query['orderby']  = 'meta_value_num';
 		break;
+			
+		case 'sales':
+			$atts['orderby']   = 'meta_value';
+			$query['meta_key'] = '_edd_download_sales';
+			$query['orderby']  = 'meta_value_num';
+		break;
+
+		case 'earnings':
+			$atts['orderby']   = 'meta_value';
+			$query['meta_key'] = '_edd_download_earnings';
+			$query['orderby']  = 'meta_value_num';
+		break;
 
 		case 'title':
 			$query['orderby'] = 'title';


### PR DESCRIPTION
As per issue #6423, added support for sales and earnings.