### PR TITLE
load JS for Agree to Terms OR Privacy Policy #6535

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -979,7 +979,7 @@ function edd_get_checkout_button_purchase_label() {
  * @return void
  */
 function edd_agree_to_terms_js() {
-	if ( edd_get_option( 'show_agree_to_terms', false ) ) {
+	if ( edd_get_option( 'show_agree_to_terms', false ) || edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
 ?>
 	<script type="text/javascript">
 		jQuery(document).ready(function($){


### PR DESCRIPTION
Fixes #

Proposed Changes:
1. Load the shared JS when Privacy Policy is enabled but Agree to Terms is disabled.
