### PR TITLE
Fix search not fully working

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -466,7 +466,13 @@ class EDD_Payments_Query extends EDD_Stats {
 
 			$this->__unset( 's' );
 
-		} elseif ( edd_get_option( 'enable_sequential' ) ) {
+		} elseif (
+			edd_get_option( 'enable_sequential' ) &&
+			(
+				false !== strpos( $search, edd_get_option( 'sequential_prefix' ) ) ||
+				false !== strpos( $search, edd_get_option( 'sequential_postfix' ) )
+			)
+		) {
 
 			$search_meta = array(
 				'key'     => '_edd_payment_number',
@@ -487,6 +493,19 @@ class EDD_Payments_Query extends EDD_Stats {
 				$arr[] = $search;
 				$this->__set( 'post__in', $arr );
 				$this->__unset( 's' );
+			}
+
+			if ( edd_get_option( 'enable_sequential' ) ) {
+
+				$search_meta = array(
+					'key'     => '_edd_payment_number',
+					'value'   => $search,
+					'compare' => 'LIKE'
+				);
+
+				$this->__set( 'meta_query', $search_meta );
+				$this->__unset( 's' );
+
 			}
 
 		} elseif ( '#' == substr( $search, 0, 1 ) ) {


### PR DESCRIPTION
Fixes https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6471

Reverts the change made in https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6178 and adds additional code to search within sequential payment numbers when entering just the numeric ID.