### PR TITLE
Support a separate privacy policy on checkout.

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -873,6 +873,30 @@ function edd_get_registered_settings() {
 						'type' => 'rich_editor',
 					),
 				),
+				'privacy_policy'     => array(
+					'show_agree_to_privacy_policy' => array(
+						'id'   => 'show_agree_to_privacy_policy',
+						'name' => __( 'Agree to Privacy Policy', 'easy-digital-downloads' ),
+						'desc' => __( 'Check this to show an agree to privacy policy on the checkout that users must agree to before purchasing.', 'easy-digital-downloads' ),
+						'type' => 'checkbox',
+					),
+					'agree_privacy_label' => array(
+						'id'   => 'privacy_agree_label',
+						'name' => __( 'Agree to Privacy Policy Label', 'easy-digital-downloads' ),
+						'desc' => __( 'Label shown next to the agree to privacy policy check box.', 'easy-digital-downloads' ),
+						'type' => 'text',
+						'size' => 'regular',
+					),
+					'agree_privacy_page' => array(
+						'id'   => 'privacy_agree_page',
+						'name' => __( 'Privacy Agreement Page', 'easy-digital-downloads' ),
+						'desc' => __( 'If Agree to Privacy Policy is checked, enter page for the Privacy Agreement Here.', 'easy-digital-downloads' ),
+						'type'        => 'select',
+						'options'     => edd_get_pages(),
+						'chosen'      => true,
+						'placeholder' => __( 'Select a page', 'easy-digital-downloads' ),
+					),
+				),
 			)
 		)
 	);
@@ -1309,6 +1333,7 @@ function edd_get_registered_settings_sections() {
 			'file_downloads'     => __( 'File Downloads', 'easy-digital-downloads' ),
 			'accounting'         => __( 'Accounting', 'easy-digital-downloads' ),
 			'site_terms'         => __( 'Terms of Agreement', 'easy-digital-downloads' ),
+			'privacy_policy'     => __( 'Privacy Policy', 'easy-digital-downloads' ),
 		) ),
 	);
 

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -853,6 +853,14 @@ function edd_get_registered_settings() {
 					),
 				),
 				'site_terms'     => array(
+					array(
+					'id'   => 'terms_settings',
+						'name' => '<h3>' . __( 'Terms and Privacy Policy', 'easy-digital-downloads' ) . '</h3>',
+						'desc' => '',
+						'type' => 'header',
+						'tooltip_title' => __( 'Terms and Privacy Policy Settings', 'easy-digital-downloads' ),
+						'tooltip_desc'  => __( 'Depending on legal and regulatory requirements, it may be necessary for your site to show checkboxes for Terms of Agreement and/or Privacy Policy.','easy-digital-downloads' ),
+					),
 					'show_agree_to_terms' => array(
 						'id'   => 'show_agree_to_terms',
 						'name' => __( 'Agree to Terms', 'easy-digital-downloads' ),
@@ -872,12 +880,10 @@ function edd_get_registered_settings() {
 						'desc' => __( 'If Agree to Terms is checked, enter the agreement terms here.', 'easy-digital-downloads' ),
 						'type' => 'rich_editor',
 					),
-				),
-				'privacy_policy'     => array(
 					'show_agree_to_privacy_policy' => array(
 						'id'   => 'show_agree_to_privacy_policy',
 						'name' => __( 'Agree to Privacy Policy', 'easy-digital-downloads' ),
-						'desc' => __( 'Check this to show an agree to privacy policy on the checkout that users must agree to before purchasing.', 'easy-digital-downloads' ),
+						'desc' => __( 'Check this to show an agree to privacy policy on checkout that users must agree to before purchasing.', 'easy-digital-downloads' ),
 						'type' => 'checkbox',
 					),
 					'agree_privacy_label' => array(
@@ -886,6 +892,12 @@ function edd_get_registered_settings() {
 						'desc' => __( 'Label shown next to the agree to privacy policy check box.', 'easy-digital-downloads' ),
 						'type' => 'text',
 						'size' => 'regular',
+					),
+					'show_privacy_policy_on_checkout' => array(
+						'id'   => 'show_to_privacy_policy_on_checkout',
+						'name' => __( 'Show the privacy policy on checkout', 'easy-digital-downloads' ),
+						'desc' => __( 'Display your privacy policy on checkout.', 'easy-digital-downloads' ),
+						'type' => 'checkbox',
 					),
 					'agree_privacy_page' => array(
 						'id'   => 'privacy_agree_page',
@@ -1333,7 +1345,6 @@ function edd_get_registered_settings_sections() {
 			'file_downloads'     => __( 'File Downloads', 'easy-digital-downloads' ),
 			'accounting'         => __( 'Accounting', 'easy-digital-downloads' ),
 			'site_terms'         => __( 'Terms of Agreement', 'easy-digital-downloads' ),
-			'privacy_policy'     => __( 'Privacy Policy', 'easy-digital-downloads' ),
 		) ),
 	);
 

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -902,7 +902,7 @@ function edd_get_registered_settings() {
 					'agree_privacy_page' => array(
 						'id'   => 'privacy_agree_page',
 						'name' => __( 'Privacy Agreement Page', 'easy-digital-downloads' ),
-						'desc' => __( 'If Agree to Privacy Policy is checked, enter page for the Privacy Agreement Here.', 'easy-digital-downloads' ),
+						'desc' => __( 'If Agree to Privacy Policy is checked, select a page for the Privacy Agreement here.', 'easy-digital-downloads' ),
 						'type'        => 'select',
 						'options'     => edd_get_pages(),
 						'chosen'      => true,

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -770,7 +770,7 @@ function edd_terms_agreement() {
 	if ( edd_get_option( 'show_agree_to_terms', false ) ) {
 		$agree_text  = edd_get_option( 'agree_text', '' );
 		$agree_label = edd_get_option( 'agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
-		
+
 		ob_start();
 ?>
 		<fieldset id="edd_terms_agreement">
@@ -785,6 +785,30 @@ function edd_terms_agreement() {
 				<a href="#" class="edd_terms_links"><?php _e( 'Show Terms', 'easy-digital-downloads' ); ?></a>
 				<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Terms', 'easy-digital-downloads' ); ?></a>
 			</div>
+
+			<?php if ( ! edd_get_option( 'show_agree_to_privacy_policy', false ) && edd_get_option( 'show_to_privacy_policy_on_checkout', false ) ) : ?>
+				<?php
+				$agree_page      = edd_get_option( 'privacy_agree_page', get_option( 'page_for_privacy_policy' ) );
+				$agree_label     = edd_get_option( 'privacy_agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
+				$agreement_text  = get_post_field( 'post_content', $agree_page );
+				?>
+
+				<?php if ( ! empty( $agreement_text ) ) : ?>
+					<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
+						<?php
+						do_action( 'edd_before_privacy_policy' );
+						echo wpautop( stripslashes( $agreement_text ) );
+						do_action( 'edd_after_privacy_policy' );
+						?>
+					</div>
+					<div id="edd-show-privacy-policy" class="edd-show-terms">
+						<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
+						<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
+					</div>
+				<?php endif; ?>
+
+			<?php endif; ?>
+
 			<div class="edd-terms-agreement">
 				<input name="edd_agree_to_terms" class="required" type="checkbox" id="edd_agree_to_terms" value="1"/>
 				<label for="edd_agree_to_terms"><?php echo stripslashes( $agree_label ); ?></label>
@@ -809,27 +833,33 @@ add_action( 'edd_purchase_form_before_submit', 'edd_terms_agreement' );
  */
 function edd_privacy_agreement() {
 	if ( edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
-		$agree_page      = edd_get_option( 'privacy_agree_page', get_option( 'page_for_privacy_policy' ) );
 		$agree_label     = edd_get_option( 'privacy_agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
-		$agreement_text  = get_post_field( 'post_content', $agree_page );
-		if ( empty( $agree_page ) || empty( $agreement_text ) ) {
-			return;
-		}
 
 		ob_start();
 		?>
 		<fieldset id="edd-privacy-policy-agreement">
-			<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
+
+			<?php if ( edd_get_option( 'show_to_privacy_policy_on_checkout', false ) ) : ?>
+
 				<?php
-				do_action( 'edd_before_privacy_policy' );
-				echo wpautop( stripslashes( $agreement_text ) );
-				do_action( 'edd_after_privacy_policy' );
+				$agree_page      = edd_get_option( 'privacy_agree_page', get_option( 'page_for_privacy_policy' ) );
+				$agreement_text  = get_post_field( 'post_content', $agree_page );
 				?>
-			</div>
-			<div id="edd-show-privacy-policy" class="edd-show-terms">
-				<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
-				<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
-			</div>
+
+				<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
+					<?php
+					do_action( 'edd_before_privacy_policy' );
+					echo wpautop( stripslashes( $agreement_text ) );
+					do_action( 'edd_after_privacy_policy' );
+					?>
+				</div>
+				<div id="edd-show-privacy-policy" class="edd-show-terms">
+					<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
+					<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
+				</div>
+
+			<?php endif; ?>
+
 			<div class="edd-privacy-policy-agreement">
 				<input name="edd_agree_to_privacy_policy" class="required" type="checkbox" id="edd-agree-to-privacy-policy" value="1"/>
 				<label for="edd-agree-to-privacy-policy"><?php echo stripslashes( $agree_label ); ?></label>

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -774,14 +774,14 @@ function edd_terms_agreement() {
 		ob_start();
 ?>
 		<fieldset id="edd_terms_agreement">
-			<div id="edd_terms" style="display:none;">
+			<div id="edd_terms" class="edd-terms" style="display:none;">
 				<?php
 					do_action( 'edd_before_terms' );
 					echo wpautop( stripslashes( $agree_text ) );
 					do_action( 'edd_after_terms' );
 				?>
 			</div>
-			<div id="edd_show_terms">
+			<div id="edd_show_terms" class="edd-show-terms">
 				<a href="#" class="edd_terms_links"><?php _e( 'Show Terms', 'easy-digital-downloads' ); ?></a>
 				<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Terms', 'easy-digital-downloads' ); ?></a>
 			</div>
@@ -797,6 +797,51 @@ function edd_terms_agreement() {
 	}
 }
 add_action( 'edd_purchase_form_before_submit', 'edd_terms_agreement' );
+
+
+/**
+ * Renders the Checkout Agree to Privacy Policy, this displays a checkbox for users to
+ * agree the Privacy Policy set in the EDD Settings. This is only displayed if T&Cs are
+ * set in the EDD Settings.
+ *
+ * @since 2.9.1
+ * @return void
+ */
+function edd_privacy_agreement() {
+	if ( edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
+		$agree_page      = edd_get_option( 'privacy_agree_page', get_option( 'page_for_privacy_policy' ) );
+		$agree_label     = edd_get_option( 'privacy_agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
+		$agreement_text  = get_post_field( 'post_content', $agree_page );
+		if ( empty( $agree_page ) || empty( $agreement_text ) ) {
+			return;
+		}
+
+		ob_start();
+		?>
+		<fieldset id="edd-privacy-policy-agreement">
+			<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
+				<?php
+				do_action( 'edd_before_privacy_policy' );
+				echo wpautop( stripslashes( $agreement_text ) );
+				do_action( 'edd_after_privacy_policy' );
+				?>
+			</div>
+			<div id="edd-show-privacy-policy" class="edd-show-terms">
+				<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
+				<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
+			</div>
+			<div class="edd-privacy-policy-agreement">
+				<input name="edd_agree_to_privacy_policy" class="required" type="checkbox" id="edd-agree-to-privacy-policy" value="1"/>
+				<label for="edd-agree-to-privacy-policy"><?php echo stripslashes( $agree_label ); ?></label>
+			</div>
+		</fieldset>
+		<?php
+		$html_output = ob_get_clean();
+
+		echo apply_filters( 'edd_checkout_privacy_policy_agreement_html', $html_output );
+	}
+}
+add_action( 'edd_purchase_form_before_submit', 'edd_privacy_agreement' );
 
 /**
  * Shows the final purchase total at the bottom of the checkout page
@@ -913,8 +958,8 @@ function edd_agree_to_terms_js() {
 		jQuery(document).ready(function($){
 			$( document.body ).on('click', '.edd_terms_links', function(e) {
 				//e.preventDefault();
-				$('#edd_terms').slideToggle();
-				$('.edd_terms_links').toggle();
+				$(this).parent().prev('.edd-terms').slideToggle();
+				$(this).parent().find('.edd_terms_links').toggle();
 				return false;
 			});
 		});

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -849,7 +849,7 @@ function edd_privacy_agreement() {
 				<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
 					<?php
 					do_action( 'edd_before_privacy_policy' );
-					echo wpautop( stripslashes( $agreement_text ) );
+					echo wpautop( do_shortcode( stripslashes( $agreement_text ) ) );
 					do_action( 'edd_after_privacy_policy' );
 					?>
 				</div>

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -797,7 +797,7 @@ function edd_terms_agreement() {
 					<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
 						<?php
 						do_action( 'edd_before_privacy_policy' );
-						echo wpautop( stripslashes( $agreement_text ) );
+						echo wpautop( do_shortcode( stripslashes( $agreement_text ) ) );
 						do_action( 'edd_after_privacy_policy' );
 						?>
 					</div>

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -264,8 +264,14 @@ function edd_purchase_form_validate_fields() {
 	);
 
 	// Validate agree to terms
-	if ( edd_get_option( 'show_agree_to_terms', false ) )
+	if ( edd_get_option( 'show_agree_to_terms', false ) ) {
 		edd_purchase_form_validate_agree_to_terms();
+	}
+
+	// Validate agree to privacy policy
+	if ( edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
+		edd_purchase_form_validate_agree_to_privacy_policy();
+	}
 
 	if ( is_user_logged_in() ) {
 		// Collect logged in user data
@@ -392,6 +398,20 @@ function edd_purchase_form_validate_agree_to_terms() {
 	if ( ! isset( $_POST['edd_agree_to_terms'] ) || $_POST['edd_agree_to_terms'] != 1 ) {
 		// User did not agree
 		edd_set_error( 'agree_to_terms', apply_filters( 'edd_agree_to_terms_text', __( 'You must agree to the terms of use', 'easy-digital-downloads' ) ) );
+	}
+}
+
+/**
+ * Purchase Form Validate Agree To Privacy Policy
+ *
+ * @since       2.9.1
+ * @return      void
+ */
+function edd_purchase_form_validate_agree_to_privacy_policy() {
+	// Validate agree to terms
+	if ( ! isset( $_POST['edd_agree_to_privacy_policy'] ) || $_POST['edd_agree_to_privacy_policy'] != 1 ) {
+		// User did not agree
+		edd_set_error( 'agree_to_privacy_policy', apply_filters( 'edd_agree_to_privacy_policy_text', __( 'You must agree to the privacy policy', 'easy-digital-downloads' ) ) );
 	}
 }
 


### PR DESCRIPTION
Fixes #6484 

Proposed Changes:
1. Add settings for privacy policy agreement, privacy policy agreement text, privacy policy page, and show privacy policy on checkout
2. Includes logic to handle showing 1 checkbox but two agreements/policies, or 2 individually.
