### PR TITLE
Make string RTL-compatible

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -280,8 +280,13 @@ function edd_customers_view( $customer ) {
 					<span class="customer-name info-item edit-item"><input size="20" data-key="email" name="customerinfo[email]" type="text" value="<?php echo $customer->email; ?>" placeholder="<?php _e( 'Customer Email', 'easy-digital-downloads' ); ?>" /></span>
 					<span class="customer-email info-item editable" data-key="email"><?php echo $customer->email; ?></span>
 					<span class="customer-since info-item">
-						<?php _e( 'Customer since', 'easy-digital-downloads' ); ?>
-						<?php echo date_i18n( get_option( 'date_format' ), strtotime( $customer->date_created ) ) ?>
+						<?php
+						printf( 
+							/* translators: The date. */
+							esc_html__( 'Customer since %s', 'easy-digital-downloads' ),
+							esc_html( date_i18n( get_option( 'date_format' ), strtotime( $customer->date_created ) ) )
+						);
+						?>
 					</span>
 					<span class="customer-user-id info-item edit-item">
 						<?php


### PR DESCRIPTION
Makes the `Customer since {$date}` string is RTL-compatible (in some languages the date should precede the "customer since" part of the string).
Also makes sure translations are properly escaped.