### PR TITLE
Log customer meta of terms and privacy policy agreements #6432

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -321,6 +321,79 @@ function edd_customers_view( $customer ) {
 						<?php endif; ?>
 					</span>
 
+					<?php
+					$show_agree_to_terms   = edd_get_option( 'show_agree_to_terms', false );
+					$show_agree_to_privacy = edd_get_option( 'show_agree_to_privacy_policy', false );
+
+					if ( $show_agree_to_terms || $show_agree_to_privacy ) {
+						$agreement_timtestamp = $customer->get_meta( 'agree_to_terms_time' );
+						$privacy_timestamp    = $customer->get_meta( 'agree_to_privacy_time' );
+
+						if ( empty( $agreement_timtestamp ) || empty( $privacy_timestamp ) ) {
+							$payments = edd_get_payments( array(
+								'output'   => 'payments',
+								'post__in' => explode( ',', $customer->payment_ids ),
+								'orderby'  => 'date',
+							));
+
+							$last_payment_date = '';
+
+							foreach ( $payments as $payment ) {
+								if ( empty( $payment->gateway ) ) {
+									continue;
+								}
+
+								// We should be using `date` here, as that is the date the button was clicked.
+								$last_payment_date = strtotime( $payment->date );
+								break;
+							}
+						}
+						?>
+
+						<?php if ( $show_agree_to_terms ) : ?>
+						<span class="customer-terms-agreement-date info-item">
+							<?php _e( 'Agreed to Terms', 'easy-digital-downloads' ); ?>:
+							<br />
+							<?php if ( ! empty( $agreement_timtestamp ) ) : ?>
+								<?php echo date_i18n( get_option( 'date_format' ) . ' H:i:s', $agreement_timtestamp ); ?>
+							<?php else: ?>
+								<?php
+									if ( empty( $last_payment_date ) ) {
+										_e( 'No date found.', 'easy-digital-downloads' );
+									} else {
+										echo date_i18n( get_option( 'date_format' ) . ' H:i:s', $last_payment_date );
+										?>
+										<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<strong><?php _e( 'Estimated Agreement Date', 'easy-digital-downloads' ); ?></strong><br /><?php _e( 'This customer made a purchase prior to agreement dates being logged, this is the date of their last purchase. If your site was displaying the agreement checkbox at that time, this is our best estimate as to when they last agreed to your terms.', 'easy-digital-downloads' ); ?>"></span>
+										<?php
+									}
+								?>
+							<?php endif; ?>
+						</span>
+						<?php endif; ?>
+
+						<?php if ( $show_agree_to_privacy ) : ?>
+						<span class="customer-privacy-policy-date info-item">
+							<?php _e( 'Agreed to Privacy Policy', 'easy-digital-downloads' ); ?>:
+							<br />
+							<?php if ( ! empty( $privacy_timestamp ) ) : ?>
+								<?php echo date_i18n( get_option( 'date_format' ) . ' H:i:s', $privacy_timestamp ); ?>
+							<?php else: ?>
+								<?php
+								if ( empty( $last_payment_date ) ) {
+									_e( 'No date found.', 'easy-digital-downloads' );
+								} else {
+									echo date_i18n( get_option( 'date_format' ) . ' H:i:s', $last_payment_date );
+									?>
+									<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<strong><?php _e( 'Estimated Privacy Policy Date', 'easy-digital-downloads' ); ?></strong><br /><?php _e( 'This customer made a purchase prior to privacy policy dates being logged, this is the date of their last purchase. If your site was displaying the privacy policy checkbox at that time, this is our best estimate as to when they last agreed to your privacy policy.', 'easy-digital-downloads' ); ?>"></span>
+									<?php
+								}
+								?>
+							<?php endif; ?>
+						</span>
+						<?php endif; ?>
+
+					<?php } ?>
+
 				</div>
 
 			</div>

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -258,6 +258,14 @@ function edd_insert_payment( $payment_data = array() ) {
 
 	$payment->save();
 
+	if ( edd_get_option( 'show_agree_to_terms', false ) && ! empty( $_POST['edd_agree_to_terms'] ) ) {
+		$payment_data['agree_to_terms_time'] = current_time( 'timestamp' );
+	}
+
+	if ( edd_get_option( 'show_agree_to_privacy_policy', false ) && ! empty( $_POST['edd_agree_to_privacy_policy'] ) ) {
+		$payment_data['agree_to_privacy_time'] = current_time( 'timestamp' );
+	}
+
 	do_action( 'edd_insert_payment', $payment->ID, $payment_data );
 
 	if ( ! empty( $payment->ID ) ) {

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -116,3 +116,34 @@ function edd_pseudo_mask_email( $email_address ) {
 
 	return $email_address;
 }
+
+/**
+ * Log the privacy and terms timestamp for the last completed purchase for a customer.
+ *
+ * Stores the timestamp of the last time the user clicked the 'complete purchase' button for the Agree to Terms and/or
+ * Privacy Policy checkboxes during the checkout process.
+ *
+ * @since 2.9.2
+ *
+ * @param $payment_id
+ * @param $payment_data
+ *
+ * @return void
+ */
+function edd_log_terms_and_privacy_times( $payment_id, $payment_data ) {
+	$payment  = edd_get_payment( $payment_id );
+	$customer = new EDD_Customer( $payment->customer_id );
+
+	if ( empty( $customer->id ) ) {
+		return;
+	}
+
+	if ( ! empty( $payment_data['agree_to_terms_time'] ) ) {
+		$customer->update_meta( 'agree_to_terms_time', $payment_data['agree_to_terms_time'] );
+	}
+
+	if ( ! empty( $payment_data['agree_to_privacy_time'] ) ) {
+		$customer->update_meta( 'agree_to_privacy_time', $payment_data['agree_to_terms_time'] );
+	}
+}
+add_action( 'edd_insert_payment', 'edd_log_terms_and_privacy_times', 10, 2 );


### PR DESCRIPTION
Fixes #6432

Proposed Changes:
1. Adds two customer meta entires when the complete purchase button is clicked, `agree_to_terms_time` and `agree_to_privacy_time`. This is a unix timestamp of the moment they started the complete purchase process.
2. Displays the agreement times on the customer card (when they are enabled)
2a. If the customer has made a purchase (on this branch and going forward), it will show the date and time based off the customer meta.
2b. If the customer has not made a purchase (on this branch or going forward), it will show the date and time of the most recent purchase with a gateway property and display a tooltip that it is our best estimate.