### PR TITLE
issue/5955 - adjust error message container class for customer email management

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1592,7 +1592,7 @@ td.edd_order_price {
 .delete-customer {
 	text-align: center;
 }
-#edd-item-card-wrapper .notice-wrap-message {
+#edd-item-card-wrapper .notice-container {
 	padding-left: 20px;
 	padding-right: 20px;
 	margin-left: -20px;

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1598,6 +1598,9 @@ td.edd_order_price {
 	margin-left: -20px;
 	margin-right: -20px;
 }
+#edd-item-card-wrapper .add-customer-email-wrapper > #add-customer-email {
+	vertical-align: middle;
+}
 
 @media screen and ( max-width: 810px ) and ( min-width: 656px ) {
 	.customer-info .customer-name {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1592,7 +1592,7 @@ td.edd_order_price {
 .delete-customer {
 	text-align: center;
 }
-#edd-item-card-wrapper .notice-wrap {
+#edd-item-card-wrapper .notice-wrap-message {
 	padding-left: 20px;
 	padding-right: 20px;
 	margin-left: -20px;

--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -1862,7 +1862,7 @@ jQuery(document).ready(function ($) {
 				var button  = $(this);
 				var wrapper = button.parent();
 
-				wrapper.parent().find('.notice-wrap-message').remove();
+				wrapper.parent().find('.notice-container').remove();
 				wrapper.find('.spinner').css('visibility', 'visible');
 				button.attr('disabled', true);
 
@@ -1885,7 +1885,7 @@ jQuery(document).ready(function ($) {
 						window.location.href=response.redirect;
 					} else {
 						button.attr('disabled', false);
-						wrapper.after('<div class="notice-wrap-message"><div class="notice notice-error inline"><p>' + response.message + '</p></div></div>');
+						wrapper.after('<div class="notice-container"><div class="notice notice-error inline"><p>' + response.message + '</p></div></div>');
 						wrapper.find('.spinner').css('visibility', 'hidden');
 					}
 

--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -1862,7 +1862,7 @@ jQuery(document).ready(function ($) {
 				var button  = $(this);
 				var wrapper = button.parent();
 
-				wrapper.parent().find('.notice-wrap').remove();
+				wrapper.parent().find('.notice-wrap-message').remove();
 				wrapper.find('.spinner').css('visibility', 'visible');
 				button.attr('disabled', true);
 
@@ -1885,7 +1885,7 @@ jQuery(document).ready(function ($) {
 						window.location.href=response.redirect;
 					} else {
 						button.attr('disabled', false);
-						wrapper.after('<div class="notice-wrap"><div class="notice notice-error inline"><p>' + response.message + '</p></div></div>');
+						wrapper.after('<div class="notice-wrap-message"><div class="notice notice-error inline"><p>' + response.message + '</p></div></div>');
 						wrapper.find('.spinner').css('visibility', 'hidden');
 					}
 

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -281,7 +281,7 @@ function edd_customers_view( $customer ) {
 					<span class="customer-email info-item editable" data-key="email"><?php echo $customer->email; ?></span>
 					<span class="customer-since info-item">
 						<?php
-						printf( 
+						printf(
 							/* translators: The date. */
 							esc_html__( 'Customer since %s', 'easy-digital-downloads' ),
 							esc_html( date_i18n( get_option( 'date_format' ), strtotime( $customer->date_created ) ) )
@@ -418,7 +418,7 @@ function edd_customers_view( $customer ) {
 								<button class="button-secondary edd-add-customer-email" id="add-customer-email" style="margin: 6px 0;"><?php _e( 'Add Email', 'easy-digital-downloads' ); ?></button>
 								<span class="spinner"></span>
 							</div>
-							<div class="notice-wrap"></div>
+							<div class="notice-wrap-message"></div>
 						</td>
 					</tr>
 				<?php else: ?>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -418,7 +418,7 @@ function edd_customers_view( $customer ) {
 								<button class="button-secondary edd-add-customer-email" id="add-customer-email" style="margin: 6px 0;"><?php _e( 'Add Email', 'easy-digital-downloads' ); ?></button>
 								<span class="spinner"></span>
 							</div>
-							<div class="notice-wrap-message"></div>
+							<div class="notice-container"></div>
 						</td>
 					</tr>
 				<?php else: ?>


### PR DESCRIPTION
Fixes #5955 

Proposed Changes:
1. Use different class for the HTML container that displays [error] messages when attempting to add an email address to a customer record from the customer card screen.

See final comments on the issue.