### PR TITLE
Add String, domain, and email masking functions

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -311,6 +311,7 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/login-register.php';
 		require_once EDD_PLUGIN_DIR . 'includes/shortcodes.php';
 		require_once EDD_PLUGIN_DIR . 'includes/admin/tracking.php'; // Must be loaded on frontend to ensure cron runs
+		require_once EDD_PLUGIN_DIR . 'includes/privacy-functions.php';
 
 		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/add-ons.php';

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -12,7 +12,22 @@
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
+/**
+ * Given a string, mask it with the * character.
+ *
+ * First and last character will remain with the filling characters being changed to *. One Character will
+ * be left in tact as is. Two character strings will has the first character remain and the second be a *.
+ *
+ * @since 2.9.2
+ * @param string $string
+ *
+ * @return string
+ */
 function edd_mask_string( $string = '' ) {
+
+	if ( empty( $string ) ) {
+		return '';
+	}
 
 	$first_char  = substr( $string, 0, 1 );
 	$last_char   = substr( $string, -1, 1 );
@@ -36,7 +51,22 @@ function edd_mask_string( $string = '' ) {
 
 }
 
+/**
+ * Given a domain, mask it with the * character.
+ *
+ * TLD parts will remain in tact (.com, .co.uk, etc). All subdomains will be masked t**t.e*****e.co.uk.
+ *
+ * @since 2.9.2
+ * @param string $domain
+ *
+ * @return string
+ */
 function edd_mask_domain( $domain = '' ) {
+
+	if ( empty( $domain ) ) {
+		return '';
+	}
+
 	$domain_parts = explode( '.', $domain );
 
 	if ( count( $domain_parts ) === 2 ) {
@@ -62,7 +92,21 @@ function edd_mask_domain( $domain = '' ) {
 	return implode( '.', $domain_parts );
 }
 
+/**
+ * Given an email address, mask the name and domain according to domain and string masking functions.
+ *
+ * Will result in an email address like a***n@e*****e.org for admin@example.org.
+ *
+ * @since 2.9.2
+ * @param $email_address
+ *
+ * @return string
+ */
 function edd_pseudo_mask_email( $email_address ) {
+	if ( ! is_email( $email_address ) ) {
+		return $email_address;
+	}
+
 	$email_parts = explode( '@', $email_address );
 	$name        = edd_mask_string( $email_parts[0] );
 	$domain      = edd_mask_domain( $email_parts[1] );

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * Given a string, mask it with the * character.
  *
  * First and last character will remain with the filling characters being changed to *. One Character will
- * be left in tact as is. Two character strings will has the first character remain and the second be a *.
+ * be left in tact as is. Two character strings will have the first character remain and the second be a *.
  *
  * @since 2.9.2
  * @param string $string
@@ -54,7 +54,7 @@ function edd_mask_string( $string = '' ) {
 /**
  * Given a domain, mask it with the * character.
  *
- * TLD parts will remain in tact (.com, .co.uk, etc). All subdomains will be masked t**t.e*****e.co.uk.
+ * TLD parts will remain intact (.com, .co.uk, etc). All subdomains will be masked t**t.e*****e.co.uk.
  *
  * @since 2.9.2
  * @param string $domain

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -50,3 +50,64 @@ Handling this data also allows us to:
 	wp_add_privacy_policy_content( 'Easy Digital Downloads', wpautop( $content ) );
 }
 add_action( 'admin_init', 'edd_register_privacy_policy_template' );
+
+function edd_mask_string( $string = '' ) {
+
+	$first_char  = substr( $string, 0, 1 );
+	$last_char   = substr( $string, -1, 1 );
+
+	$masked_string = $string;
+
+	if ( strlen( $string ) > 2 ) {
+
+		$total_stars = strlen( $string ) - 2;
+		$masked_string = $first_char . str_repeat( '*', $total_stars ) . $last_char;
+
+	} elseif ( strlen( $string ) === 2 ) {
+
+		$masked_string = $first_char . '*';
+
+	}
+
+
+
+	return $masked_string;
+
+}
+
+function edd_mask_domain( $domain = '' ) {
+	$domain_parts = explode( '.', $domain );
+
+	if ( count( $domain_parts ) === 2 ) {
+
+		// We have a single entry tld like .org or .com
+		$domain_parts[0] = edd_mask_string( $domain_parts[0] );
+
+	} else {
+
+		$part_count     = count( $domain_parts );
+		$possible_cctld = strlen( $domain_parts[ $part_count - 2 ] ) <= 3 ? true : false;
+
+		$mask_parts = $possible_cctld ? array_slice( $domain_parts, 0, $part_count - 2 ) : array_slice( $domain_parts, 0, $part_count - 1 );
+
+		$i = 0;
+		while ( $i < count( $mask_parts ) ) {
+			$domain_parts[ $i ] = edd_mask_string( $domain_parts[ $i ]);
+			$i++;
+		}
+
+	}
+
+	return implode( '.', $domain_parts );
+}
+
+function edd_pseudo_mask_email( $email_address ) {
+	$email_parts = explode( '@', $email_address );
+	$name        = edd_mask_string( $email_parts[0] );
+	$domain      = edd_mask_domain( $email_parts[1] );
+
+	$email_address = $name . '@' . $domain;
+
+
+	return $email_address;
+}

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Privacy Functions
+ *
+ * @package     EDD
+ * @subpackage  Functions
+ * @copyright   Copyright (c) 2018, Easy Digital Downloads, LLC
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       2.9.x
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+
+function edd_register_privacy_policy_template() {
+
+	if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
+		return;
+	}
+
+	$content = wp_kses_post( apply_filters( 'edd_privacy_policy_content', __( '
+We collect information about you during the checkout process on our store. This information may include, but is not limited to, your name, billing address, shipping address, email address, phone number, credit card/payment details and any other details that might be requested from you for the purpose of processing your orders.
+Handling this data also allows us to:
+- Send you important account/order/service information.
+- Respond to your queries, refund requests, or complaints.
+- Process payments and to prevent fraudulent transactions. We do this on the basis of our legitimate business interests.
+- Set up and administer your account, provide technical and/or customer support, and to verify your identity.
+' ) ) );
+
+	$content .= "\n\n";
+
+	$additional_collection = array(
+		__( 'Location and traffic data (including IP address and browser type) if you place an order, or if we need to estimate taxes and shipping costs based on your location.', 'easy-digital-downloads' ),
+		__( 'Product pages visited and content viewed whist your session is active.', 'easy-digital-downloads' ),
+		__( 'Your comments and product reviews if you choose to leave them on our website.', 'easy-digital-downloads' ),
+		__( 'Account email/password to allow you to access your account, if you have one.', 'easy-digital-downloads' ),
+		__( 'If you choose to create an account with us, your name, address, and email address, which will be used to populate the checkout for future orders.', 'easy-digital-downloads' ),
+	);
+
+	$additional_collection = apply_filters( 'edd_privacy_policy_additinal_collection', $additional_collection );
+
+	$content .= __( 'Additionally we may also collect the following information:', 'easy-digital-downloads' ) . "\n";
+	if ( ! empty( $additional_collection ) ) {
+		foreach ( $additional_collection as $item ) {
+			$content .= '-' . $item . "\n";
+		}
+	}
+
+	wp_add_privacy_policy_content( 'Easy Digital Downloads', wpautop( $content ) );
+}
+add_action( 'admin_init', 'edd_register_privacy_policy_template' );

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -6,7 +6,7 @@
  * @subpackage  Functions
  * @copyright   Copyright (c) 2018, Easy Digital Downloads, LLC
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
- * @since       2.9.x
+ * @since       2.9.2
  */
 
 // Exit if accessed directly

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -38,7 +38,7 @@ Handling this data also allows us to:
 		__( 'If you choose to create an account with us, your name, address, and email address, which will be used to populate the checkout for future orders.', 'easy-digital-downloads' ),
 	);
 
-	$additional_collection = apply_filters( 'edd_privacy_policy_additinal_collection', $additional_collection );
+	$additional_collection = apply_filters( 'edd_privacy_policy_additional_collection', $additional_collection );
 
 	$content .= __( 'Additionally we may also collect the following information:', 'easy-digital-downloads' ) . "\n";
 	if ( ! empty( $additional_collection ) ) {

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -12,45 +12,6 @@
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-
-function edd_register_privacy_policy_template() {
-
-	if ( ! function_exists( 'wp_add_privacy_policy_content' ) ) {
-		return;
-	}
-
-	$content = wp_kses_post( apply_filters( 'edd_privacy_policy_content', __( '
-We collect information about you during the checkout process on our store. This information may include, but is not limited to, your name, billing address, shipping address, email address, phone number, credit card/payment details and any other details that might be requested from you for the purpose of processing your orders.
-Handling this data also allows us to:
-- Send you important account/order/service information.
-- Respond to your queries, refund requests, or complaints.
-- Process payments and to prevent fraudulent transactions. We do this on the basis of our legitimate business interests.
-- Set up and administer your account, provide technical and/or customer support, and to verify your identity.
-' ) ) );
-
-	$content .= "\n\n";
-
-	$additional_collection = array(
-		__( 'Location and traffic data (including IP address and browser type) if you place an order, or if we need to estimate taxes and shipping costs based on your location.', 'easy-digital-downloads' ),
-		__( 'Product pages visited and content viewed whist your session is active.', 'easy-digital-downloads' ),
-		__( 'Your comments and product reviews if you choose to leave them on our website.', 'easy-digital-downloads' ),
-		__( 'Account email/password to allow you to access your account, if you have one.', 'easy-digital-downloads' ),
-		__( 'If you choose to create an account with us, your name, address, and email address, which will be used to populate the checkout for future orders.', 'easy-digital-downloads' ),
-	);
-
-	$additional_collection = apply_filters( 'edd_privacy_policy_additional_collection', $additional_collection );
-
-	$content .= __( 'Additionally we may also collect the following information:', 'easy-digital-downloads' ) . "\n";
-	if ( ! empty( $additional_collection ) ) {
-		foreach ( $additional_collection as $item ) {
-			$content .= '-' . $item . "\n";
-		}
-	}
-
-	wp_add_privacy_policy_content( 'Easy Digital Downloads', wpautop( $content ) );
-}
-add_action( 'admin_init', 'edd_register_privacy_policy_template' );
-
 function edd_mask_string( $string = '' ) {
 
 	$first_char  = substr( $string, 0, 1 );

--- a/tests/tests-privacy.php
+++ b/tests/tests-privacy.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @group edd_payments
+ */
+class Tests_Privacy extends EDD_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+	}
+
+	public function test_string_mask_1_char() {
+		$this->assertSame( 'a', edd_mask_string( 'a' ) );
+	}
+
+	public function test_string_mask_2_char() {
+		$this->assertSame( 'h*', edd_mask_string( 'hi' ) );
+	}
+
+	public function test_string_mask_5_char() {
+		$this->assertSame( 'h***o', edd_mask_string( 'hello' ) );
+	}
+
+	public function test_domain_mask_2_parts() {
+		$this->assertSame( 'e*****e.org', edd_mask_domain( 'example.org' ) );
+	}
+
+	public function test_domain_mask_3_parts_cctld() {
+		$this->assertSame( 'e*****e.co.uk', edd_mask_domain( 'example.co.uk' ) );
+	}
+
+	public function test_domain_mask_3_parts_subdomain() {
+		$this->assertSame( 'e*****e.i*****d.org', edd_mask_domain( 'example.invalid.org' ) );
+	}
+
+	public function test_domain_mask_4_parts_subdomain_cctld() {
+		$this->assertSame( 'e*****e.i*****d.org.uk', edd_mask_domain( 'example.invalid.org.uk' ) );
+	}
+
+	public function test_email_mask_() {
+		$this->assertSame( 'a***n@e*****e.org', edd_pseudo_mask_email( 'admin@example.org' ) );
+	}
+}

--- a/tests/tests-privacy.php
+++ b/tests/tests-privacy.php
@@ -13,6 +13,10 @@ class Tests_Privacy extends EDD_UnitTestCase {
 		parent::tearDown();
 	}
 
+	public function test_string_mask_0_char() {
+		$this->assertSame( '', edd_mask_string( '' ) );
+	}
+
 	public function test_string_mask_1_char() {
 		$this->assertSame( 'a', edd_mask_string( 'a' ) );
 	}
@@ -23,6 +27,10 @@ class Tests_Privacy extends EDD_UnitTestCase {
 
 	public function test_string_mask_5_char() {
 		$this->assertSame( 'h***o', edd_mask_string( 'hello' ) );
+	}
+
+	public function test_domain_mask_0_parts() {
+		$this->assertSame( '', edd_mask_domain( '' ) );
 	}
 
 	public function test_domain_mask_2_parts() {
@@ -41,7 +49,11 @@ class Tests_Privacy extends EDD_UnitTestCase {
 		$this->assertSame( 'e*****e.i*****d.org.uk', edd_mask_domain( 'example.invalid.org.uk' ) );
 	}
 
-	public function test_email_mask_() {
+	public function test_email_mask() {
 		$this->assertSame( 'a***n@e*****e.org', edd_pseudo_mask_email( 'admin@example.org' ) );
+	}
+
+	public function test_email_mask_not_email() {
+		$this->assertSame( 'test-string', edd_pseudo_mask_email( 'test-string' ) );
 	}
 }


### PR DESCRIPTION
Fixes #6502 

Proposed Changes:
1. Adds 3 new functions `edd_mask_string`, `edd_mask_domain`, and `edd_mask_email`.
2. The mask email function uses the mask domain, which uses the mask string. DRY style.
3. Adds in unit tests for cases I could think of

Note:
The domain parsing supports domains like `example.org`, `example.org.uk`, `test.example.com` and `test.example.org.uk`.