### PR TITLE
Fix text fields being unset when saving another settings section

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -957,7 +957,8 @@ function edd_settings_sanitize( $input = array() ) {
 					}
 					break;
 				default:
-					if ( array_key_exists( $key, $input ) && empty( $input[ $key ] ) || ( array_key_exists( $key, $output ) && ! array_key_exists( $key, $input ) ) ) {
+					// Remove from settings if empty OR if its a non-existent setting
+					if ( ( array_key_exists( $key, $input ) && empty( $input[ $key ] ) ) || ! edd_is_registered_setting( $key ) ) {
 						unset( $output[ $key ] );
 					}
 					break;
@@ -975,6 +976,35 @@ function edd_settings_sanitize( $input = array() ) {
 	}
 
 	return $output;
+}
+
+
+/**
+ * Check if a setting exists/ is registered.
+ *
+ * @since 2.9.1
+ *
+ * @param string $setting_id Setting ID to check.
+ * @return bool
+ */
+function edd_is_registered_setting( $setting_id ) {
+	$setting_tabs = edd_get_registered_settings();
+
+	foreach ( $setting_tabs as $tab_key => $setting_sections ) {
+		foreach ( $setting_sections as $section_key => $settings ) {
+
+			// Settings COULD be without a section
+			if ( isset( $settings['id'] ) && $settings['id'] === $setting_id ) {
+				return true;
+			}
+
+			if ( isset( $settings[0] ) && is_array( $settings[0] ) && in_array( $setting_id, wp_list_pluck( $settings, 'id' ) ) ) {
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
Resolves #6455
Showing the issue:
![screen recording 2018-03-26 at 07 20 pm](https://user-images.githubusercontent.com/5774447/37921977-9d4f9d70-312b-11e8-870d-26f15356130a.gif)

Only seems to happen for text fields when saving another settings section, no issue saving the value on the section itself.

Quick code snippet to reproduce:
```
add_filter( 'edd_settings_extensions', function( $settings ) {
	$edd_ar_settings = array(
		array(
			'id' => 'edd_test_setting_head',
			'name' => '<strong>' . __( 'Test setting', 'edd-auto-register' ) . '</strong>',
			'type' => 'header',
		),
		array(
			'id' => 'edd_test_text_setting',
			'name' => __( 'Text setting', 'edd-auto-register' ),
			'desc' => __( 'This will be emptied when saving ANOTHER section', 'edd-auto-register' ),
			'type' => 'text',
		),
	);

	return array_merge( $settings, $edd_ar_settings );
} );
```