### PR TITLE
Fix EDD API Issues with psudo-date ranges

### DIFF
--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1322,86 +1322,22 @@ class EDD_API {
 
 					$earnings['totals'] = $total;
 				} else {
-					if ( $args['date'] == 'this_quarter' || $args['date'] == 'last_quarter'  ) {
-						$current_time = current_time( 'timestamp' );
+					$date_start = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day'];
+					$date_end   = $dates['year'] . '-' . $dates['m_end'] . '-' . $dates['day_end'];
 
-						if ( 'this_quarter' == $args['date'] ) {
-							$month_now = date( 'n', $current_time );
-							$dates['year']     = date( 'Y', $current_time );
-							$dates['year_end'] = $dates['year'];
+					$results = EDD()->payment_stats->get_earnings_by_range( $args['date'], false, $date_start, $date_end );
+					if ( $results instanceof WP_Error ) {
 
-							if ( $month_now <= 3 ) {
-								$dates['m_start']  = 1;
-								$dates['m_end']    = 3;
-							} else if ( $month_now <= 6 ) {
-								$dates['m_start'] = 4;
-								$dates['m_end']   = 6;
-							} else if ( $month_now <= 9 ) {
-								$dates['m_start'] = 7;
-								$dates['m_end']   = 9;
-							} else {
-								$dates['m_start']  = 10;
-								$dates['m_end']    = 12;
+						$error_message = __( 'There was an error retrieving earnings.', 'easy-digital-downloads' );
+
+						foreach ( $results->errors as $error_key => $error_array ) {
+							if ( ! empty( $error_array[0] ) ) {
+								$error_message = $error_array[0];
 							}
-
-							$dates['day_end'] = cal_days_in_month( CAL_GREGORIAN, $dates['m_end'], $dates['year'] );
-						} else {
-							$month_now = date( 'n' );
-
-							if ( $month_now <= 3 ) {
-								$dates['m_start']  = 10;
-								$dates['m_end']    = 12;
-								$dates['year']     = date( 'Y', $current_time ) - 1; // Previous year
-							} else if ( $month_now <= 6 ) {
-								$dates['m_start'] = 1;
-								$dates['m_end']   = 3;
-								$dates['year']    = date( 'Y', $current_time );
-							} else if ( $month_now <= 9 ) {
-								$dates['m_start'] = 4;
-								$dates['m_end']   = 6;
-								$dates['year']    = date( 'Y', $current_time );
-							} else {
-								$dates['m_start'] = 7;
-								$dates['m_end']   = 9;
-								$dates['year']    = date( 'Y', $current_time );
-							}
-
-							$dates['day_end']  = cal_days_in_month( CAL_GREGORIAN, $dates['m_end'],  $dates['year'] );
-							$dates['year_end'] = $dates['year'];
 						}
 
-						$dates['day_start'] = 1;
-
-						if ( cal_days_in_month( CAL_GREGORIAN, $dates['m_start'], $dates['year'] ) < $dates['day_start'] ) {
-							$next_day = mktime( 0, 0, 0, $dates['m_start'] + 1, 1, $dates['year'] );
-							$day = date( 'd', $next_day );
-							$month = date( 'm', $next_day );
-							$year = date( 'Y', $next_day );
-							$date_start = $year . '-' . $month . '-' . $day;
-						} else {
-							$date_start = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day_start'];
-						}
-
-						if ( cal_days_in_month( CAL_GREGORIAN, $dates['m_end'], $dates['year'] ) < $dates['day_end'] ) {
-							$date_end = $dates['year_end'] . '-' . $dates['m_end'] . '-' . cal_days_in_month( CAL_GREGORIAN, $dates['m_end'], $dates['year'] );
-						} else {
-							$date_end = $dates['year_end'] . '-' . $dates['m_end'] . '-' . $dates['day_end'];
-						}
-
-						$results = EDD()->payment_stats->get_earnings_by_range( $args['date'], false, $date_start, $date_end );
-
-						$total = (float) 0.00;
-
-						foreach ( $results as $result ) {
-							$total += (float) $result['total'];
-						}
-
-						$earnings['earnings'][ $args['date'] ] = (float) $total;
+						$error['error'] = sprintf( '%s %s', $error_message, $args['date'] );
 					} else {
-						$date_start = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day'];
-						$date_end = date( 'Y-m-d', strtotime( '+1 day', strtotime( $date_start ) ) );
-
-						$results = EDD()->payment_stats->get_earnings_by_range( $args['date'], false, $date_start, $date_end );
 						if ($args['date'] == 'yesterday' || $args['date'] == 'today') {
 							foreach ($results as $result) {
 								$earnings['earnings'][ $args['date'] ] += $result['total'];

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -897,6 +897,42 @@ class EDD_API {
 					$dates['year']      = date( 'Y', $current_time ) - 1;
 				break;
 
+				case 'this_week' :
+				case 'last_week' :
+					$current_time    = current_time( 'timestamp' );
+					$start_of_week   = get_option( 'start_of_week' );
+
+					if ( 'last_week' === $args['date'] ) {
+						$today = date( 'd', $current_time - WEEK_IN_SECONDS );
+					} else {
+						$today = date( 'd', $current_time );
+					}
+
+					$day_of_the_week = date( 'w', $current_time );
+					$month           = date( 'n', $current_time );
+					$year            = date( 'Y', $current_time );
+
+					// Account for a week the spans a month change (including if that week spans over a break in the year.
+					if ( ( $today - $day_of_the_week ) < 1 ) {
+						$start_date = date( 'd', strtotime( $year . '-' . $month . '-' . $today . ' -' . $day_of_the_week . ' days' ) );
+						$month      = $month > 1 ? $month -= 1 : 12;
+					} else {
+						$start_date = $today - $day_of_the_week;
+					}
+
+					$start_date = date( 'd', strtotime( $year . '-' . $month . '-' . $start_date . ' +' . $start_of_week . 'days' ) );
+
+					$dates['day']        = $start_date;
+					$dates['m_start']    = $month;
+					$dates['year']       = $month === 12 ? $year - 1 : $year;
+
+					$base_start_date      = $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day'];
+					$base_start_timestamp = strtotime( $base_start_date . ' +6 days' );
+					$dates['m_end']       = date( 'n', $base_start_timestamp );
+					$dates['day_end']     = date( 'd', $base_start_timestamp );
+					$dates['year_end']    = date( 'Y', $base_start_timestamp );
+				break;
+
 			endswitch;
 		}
 

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -758,21 +758,24 @@ class EDD_API {
 			switch ( $args['date'] ) :
 
 				case 'this_month' :
-					$dates['day']       = null;
+					$dates['day']       = 1;
+					$dates['day_end']   = date( 't', $current_time );
 					$dates['m_start']   = date( 'n', $current_time );
 					$dates['m_end']     = date( 'n', $current_time );
 					$dates['year']      = date( 'Y', $current_time );
 				break;
 
 				case 'last_month' :
-					$dates['day']     = null;
-					$dates['m_start'] = date( 'n', $current_time ) == 1 ? 12 : date( 'n', $current_time ) - 1;
-					$dates['m_end']   = $dates['m_start'];
-					$dates['year']    = date( 'n', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
-				break;
+					$dates['day']       = 1;
+					$dates['m_start']   = date( 'n', $current_time ) == 1 ? 12 : date( 'n', $current_time ) - 1;
+					$dates['m_end']     = $dates['m_start'];
+					$dates['year']      = date( 'n', $current_time ) == 1 ? date( 'Y', $current_time ) - 1 : date( 'Y', $current_time );
+					$dates['day_end']   = date( 't', strtotime( $dates['year'] . '-' . $dates['m_start'] . '-' . $dates['day'] ) );
+					break;
 
 				case 'today' :
 					$dates['day']       = date( 'd', $current_time );
+					$dates['day_end']   = date( 'd', $current_time );
 					$dates['m_start']   = date( 'n', $current_time );
 					$dates['m_end']     = date( 'n', $current_time );
 					$dates['year']      = date( 'Y', $current_time );
@@ -802,6 +805,7 @@ class EDD_API {
 					}
 
 					$dates['day']       = $day;
+					$dates['day_end']   = $day;
 					$dates['m_start']   = $month;
 					$dates['m_end']     = $month;
 					$dates['year']      = $year;
@@ -811,7 +815,7 @@ class EDD_API {
 				case 'this_quarter' :
 					$month_now = date( 'n', $current_time );
 
-					$dates['day']           = null;
+					$dates['day']           = 1;
 
 					if ( $month_now <= 3 ) {
 
@@ -838,12 +842,15 @@ class EDD_API {
 						$dates['year']      = date( 'Y', $current_time );
 
 					}
-				break;
+
+					$dates['day_end']   = date( 't', strtotime( $dates['year'] . '-' . $dates['m_end'] ) );
+
+					break;
 
 				case 'last_quarter' :
 					$month_now = date( 'n', $current_time );
 
-					$dates['day']           = null;
+					$dates['day']           = 1;
 
 					if ( $month_now <= 3 ) {
 
@@ -870,19 +877,23 @@ class EDD_API {
 						$dates['year']      = date( 'Y', $current_time );
 
 					}
+
+					$dates['day_end']   = date( 't', strtotime( $dates['year'] . '-' . $dates['m_end'] ) );
 				break;
 
 				case 'this_year' :
-					$dates['day']       = null;
-					$dates['m_start']   = null;
-					$dates['m_end']     = null;
+					$dates['day']       = 1;
+					$dates['m_start']   = 1;
+					$dates['m_end']     = 12;
+					$dates['day_end']   = 31;
 					$dates['year']      = date( 'Y', $current_time );
 				break;
 
 				case 'last_year' :
-					$dates['day']       = null;
-					$dates['m_start']   = null;
-					$dates['m_end']     = null;
+					$dates['day']       = 1;
+					$dates['m_start']   = 1;
+					$dates['m_end']     = 12;
+					$dates['day_end']   = 31;
 					$dates['year']      = date( 'Y', $current_time ) - 1;
 				break;
 


### PR DESCRIPTION
Fixes #6505 

Proposed Changes:
1. Add explicit cases in `EDD_API::get_dates` for `this/last_week`
2. Updated all psudo-date cases in `EDD_API::get_dates` to return _all_ date values, to avoid any assumptions for the stats class.
3. Catch an exception for `WP_Error` when stats and earnings have an invalid date parse.