### PR TITLE
Alias `EDD_Gateawy_Reports_Table` class.

### DIFF
--- a/includes/admin/reporting/class-gateways-reports-table.php
+++ b/includes/admin/reporting/class-gateways-reports-table.php
@@ -18,13 +18,13 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 }
 
 /**
- * EDD_Gateawy_Reports_Table Class
+ * EDD_Gateway_Reports_Table Class
  *
  * Renders the Download Reports table
  *
  * @since 1.5
  */
-class EDD_Gateawy_Reports_Table extends WP_List_Table {
+class EDD_Gateway_Reports_Table extends WP_List_Table {
 
 	/**
 	 * @var int Number of items per page
@@ -151,9 +151,9 @@ class EDD_Gateawy_Reports_Table extends WP_List_Table {
 	 * Setup the final data for the table
 	 *
 	 * @since 1.5
-	 * @uses EDD_Gateawy_Reports_Table::get_columns()
-	 * @uses EDD_Gateawy_Reports_Table::get_sortable_columns()
-	 * @uses EDD_Gateawy_Reports_Table::reports_data()
+	 * @uses EDD_Gateway_Reports_Table::get_columns()
+	 * @uses EDD_Gateway_Reports_Table::get_sortable_columns()
+	 * @uses EDD_Gateway_Reports_Table::reports_data()
 	 * @return void
 	 */
 	public function prepare_items() {
@@ -165,3 +165,10 @@ class EDD_Gateawy_Reports_Table extends WP_List_Table {
 
 	}
 }
+
+/**
+ * Back-compat for typo
+ *
+ * @see https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6549
+ */
+class_alias( 'EDD_Gateway_Reports_Table', 'EDD_Gateawy_Reports_Table' );

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -287,8 +287,8 @@ add_action( 'edd_reports_view_downloads', 'edd_reports_download_details' );
  * Renders the Gateways Table
  *
  * @since 1.3
- * @uses EDD_Gateawy_Reports_Table::prepare_items()
- * @uses EDD_Gateawy_Reports_Table::display()
+ * @uses EDD_Gateway_Reports_Table::prepare_items()
+ * @uses EDD_Gateway_Reports_Table::display()
  * @return void
  */
 function edd_reports_gateways_table() {
@@ -299,7 +299,7 @@ function edd_reports_gateways_table() {
 
 	include( dirname( __FILE__ ) . '/class-gateways-reports-table.php' );
 
-	$downloads_table = new EDD_Gateawy_Reports_Table();
+	$downloads_table = new EDD_Gateway_Reports_Table();
 	$downloads_table->prepare_items();
 	$downloads_table->display();
 }


### PR DESCRIPTION
This class name contained a typo, for a few years.

We can use `class_alias()` to rename the class without the typo, and still make sure anyone that might be using the old class name still can.

See #6549.