### PR TITLE
issue/6436 - add support for custom classes on downloads shortcode

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -590,8 +590,9 @@ function edd_downloads_query( $atts, $content = null ) {
 	if ( $downloads->have_posts() ) :
 		$i = 1;
 		$columns_class   = array( 'edd_download_columns_' . $atts['columns'] );
-		$wrapper_classes = array_unique( array_merge( $columns_class, explode( ',', $atts['class'] ) ) );
-		$wrapper_classes = rtrim( implode( ' ', $wrapper_classes ) );
+		$custom_classes  = array_filter( explode( ',', $atts['class'] ) );
+		$wrapper_classes = array_unique( array_merge( $columns_class, $custom_classes ) );
+		$wrapper_classes = implode( ' ', $wrapper_classes );
 		ob_start(); ?>
 		<div class="edd_downloads_list <?php echo apply_filters( 'edd_downloads_list_wrapper_class', $wrapper_classes, $atts ); ?>">
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -336,6 +336,7 @@ function edd_downloads_query( $atts, $content = null ) {
 		'orderby'          => 'post_date',
 		'order'            => 'DESC',
 		'ids'              => '',
+		'class'            => '',
 		'pagination'       => 'true',
 	), $atts, 'downloads' );
 
@@ -366,7 +367,7 @@ function edd_downloads_query( $atts, $content = null ) {
 			$query['meta_key'] = 'edd_price';
 			$query['orderby']  = 'meta_value_num';
 		break;
-			
+
 		case 'sales':
 			$atts['orderby']   = 'meta_value';
 			$query['meta_key'] = '_edd_download_sales';
@@ -588,9 +589,11 @@ function edd_downloads_query( $atts, $content = null ) {
 	$downloads = new WP_Query( $query );
 	if ( $downloads->have_posts() ) :
 		$i = 1;
-		$wrapper_class = 'edd_download_columns_' . $atts['columns'];
+		$columns_class   = array( 'edd_download_columns_' . $atts['columns'] );
+		$wrapper_classes = array_unique( array_merge( $columns_class, explode( ',', $atts['class'] ) ) );
+		$wrapper_classes = rtrim( implode( ' ', $wrapper_classes ) );
 		ob_start(); ?>
-		<div class="edd_downloads_list <?php echo apply_filters( 'edd_downloads_list_wrapper_class', $wrapper_class, $atts ); ?>">
+		<div class="edd_downloads_list <?php echo apply_filters( 'edd_downloads_list_wrapper_class', $wrapper_classes, $atts ); ?>">
 
 			<?php do_action( 'edd_downloads_list_top', $atts ); ?>
 


### PR DESCRIPTION
Fixes #6436

Proposed Changes:
1. Add support for `class` parameter in `[downloads]` shortcode.
