### PR TITLE
issue/6400 - correctly count cart columns based on hook usage

### DIFF
--- a/includes/cart/template.php
+++ b/includes/cart/template.php
@@ -138,13 +138,15 @@ add_action( 'edd_cart_empty', 'edd_empty_checkout_cart' );
  * @return int The number of columns
  */
 function edd_checkout_cart_columns() {
-	global $wp_filter;
+	global $wp_filter, $wp_version;
 
 	$columns_count = 3;
 
 	if ( ! empty( $wp_filter['edd_checkout_table_header_first'] ) ) {
 		$header_first_count = 0;
-		foreach ( $wp_filter['edd_checkout_table_header_first']->callbacks as $callback ) {
+		$callbacks = version_compare( $wp_version, '4.7', '>=' ) ? $wp_filter['edd_checkout_table_header_first']->callbacks : $wp_filter['edd_checkout_table_header_first'] ;
+
+		foreach ( $callbacks as $callback ) {
 			$header_first_count += count( $callback );
 		}
 		$columns_count += $header_first_count;
@@ -152,7 +154,9 @@ function edd_checkout_cart_columns() {
 
 	if ( ! empty( $wp_filter['edd_checkout_table_header_last'] ) ) {
 		$header_last_count = 0;
-		foreach ( $wp_filter['edd_checkout_table_header_last']->callbacks as $callback ) {
+		$callbacks = version_compare( $wp_version, '4.7', '>=' ) ? $wp_filter['edd_checkout_table_header_last']->callbacks : $wp_filter['edd_checkout_table_header_last'] ;
+
+		foreach ( $callbacks as $callback ) {
 			$header_last_count += count( $callback );
 		}
 		$columns_count += $header_last_count;

--- a/includes/cart/template.php
+++ b/includes/cart/template.php
@@ -138,11 +138,27 @@ add_action( 'edd_cart_empty', 'edd_empty_checkout_cart' );
  * @return int The number of columns
  */
 function edd_checkout_cart_columns() {
-	$head_first = did_action( 'edd_checkout_table_header_first' );
-	$head_last  = did_action( 'edd_checkout_table_header_last' );
-	$default    = 3;
+	global $wp_filter;
 
-	return apply_filters( 'edd_checkout_cart_columns', $head_first + $head_last + $default );
+	$columns_count = 3;
+
+	if ( ! empty( $wp_filter['edd_checkout_table_header_first'] ) ) {
+		$header_first_count = 0;
+		foreach ( $wp_filter['edd_checkout_table_header_first']->callbacks as $callback ) {
+			$header_first_count += count( $callback );
+		}
+		$columns_count += $header_first_count;
+	}
+
+	if ( ! empty( $wp_filter['edd_checkout_table_header_last'] ) ) {
+		$header_last_count = 0;
+		foreach ( $wp_filter['edd_checkout_table_header_last']->callbacks as $callback ) {
+			$header_last_count += count( $callback );
+		}
+		$columns_count += $header_last_count;
+	}
+
+	return apply_filters( 'edd_checkout_cart_columns', $columns_count );
 }
 
 /**

--- a/tests/tests-checkout.php
+++ b/tests/tests-checkout.php
@@ -51,6 +51,52 @@ class Tests_Checkout extends EDD_UnitTestCase {
 	}
 
 	/**
+	 * Test the default 3 columns used for checkout carts.
+	 */
+	public function test_checkout_cart_columns_default() {
+		$this->assertSame( 3, edd_checkout_cart_columns() );
+	}
+
+	/**
+	 * Test the default 3 columns + 1 column used for checkout carts.
+	 */
+	public function test_checkout_cart_columns_add_one() {
+		add_action( 'edd_checkout_table_header_first', '__return_true' );
+		$this->assertSame( 4, edd_checkout_cart_columns() );
+		remove_action( 'edd_checkout_table_header_first', '__return_true' );
+	}
+
+	/**
+	 * Test the default 3 columns + 2 columns used for checkout carts.
+	 */
+	public function test_checkout_cart_columns_add_two() {
+		add_action( 'edd_checkout_table_header_first', '__return_true' );
+		add_action( 'edd_checkout_table_header_first', '__return_false' );
+		$this->assertSame( 5, edd_checkout_cart_columns() );
+		remove_action( 'edd_checkout_table_header_first', '__return_true' );
+		remove_action( 'edd_checkout_table_header_first', '__return_false' );
+	}
+
+	/**
+	 * Test the filter at the bottom of
+	 */
+	public function test_checkout_cart_columns_filter() {
+		add_filter( 'edd_checkout_cart_columns', array( $this, 'helper_test_checkout_cart_columns_filter' ) );
+		$this->assertSame( 2, edd_checkout_cart_columns() );
+		remove_filter( 'edd_checkout_cart_columns', array( $this, 'helper_test_checkout_cart_columns_filter' ) );
+	}
+
+		/**
+		 * Helper function for the above test, to test the filter in edd_checkout_cart_columns()
+		 * @param $columns
+		 *
+		 * @return int
+		 */
+		public function helper_test_checkout_cart_columns_filter( $columns ) {
+			return 2;
+		}
+
+	/**
      * Test to make sure the checkout form returns the expected HTML
      */
 	public function test_checkout_form() {


### PR DESCRIPTION
Fixes #6400

Proposed Changes:
1. Instead of using `did_action()` to see if hooks are being used, use `$wp_filter` to retrieve the callbacks of the hooks. _If_ callbacks exist, count those to determine the number of columns to add to the default column count (3).
