### PR TITLE
Show the log file path on the Debug Log tool page #6461

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1091,6 +1091,7 @@ function edd_tools_debug_log_display() {
 				</p>
 				<?php wp_nonce_field( 'edd-debug-log-action' ); ?>
 			</form>
+			<p><?php _e( 'Log file', 'easy-digital-downloads' ); ?>: <code><?php echo $edd_logs->get_log_file_path(); ?></code></p>
 		</div><!-- .inside -->
 	</div><!-- .postbox -->
 <?php

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -467,6 +467,19 @@ class EDD_Logging {
 
 	}
 
+	/**
+	 * Return the location of the log file that EDD_Logging will use.
+	 *
+	 * Note: Do not use this file to write to the logs, please use the `edd_debug_log` function to do so.
+	 *
+	 * @since 2.9.1
+	 *
+	 * @return string
+	 */
+	public function get_log_file_path() {
+		return $this->file;
+	}
+
 }
 
 // Initiate the logging system


### PR DESCRIPTION
Fixes #6461 

Proposed Changes:
1. Adds a paragraph under the Debug Log buttons, telling the user the path to the debug log file to make it easier to locate.
![image](https://user-images.githubusercontent.com/1390124/38061496-49c9390c-32a4-11e8-8460-9dfed47ededc.png)
2. Adds `EDD_Logging::get_log_file_path()` to be able to be able to retrieve the location of the generated log file.