### PR TITLE
Genoa Italy, not Genova #6491

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -1373,7 +1373,7 @@ function edd_get_italian_states_list() {
 		'FG' => 'Foggia',
 		'FC' => 'Forli-Cesena',
 		'FR' => 'Frosinone',
-		'GE' => 'Genova',
+		'GE' => 'Genoa',
 		'GO' => 'Gorizia',
 		'GR' => 'Grosseto',
 		'IM' => 'Imperia',


### PR DESCRIPTION
Fixes #6491

Proposed Changes:
1. Switches _Genova_ to *Genoa* in the Italian list of states/provinces
