### PR TITLE
Remove qualifying selector on purchase form submit button.

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -381,7 +381,7 @@ jQuery(document).ready(function ($) {
 	}
 
 	// Process checkout
-	$(document).on('click', '#edd_purchase_form #edd_purchase_submit input[type=submit]', function(e) {
+	$(document).on('click', '#edd_purchase_form #edd_purchase_submit [type=submit]', function(e) {
 
 		var eddPurchaseform = document.getElementById('edd_purchase_form');
 

--- a/templates/edd.css
+++ b/templates/edd.css
@@ -793,7 +793,7 @@ input.edd_submit_plain {
 }
 .edd-submit,
 #edd-purchase-button,
-input[type="submit"].edd-submit {
+[type="submit"].edd-submit {
 	display: inline-block;
 	padding: 6px 12px;
 	margin: 0;
@@ -816,7 +816,7 @@ input[type="submit"].edd-submit {
 	user-select: none;
 }
 .edd-submit.button:focus,
-input[type="submit"].edd-submit:focus {
+[type="submit"].edd-submit:focus {
 	outline: thin dotted #333;
 	outline: 5px auto -webkit-focus-ring-color;
 	outline-offset: -2px;


### PR DESCRIPTION
Fixes #6525

Proposed Changes:
1. Remove qualifying selector in Javascript and CSS for the checkout form.
