### PR TITLE
Allow the same product to be assigned to different prices in bundles

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -191,7 +191,7 @@ function edd_sanitize_bundled_products_save( $products = array() ) {
 	if( $self !== false )
 		unset( $products[ $self ] );
 
-	return array_values( array_unique( $products ) );
+	return array_values( $products );
 }
 add_filter( 'edd_metabox_save__edd_bundled_products', 'edd_sanitize_bundled_products_save' );
 


### PR DESCRIPTION
Fixes #6524

Proposed Changes:
1. Remove the "unique" product filtering when saving a bundle's products to allow the same product to be assigned to multiple prices.
