### PR TITLE
Adds support for customer record and billing information from all payments for a customer record #6543

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -715,24 +715,38 @@ function edd_get_payment_status( $payment, $return_label = false ) {
 		return false;
 	}
 
+	if ( true === $return_label ) {
+		return edd_get_payment_status_label( $payment->post_status );
+	} else {
+		$statuses = edd_get_payment_statuses();
+
+		// Account that our 'publish' status is labeled 'Complete'
+		$post_status = 'publish' == $payment->status ? 'Complete' : $payment->post_status;
+
+		// Make sure we're matching cases, since they matter
+		return array_search( strtolower( $post_status ), array_map( 'strtolower', $statuses ) );
+	}
+
+	return ! empty( $status ) ? $status : false;
+}
+
+/**
+ * Given a payment status string, return the label for that string.
+ *
+ * @since 2.9.2
+ * @param string $status
+ *
+ * @return bool|mixed
+ */
+function edd_get_payment_status_label( $status = '' ) {
 	$statuses = edd_get_payment_statuses();
 
 	if ( ! is_array( $statuses ) || empty( $statuses ) ) {
 		return false;
 	}
 
-	$payment = new EDD_Payment( $payment->ID );
-
-	if ( array_key_exists( $payment->status, $statuses ) ) {
-		if ( true === $return_label ) {
-			return $statuses[ $payment->status ];
-		} else {
-			// Account that our 'publish' status is labeled 'Complete'
-			$post_status = 'publish' == $payment->status ? 'Complete' : $payment->post_status;
-
-			// Make sure we're matching cases, since they matter
-			return array_search( strtolower( $post_status ), array_map( 'strtolower', $statuses ) );
-		}
+	if ( array_key_exists( $status, $statuses ) ) {
+		return $statuses[ $status ];
 	}
 
 	return false;

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -349,6 +349,8 @@ function edd_privacy_billing_information_exporter( $email_address = '', $page = 
 			),
 		);
 
+		$data_points = apply_filters( 'edd_privacy_order_details_item', $data_points, $payment );
+
 		$export_items[] = array(
 			'group_id'    => 'edd-order-details',
 			'group_label' => __( 'Customer Orders', 'easy-digital-downloads' ),

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -186,14 +186,16 @@ function edd_privacy_cutomer_record_exporter( $email_address = '', $page = 1 ) {
 			)
 		);
 
-		if ( ! empty( $customer->get_meta( 'agree_to_terms_time' ) ) ) {
+		$agree_to_terms_time = $customer->get_meta( 'agree_to_terms_time' );
+		if ( ! empty( $agree_to_terms_time ) ) {
 			$export_data['data'][] = array(
 				'name' => __( 'Agreed to Terms' ),
 				'value' => date_i18n( get_option( 'date_format' ) . ' H:i:s', strtotime( $customer->get_meta( 'agree_to_terms_time' ) ) )
 			);
 		}
 
-		if ( ! empty( $customer->get_meta( 'agree_to_privacy_time' ) ) ) {
+		$agree_to_privacy_time = $customer->get_meta( 'agree_to_privacy_time' );
+		if ( ! empty( $agree_to_privacy_time ) ) {
 			$export_data['data'][] = array(
 				'name' => __( 'Agreed to Privacy Policy' ),
 				'value' => date_i18n( get_option( 'date_format' ) . ' H:i:s', strtotime( $customer->get_meta( 'agree_to_privacy_time' ) ) )

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -260,11 +260,11 @@ function edd_privacy_billing_information_exporter( $email_address = '', $page = 
 		$billing_name = implode( ' ', array_values( $billing_name ) );
 
 		$billing_street = array();
-		if ( ! empty( ! empty( $payment->address['line1'] ) ) ) {
+		if ( ! empty( $payment->address['line1'] ) ) {
 			$billing_street[] = $payment->address['line1'];
 		}
 
-		if ( ! empty( ! empty( $payment->address['line2'] ) ) ) {
+		if ( ! empty( $payment->address['line2'] ) ) {
 			$billing_street[] = $payment->address['line2'];
 		}
 		$billing_street = implode( "\n", array_values( $billing_street ) );

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -130,7 +130,7 @@ function edd_register_privacy_exporters( $exporters ) {
 
 	$exporters[] = array(
 		'exporter_friendly_name' => __( 'Customer Record', 'easy-digital-downloads' ),
-		'callback'               => 'edd_privacy_cutomer_record_exporter',
+		'callback'               => 'edd_privacy_customer_record_exporter',
 	);
 
 	$exporters[] = array(
@@ -152,7 +152,7 @@ add_filter( 'wp_privacy_personal_data_exporters', 'edd_register_privacy_exporter
  *
  * @return array
  */
-function edd_privacy_cutomer_record_exporter( $email_address = '', $page = 1 ) {
+function edd_privacy_customer_record_exporter( $email_address = '', $page = 1 ) {
 
 	$customer    = new EDD_Customer( $email_address );
 	$export_data = array();

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -116,3 +116,181 @@ function edd_pseudo_mask_email( $email_address ) {
 
 	return $email_address;
 }
+
+/**
+ * Register any of our Privacy Data Exporters
+ *
+ * @since 2.9.2
+ *
+ * @param $exporters
+ *
+ * @return array
+ */
+function edd_register_privacy_exporters( $exporters ) {
+
+	$exporters[] = array(
+		'exporter_friendly_name' => __( 'Customer Record', 'easy-digital-downloads' ),
+		'callback'               => 'edd_privacy_cutomer_record_exporter',
+	);
+
+	$exporters[] = array(
+		'exporter_friendly_name' => __( 'Billing Information', 'easy-digital-downloads' ),
+		'callback'               => 'edd_privacy_billing_information_exporter',
+	);
+
+	return $exporters;
+
+}
+add_filter( 'wp_privacy_personal_data_exporters', 'edd_register_privacy_exporters' );
+
+/**
+ * Retrieves the Customer record for the Privacy Data Exporter
+ *
+ * @since 2.9.2
+ * @param string $email_address
+ * @param int    $page
+ *
+ * @return array
+ */
+function edd_privacy_cutomer_record_exporter( $email_address = '', $page = 1 ) {
+
+	$customer    = new EDD_Customer( $email_address );
+	$export_data = array();
+
+	if ( ! empty( $customer->id ) ) {
+		$export_data = array(
+			'group_id'    => 'edd-customer-record',
+			'group_label' => __( 'Customer Record', 'easy-digital-downloads' ),
+			'item_id'     => "edd-customer-record-{$customer->id}",
+			'data'        => array(
+				array(
+					'name'  => __( 'Customer ID', 'easy-digital-downloads' ),
+					'value' => $customer->id
+				),
+				array(
+					'name'  => __( 'Primary Email', 'easy-digital-downloads' ),
+					'value' => $customer->email
+				),
+				array(
+					'name'  => __( 'Name', 'easy-digital-downloads' ),
+					'value' => $customer->name
+				),
+				array(
+					'name'  => __( 'Date Created', 'easy-digital-downloads' ),
+					'value' => $customer->date_created
+				),
+				array(
+					'name'  => __( 'All Email Addresses', 'easy-digital-downloads' ),
+					'value' => implode( ', ', $customer->emails )
+				),
+			)
+		);
+
+		if ( ! empty( $customer->get_meta( 'agree_to_terms_time' ) ) ) {
+			$export_data['data'][] = array(
+				'name' => __( 'Agreed to Terms' ),
+				'value' => date_i18n( get_option( 'date_format' ) . ' H:i:s', strtotime( $customer->get_meta( 'agree_to_terms_time' ) ) )
+			);
+		}
+
+		if ( ! empty( $customer->get_meta( 'agree_to_privacy_time' ) ) ) {
+			$export_data['data'][] = array(
+				'name' => __( 'Agreed to Privacy Policy' ),
+				'value' => date_i18n( get_option( 'date_format' ) . ' H:i:s', strtotime( $customer->get_meta( 'agree_to_privacy_time' ) ) )
+			);
+		}
+	}
+
+	return array( 'data' => array( $export_data ), 'done' => true );
+}
+
+/**
+ * Retrieves the billing information for the Privacy Exporter
+ *
+ * @since 2.9.2
+ * @param string $email_address
+ * @param int    $page
+ *
+ * @return array
+ */
+function edd_privacy_billing_information_exporter( $email_address = '', $page = 1 ) {
+
+	$customer = new EDD_Customer( $email_address );
+	$payments = edd_get_payments( array(
+		'customer' => $customer->id,
+		'output'   => 'payments',
+		'page'     => $page,
+	) );
+
+	// If we haven't found any payments for this page, just return that we're done.
+	if ( empty( $payments ) ) {
+		return array( 'data' => array(), 'done' => true );
+	}
+
+
+	$export_items = array();
+	foreach ( $payments as $payment ) {
+		$data_points = array(
+			array(
+				'name'  => __( 'Order ID', 'easy-digital-downloads' ),
+				'value' => $payment->ID,
+			),
+			array(
+				'name'  => __( 'First Name', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->user_info['first_name'] ) ? $payment->user_info['first_name'] : '',
+			),
+			array(
+				'name'  => __( 'Last Name', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->user_info['last_name'] ) ? $payment->user_info['last_name'] : '',
+			),
+			array(
+				'name'  => __( 'Email Address', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->email ) ? $payment->email : '',
+			),
+			array(
+				'name'  => __( 'Address', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->address['line1'] ) ? $payment->address['line1'] : '',
+			),
+			array(
+				'name'  => __( 'Address Line 2', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->address['line2'] ) ? $payment->address['line2'] : '',
+			),
+			array(
+				'name'  => __( 'City', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->address['city'] ) ? $payment->address['city'] : '',
+			),
+			array(
+				'name'  => __( 'State', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->address['state'] ) ? $payment->address['state'] : '',
+			),
+			array(
+				'name'  => __( 'Postal Code', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->address['zip'] ) ? $payment->address['zip'] : '',
+			),
+			array(
+				'name'  => __( 'Country', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->address['country'] ) ? $payment->address['country'] : '',
+			),
+			array(
+				'name'  => __( 'IP Address', 'easy-digital-downloads' ),
+				'value' => ! empty( $payment->ip ) ? $payment->ip : '',
+			),
+		);
+
+		$export_items[] = array(
+			'group_id'    => 'edd-billing-information',
+			'group_label' => __( 'Customer Billing information', 'easy-digital-downloads' ),
+			'item_id'     => "edd-billing-addresses-{$payment->ID}",
+			'data'        => $data_points,
+		);
+
+	}
+
+
+	// Add the data to the list, and tell the exporter to come back for the next page of payments.
+	return array(
+		'data' => $export_items,
+		'done' => false,
+	);
+
+}


### PR DESCRIPTION
Fixes #6543 
Fixes #6544

Proposed Changes:
1. Adds two exporters, customer record and order billing details to the WP Core data exporter

![screen shot 2018-05-07 at 2 51 33 pm](https://user-images.githubusercontent.com/1390124/39727120-4c385f8e-5206-11e8-9f30-bb38c2c45ca5.png)
![image 2018-05-07 at 2 51 46 pm](https://user-images.githubusercontent.com/1390124/39727123-4f23cabc-5206-11e8-9df3-b5a8057deb06.png)
