### PR TITLE
Switch all is_a checks to instanceof #6355

### DIFF
--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -449,7 +449,7 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 			// Make sure we found a customer. Create one if not.
 			if( empty( $customer->id ) ) {
 
-				if ( ! is_a( $customer, 'EDD_Customer' ) ) {
+				if ( ! $customer instanceof EDD_Customer ) {
 					$customer = new EDD_Customer;
 				}
 

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -617,7 +617,7 @@ class EDD_CLI extends WP_CLI_Command {
 			// Create the purchases
 			foreach( $products as $key => $download ) {
 
-				if( ! is_a( $download, 'WP_Post' ) ) {
+				if( ! $download instanceof WP_Post ) {
 					continue;
 				}
 

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -405,7 +405,7 @@ class EDD_Discount {
 			return false;
 		}
 
-		if ( ! is_a( $discount, 'WP_Post' ) ) {
+		if ( ! $discount instanceof WP_Post ) {
 			return false;
 		}
 

--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -156,7 +156,7 @@ class EDD_Download {
 			return false;
 		}
 
-		if( ! is_a( $download, 'WP_Post' ) ) {
+		if( ! $download instanceof WP_Post ) {
 			return false;
 		}
 

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -1083,7 +1083,7 @@ add_action( 'edd_pre_refund_payment', 'edd_maybe_refund_paypal_purchase', 999 );
  */
 function edd_refund_paypal_purchase( $payment ) {
 
-	if( ! is_a( $payment, 'EDD_Payment' ) && is_numeric( $payment ) ) {
+	if( ! $payment instanceof EDD_Payment && is_numeric( $payment ) ) {
 		$payment = new EDD_Payment( $payment );
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -766,7 +766,7 @@ function edd_object_to_array( $object = array() ) {
 	if ( is_array( $object ) ) {
 		$return = array();
 		foreach ( $object as $item ) {
-			if ( is_a( $object, 'EDD_Payment' ) ) {
+			if ( $object instanceof EDD_Payment ) {
 				$return[] = $object->array_convert();
 			} else {
 				$return[] = edd_object_to_array( $item );
@@ -774,7 +774,7 @@ function edd_object_to_array( $object = array() ) {
 
 		}
 	} else {
-		if ( is_a( $object, 'EDD_Payment' ) ) {
+		if ( $object instanceof EDD_Payment ) {
 			$return = $object->array_convert();
 		} else {
 			$return = get_object_vars( $object );

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -24,7 +24,7 @@ if ( !defined( 'ABSPATH' ) ) exit;
 function edd_get_payment( $payment_or_txn_id = null, $by_txn = false ) {
 	global $wpdb;
 
-	if ( is_a( $payment_or_txn_id, 'WP_Post' ) || is_a( $payment_or_txn_id, 'EDD_Payment' ) ) {
+	if ( $payment_or_txn_id instanceof WP_Post || $payment_or_txn_id instanceof EDD_Payment ) {
 		$payment_id = $payment_or_txn_id->ID;
 	} elseif ( $by_txn ) {
 		if ( empty( $payment_or_txn_id ) ) {


### PR DESCRIPTION
Fixes #6355

Proposed Changes:
1. Any calls to `is_a` is switched to `instanceof` checks, for the performance improvements.
