### PR TITLE
Remove PII and switch file download logs to use customer ID #6548

### DIFF
--- a/includes/admin/upgrades/classes/class-file-download-log-migration.php
+++ b/includes/admin/upgrades/classes/class-file-download-log-migration.php
@@ -40,7 +40,7 @@ class EDD_File_Download_Log_Migration extends EDD_Batch_Export {
 	 * @since  2.9.2
 	 * @var integer
 	 */
-	public $per_step = 25;
+	public $per_step = 50;
 
 	/**
 	 * Get the Export Data
@@ -73,6 +73,11 @@ class EDD_File_Download_Log_Migration extends EDD_Batch_Export {
 
 				if ( $sanitized_log_id !== $log_id ) {
 					edd_debug_log( "Log ID mismatch, skipping log ID {$log_id}" );
+					continue;
+				}
+
+				$has_customer_id = get_post_meta( $log_id, '_edd_log_customer_id', true );
+				if ( ! empty( $has_customer_id ) ) {
 					continue;
 				}
 

--- a/includes/admin/upgrades/classes/class-file-download-log-migration.php
+++ b/includes/admin/upgrades/classes/class-file-download-log-migration.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Migrate File Download Logs
+ *
+ * Removes some PII from the log meta, and adds the customer ID of the payment to allow more accurate
+ * file download counts for a customer.
+ *
+ * @subpackage  Admin/Classes/EDD_SL_License_Log_Migration
+ * @copyright   Copyright (c) 2018, Easy Digital Downloads, LLC
+ * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       2.6.2
+ */
+
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * EDD_File_Download_Log_Migration Class
+ *
+ * @since 2.9.2
+ */
+class EDD_File_Download_Log_Migration extends EDD_Batch_Export {
+
+	/**
+	 * Our export type. Used for export-type specific filters/actions
+	 * @var string
+	 * @since 2.9.2
+	 */
+	public $export_type = '';
+
+	/**
+	 * Allows for a non-download batch processing to be run.
+	 * @since  2.9.2
+	 * @var boolean
+	 */
+	public $is_void = true;
+
+	/**
+	 * Sets the number of items to pull on each step
+	 * @since  2.9.2
+	 * @var integer
+	 */
+	public $per_step = 25;
+
+	/**
+	 * Get the Export Data
+	 *
+	 * @access public
+	 * @since 2.9.2
+	 * @global object $wpdb Used to query the database using the WordPress
+	 *   Database API
+	 * @return array $data The data for the CSV file
+	 */
+	public function get_data() {
+
+		global $wpdb;
+
+		$items = $this->get_stored_data( 'edd_file_download_log_ids' );
+
+		if ( ! is_array( $items ) ) {
+			return false;
+		}
+
+		$offset     = ( $this->step - 1 ) * $this->per_step;
+		$step_items = array_slice( $items, $offset, $this->per_step, true );
+
+		if ( $step_items ) {
+
+			foreach ( $step_items as $log_id ) {
+
+				$sanitized_log_id = absint( $log_id );
+
+				if ( $sanitized_log_id !== $log_id ) {
+					edd_debug_log( "Log ID mismatch, skipping log ID {$log_id}" );
+					continue;
+				}
+
+				$payment_id = $wpdb->get_var( "SELECT meta_value FROM {$wpdb->postmeta} WHERE post_id = {$sanitized_log_id} AND meta_key = '_edd_log_payment_id'" );
+				if ( ! empty( $payment_id ) ) {
+					$payment     = edd_get_payment( $payment_id );
+					$customer_id = $payment->customer_id;
+
+					if ( $customer_id < 0 ) {
+						$customer_id = 0;
+					}
+
+					edd_debug_log( "Updating log ID {$log_id} with customer ID {$customer_id} and removing user info" );
+
+					update_post_meta( $log_id, '_edd_log_customer_id', $customer_id );
+					delete_post_meta( $log_id, '_edd_log_user_info' );
+
+				}
+
+			}
+
+			return true;
+
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Return the calculated completion percentage
+	 *
+	 * @since 2.9.2
+	 * @return int
+	 */
+	public function get_percentage_complete() {
+
+		$items = $this->get_stored_data( 'edd_file_download_log_ids', false );
+		$total = count( $items );
+
+		$percentage = 100;
+
+		if( $total > 0 ) {
+			$percentage = ( ( $this->per_step * $this->step ) / $total ) * 100;
+		}
+
+		if( $percentage > 100 ) {
+			$percentage = 100;
+		}
+
+		return $percentage;
+	}
+
+	/**
+	 * Set the properties specific to the payments export
+	 *
+	 * @since 2.9.2
+	 * @param array $request The Form Data passed into the batch processing
+	 */
+	public function set_properties( $request ) {}
+
+	/**
+	 * Process a step
+	 *
+	 * @since 2.9.2
+	 * @return bool
+	 */
+	public function process_step() {
+
+		if ( ! $this->can_export() ) {
+			wp_die(
+				__( 'You do not have permission to run this upgrade.', 'easy-digital-downloads' ),
+				__( 'Error', 'easy-digital-downloads' ),
+				array( 'response' => 403 ) );
+		}
+
+		$had_data = $this->get_data();
+
+		if( $had_data ) {
+			$this->done = false;
+			return true;
+		} else {
+			$this->delete_data( 'edd_file_download_log_ids' );
+
+			$this->done    = true;
+			$this->message = __( 'File download logs updated successfully.', 'easy-digital-downloads' );
+			edd_set_upgrade_complete( 'update_file_download_log_data' );
+			return false;
+		}
+	}
+
+	public function headers() {
+		ignore_user_abort( true );
+
+		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
+			set_time_limit( 0 );
+		}
+	}
+
+	/**
+	 * Perform the export
+	 *
+	 * @access public
+	 * @since 2.9.2
+	 * @return void
+	 */
+	public function export() {
+
+		// Set headers
+		$this->headers();
+
+		edd_die();
+	}
+
+	public function pre_fetch() {
+		global $edd_logs;
+
+		if ( $this->step == 1 ) {
+			$this->delete_data( 'edd_file_download_log_ids' );
+		}
+
+		// Get any file download logs that have an entry for the user info
+		$file_download_log_ids = get_option( 'edd_file_download_log_ids', false );
+		if ( false === $file_download_log_ids ) {
+
+			$log_query = array(
+				'post_parent'            => null,
+				'log_type'               => 'file_download',
+				'posts_per_page'         => -1,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'fields'                 => 'ids',
+				'meta_query'             => array(
+					array(
+						'key'     => '_edd_log_user_info',
+						'compare' => 'EXISTS',
+					)
+				)
+			);
+
+			$file_download_log_ids = $edd_logs->get_connected_logs( $log_query );
+
+			$this->store_data( 'edd_file_download_log_ids', $file_download_log_ids );
+
+		}
+
+	}
+
+	/**
+	 * Given a key, get the information from the Database Directly
+	 *
+	 * @since  2.9.2
+	 * @param  string $key The option_name
+	 * @return mixed       Returns the data from the database
+	 */
+	private function get_stored_data( $key ) {
+		global $wpdb;
+		$value = $wpdb->get_var(
+			$wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = '%s'", $key )
+		);
+
+		if ( empty( $value ) ) {
+			return false;
+		}
+
+		$maybe_json = json_decode( $value );
+		if ( ! is_null( $maybe_json ) ) {
+			$value = json_decode( $value, true );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Give a key, store the value
+	 *
+	 * @since  2.9.2
+	 * @param  string $key   The option_name
+	 * @param  mixed  $value  The value to store
+	 * @return void
+	 */
+	private function store_data( $key, $value ) {
+		global $wpdb;
+
+		$value = is_array( $value ) ? wp_json_encode( $value ) : esc_attr( $value );
+
+		$data = array(
+			'option_name'  => $key,
+			'option_value' => $value,
+			'autoload'     => 'no',
+		);
+
+		$formats = array(
+			'%s', '%s', '%s',
+		);
+
+		$wpdb->replace( $wpdb->options, $data, $formats );
+	}
+
+	/**
+	 * Delete an option
+	 *
+	 * @since  2.9.2
+	 * @param  string $key The option_name to delete
+	 * @return void
+	 */
+	private function delete_data( $key ) {
+		global $wpdb;
+		$wpdb->delete( $wpdb->options, array( 'option_name' => $key ) );
+	}
+
+}

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -176,6 +176,13 @@ function edd_show_upgrade_notices() {
 			);
 		}
 
+		if ( version_compare( $edd_version, '2.9.2', '<' ) || ! edd_has_upgrade_completed( 'update_file_download_log_data' ) ) {
+			printf(
+				'<div class="updated"><p>' . __( 'Easy Digital Downloads needs to upgrade the file download logs database, click <a href="%s">here</a> to start the upgrade.', 'easy-digital-downloads' ) . '</p></div>',
+				esc_url( admin_url( 'index.php?page=edd-upgrades&edd-upgrade=update_file_download_log_data' ) )
+			);
+		}
+
 		/*
 		 *  NOTICE:
 		 *
@@ -1162,4 +1169,117 @@ add_action( 'edd_remove_refunded_sale_logs', 'edd_remove_refunded_sale_logs' );
 function edd_v26_upgrades() {
 	@EDD()->customers->create_table();
 	@EDD()->customer_meta->create_table();
+}
+
+
+function edd_upgrade_render_update_file_download_log_data() {
+	$migration_complete = edd_has_upgrade_completed( 'update_file_download_log_data' );
+
+	if ( $migration_complete ) : ?>
+		<div id="edd-sl-migration-complete" class="notice notice-success">
+			<p>
+				<?php _e( '<strong>Migration complete:</strong> You have already completed the update to the file download logs.', 'easy-digital-downloads' ); ?>
+			</p>
+		</div>
+		<?php return; ?>
+	<?php endif; ?>
+
+	<div id="edd-migration-ready" class="notice notice-success" style="display: none;">
+		<p>
+			<?php _e( '<strong>Database Upgrade Complete:</strong> All database upgrades have been completed.', 'easy-digital-downloads' ); ?>
+			<br /><br />
+			<?php _e( 'You may now leave this page.', 'easy-digital-downloads' ); ?>
+		</p>
+	</div>
+
+	<div id="edd-migration-nav-warn" class="notice notice-info">
+		<p>
+			<?php _e( '<strong>Important:</strong> Please leave this screen open and do not navigate away until the process completes.', 'easy-digital-downloads' ); ?>
+		</p>
+	</div>
+
+	<style>
+		.dashicons.dashicons-yes { display: none; color: rgb(0, 128, 0); vertical-align: middle; }
+	</style>
+	<script>
+		jQuery( function($) {
+			$(document).ready(function () {
+				$(document).on("DOMNodeInserted", function (e) {
+					var element = e.target;
+
+					if (element.id === 'edd-batch-success') {
+						element = $(element);
+
+						element.parent().prev().find('.edd-migration.allowed').hide();
+						element.parent().prev().find('.edd-migration.unavailable').show();
+						var element_wrapper = element.parents().eq(4);
+						element_wrapper.find('.dashicons.dashicons-yes').show();
+
+						var next_step_wrapper = element_wrapper.next();
+						if (next_step_wrapper.find('.postbox').length) {
+							next_step_wrapper.find('.edd-migration.allowed').show();
+							next_step_wrapper.find('.edd-migration.unavailable').hide();
+
+							if (auto_start_next_step) {
+								next_step_wrapper.find('.edd-export-form').submit();
+							}
+						} else {
+							$('#edd-migration-nav-warn').hide();
+							$('#edd-migration-ready').slideDown();
+						}
+
+					}
+				});
+			});
+		});
+	</script>
+
+	<div class="metabox-holder">
+		<div class="postbox">
+			<h2 class="hndle">
+				<span><?php _e( 'Update file download logs', 'easy-digital-downloads' ); ?></span>
+				<span class="dashicons dashicons-yes"></span>
+			</h2>
+			<div class="inside migrate-file-download-logs-control">
+				<p>
+					<?php _e( 'This will update the file download logs to remove some PII and make file download counts more accurate.', 'easy-digital-downloads' ); ?>
+				</p>
+				<form method="post" id="edd-fix-file-download-logs-form" class="edd-export-form edd-import-export-form">
+			<span class="step-instructions-wrapper">
+
+				<?php wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' ); ?>
+
+				<?php if ( ! $migration_complete ) : ?>
+					<span class="edd-migration allowed">
+						<input type="submit" id="migrate-logs-submit" value="<?php _e( 'Update File Download Logs', 'easy-digital-downloads' ); ?>" class="button-primary"/>
+					</span>
+				<?php else: ?>
+					<input type="submit" disabled="disabled" id="migrate-logs-submit" value="<?php _e( 'Update File Download Logs', 'easy-digital-downloads' ); ?>" class="button-secondary"/>
+					&mdash; <?php _e( 'File download logs have already been updated.', 'easy-digital-downloads' ); ?>
+				<?php endif; ?>
+
+				<input type="hidden" name="edd-export-class" value="EDD_File_Download_Log_Migration" />
+				<span class="spinner"></span>
+
+			</span>
+				</form>
+			</div><!-- .inside -->
+		</div><!-- .postbox -->
+	</div>
+
+	<?php
+}
+
+function edd_register_batch_file_download_log_migration() {
+	add_action( 'edd_batch_export_class_include', 'edd_include_file_download_log_migration_batch_processor', 10, 1 );
+}
+add_action( 'edd_register_batch_exporter', 'edd_register_batch_file_download_log_migration', 10 );
+
+
+function edd_include_file_download_log_migration_batch_processor( $class ) {
+
+	if ( 'EDD_File_Download_Log_Migration' === $class ) {
+		require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/classes/class-file-download-log-migration.php';
+	}
+
 }

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -1242,7 +1242,7 @@ function edd_upgrade_render_update_file_download_log_data() {
 			</h2>
 			<div class="inside migrate-file-download-logs-control">
 				<p>
-					<?php _e( 'This will update the file download logs to remove some PII and make file download counts more accurate.', 'easy-digital-downloads' ); ?>
+					<?php _e( 'This will update the file download logs to remove some <abbr title="Personally Identifiable Information">PII</abbr> and make file download counts more accurate.', 'easy-digital-downloads' ); ?>
 				</p>
 				<form method="post" id="edd-fix-file-download-logs-form" class="edd-export-form edd-import-export-form">
 			<span class="step-instructions-wrapper">

--- a/includes/admin/upgrades/upgrades.php
+++ b/includes/admin/upgrades/upgrades.php
@@ -20,68 +20,86 @@ if ( !defined( 'ABSPATH' ) ) exit;
 */
 function edd_upgrades_screen() {
 	$action = isset( $_GET['edd-upgrade'] ) ? sanitize_text_field( $_GET['edd-upgrade'] ) : '';
-	$step   = isset( $_GET['step'] )        ? absint( $_GET['step'] )                     : 1;
-	$total  = isset( $_GET['total'] )       ? absint( $_GET['total'] )                    : false;
-	$custom = isset( $_GET['custom'] )      ? absint( $_GET['custom'] )                   : 0;
-	$number = isset( $_GET['number'] )      ? absint( $_GET['number'] )                   : 100;
-	$steps  = round( ( $total / $number ), 0 );
-	if ( ( $steps * $number ) < $total ) {
-		$steps++;
-	}
+	?>
 
-	$doing_upgrade_args = array(
-		'page'        => 'edd-upgrades',
-		'edd-upgrade' => $action,
-		'step'        => $step,
-		'total'       => $total,
-		'custom'      => $custom,
-		'steps'       => $steps
-	);
-	update_option( 'edd_doing_upgrade', $doing_upgrade_args );
-	if ( $step > $steps ) {
-		// Prevent a weird case where the estimate was off. Usually only a couple.
-		$steps = $step;
+	<div class="wrap">
+	<h2><?php _e( 'Easy Digital Downloads - Upgrades', 'easy-digital-downloads' ); ?></h2>
+	<?php
+	if ( is_callable( 'edd_upgrade_render_' . $action ) ) {
+
+		// Until we have fully migrated all upgrade scripts to this new system, we will selectively enqueue the necessary scripts.
+		add_filter( 'edd_load_admin_scripts', '__return_true' );
+		edd_load_admin_scripts( '' );
+
+		// This is the new method to register an upgrade routine, so we can use an ajax and progress bar to display any needed upgrades.
+		call_user_func( 'edd_upgrade_render_' . $action );
+
+	} else {
+
+		// This is the legacy upgrade method, which requires a page refresh at each step.
+		$step   = isset( $_GET['step'] )        ? absint( $_GET['step'] )                     : 1;
+		$total  = isset( $_GET['total'] )       ? absint( $_GET['total'] )                    : false;
+		$custom = isset( $_GET['custom'] )      ? absint( $_GET['custom'] )                   : 0;
+		$number = isset( $_GET['number'] )      ? absint( $_GET['number'] )                   : 100;
+		$steps  = round( ( $total / $number ), 0 );
+		if ( ( $steps * $number ) < $total ) {
+			$steps++;
+		}
+
+		$doing_upgrade_args = array(
+			'page'        => 'edd-upgrades',
+			'edd-upgrade' => $action,
+			'step'        => $step,
+			'total'       => $total,
+			'custom'      => $custom,
+			'steps'       => $steps
+		);
+		update_option( 'edd_doing_upgrade', $doing_upgrade_args );
+		if ( $step > $steps ) {
+			// Prevent a weird case where the estimate was off. Usually only a couple.
+			$steps = $step;
+		}
+		?>
+
+			<?php if( ! empty( $action ) ) : ?>
+
+				<div id="edd-upgrade-status">
+					<p><?php _e( 'The upgrade process has started, please be patient. This could take several minutes. You will be automatically redirected when the upgrade is finished.', 'easy-digital-downloads' ); ?></p>
+
+					<?php if( ! empty( $total ) ) : ?>
+						<p><strong><?php printf( __( 'Step %d of approximately %d running', 'easy-digital-downloads' ), $step, $steps ); ?></strong></p>
+					<?php endif; ?>
+				</div>
+				<script type="text/javascript">
+					setTimeout(function() { document.location.href = "index.php?edd_action=<?php echo $action; ?>&step=<?php echo $step; ?>&total=<?php echo $total; ?>&custom=<?php echo $custom; ?>"; }, 250);
+				</script>
+
+			<?php else : ?>
+
+				<div id="edd-upgrade-status">
+					<p>
+						<?php _e( 'The upgrade process has started, please be patient. This could take several minutes. You will be automatically redirected when the upgrade is finished.', 'easy-digital-downloads' ); ?>
+						<img src="<?php echo EDD_PLUGIN_URL . '/assets/images/loading.gif'; ?>" id="edd-upgrade-loader"/>
+					</p>
+				</div>
+				<script type="text/javascript">
+					jQuery( document ).ready( function() {
+						// Trigger upgrades on page load
+						var data = { action: 'edd_trigger_upgrades' };
+						jQuery.post( ajaxurl, data, function (response) {
+							if( response == 'complete' ) {
+								jQuery('#edd-upgrade-loader').hide();
+								document.location.href = 'index.php'; // Redirect to the dashboard
+							}
+						});
+					});
+				</script>
+
+			<?php endif; ?>
+
+		<?php
 	}
 	?>
-	<div class="wrap">
-		<h2><?php _e( 'Easy Digital Downloads - Upgrades', 'easy-digital-downloads' ); ?></h2>
-
-		<?php if( ! empty( $action ) ) : ?>
-
-			<div id="edd-upgrade-status">
-				<p><?php _e( 'The upgrade process has started, please be patient. This could take several minutes. You will be automatically redirected when the upgrade is finished.', 'easy-digital-downloads' ); ?></p>
-
-				<?php if( ! empty( $total ) ) : ?>
-					<p><strong><?php printf( __( 'Step %d of approximately %d running', 'easy-digital-downloads' ), $step, $steps ); ?></strong></p>
-				<?php endif; ?>
-			</div>
-			<script type="text/javascript">
-				setTimeout(function() { document.location.href = "index.php?edd_action=<?php echo $action; ?>&step=<?php echo $step; ?>&total=<?php echo $total; ?>&custom=<?php echo $custom; ?>"; }, 250);
-			</script>
-
-		<?php else : ?>
-
-			<div id="edd-upgrade-status">
-				<p>
-					<?php _e( 'The upgrade process has started, please be patient. This could take several minutes. You will be automatically redirected when the upgrade is finished.', 'easy-digital-downloads' ); ?>
-					<img src="<?php echo EDD_PLUGIN_URL . '/assets/images/loading.gif'; ?>" id="edd-upgrade-loader"/>
-				</p>
-			</div>
-			<script type="text/javascript">
-				jQuery( document ).ready( function() {
-					// Trigger upgrades on page load
-					var data = { action: 'edd_trigger_upgrades' };
-					jQuery.post( ajaxurl, data, function (response) {
-						if( response == 'complete' ) {
-							jQuery('#edd-upgrade-loader').hide();
-							document.location.href = 'index.php'; // Redirect to the dashboard
-						}
-					});
-				});
-			</script>
-
-		<?php endif; ?>
-
 	</div>
 	<?php
 }

--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -306,7 +306,7 @@ class EDD_API_V2 extends EDD_API_V1 {
 
 				$customers['customers'][ $customer_count ]['stats']['total_purchases'] = $customer_obj->purchase_count;
 				$customers['customers'][ $customer_count ]['stats']['total_spent']     = $customer_obj->purchase_value;
-				$customers['customers'][ $customer_count ]['stats']['total_downloads'] = edd_count_file_downloads_of_user( $customer_obj->email );
+				$customers['customers'][ $customer_count ]['stats']['total_downloads'] = edd_count_file_downloads_of_customer( $customer_obj->id );
 
 				$customer_count++;
 

--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1044,7 +1044,7 @@ class EDD_API {
 
 				$customers['customers'][$customer_count]['stats']['total_purchases'] = $customer_obj->purchase_count;
 				$customers['customers'][$customer_count]['stats']['total_spent']     = $customer_obj->purchase_value;
-				$customers['customers'][$customer_count]['stats']['total_downloads'] = edd_count_file_downloads_of_user( $customer_obj->email );
+				$customers['customers'][$customer_count]['stats']['total_downloads'] = edd_count_file_downloads_of_customer( $customer_obj->id );
 
 				$customer_count++;
 

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -635,7 +635,7 @@ function edd_record_sale_in_log( $download_id = 0, $payment_id, $price_id = fals
  * @global $edd_logs
  * @param int $download_id Download ID
  * @param int $file_id ID of the file downloaded
- * @param array $user_info User information
+ * @param array $user_info User information (Deprecated)
  * @param string $ip IP Address
  * @param int $payment_id Payment ID
  * @param int $price_id Price ID, if any
@@ -645,19 +645,19 @@ function edd_record_download_in_log( $download_id = 0, $file_id, $user_info, $ip
 	global $edd_logs;
 
 	$log_data = array(
-		'post_parent'	=> $download_id,
-		'log_type'		=> 'file_download'
+		'post_parent' => $download_id,
+		'log_type'    => 'file_download',
 	);
 
-	$user_id = isset( $user_info['id'] ) ? $user_info['id'] : (int) -1;
+	$payment = new EDD_Payment( $payment_id );
 
 	$log_meta = array(
-		'user_info'	=> $user_info,
-		'user_id'	=> $user_id,
-		'file_id'	=> (int) $file_id,
-		'ip'		=> $ip,
-		'payment_id'=> $payment_id,
-		'price_id'  => (int) $price_id
+		'customer_id' => $payment->customer_id,
+		'user_id'     => $payment->user_id,
+		'file_id'     => (int) $file_id,
+		'ip'          => $ip,
+		'payment_id'  => $payment_id,
+		'price_id'    => (int) $price_id,
 	);
 
 	$edd_logs->insert_log( $log_data, $log_meta );

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -354,7 +354,7 @@ function edd_purchase_total_of_user( $user = null ) {
 }
 
 /**
- * Counts the total number of files a customer has downloaded
+ * Counts the total number of files a user (or customer if an email address is given) has downloaded
  *
  * @since       1.3
  * @param       mixed $user - ID or email
@@ -364,13 +364,10 @@ function edd_count_file_downloads_of_user( $user ) {
 	global $edd_logs;
 
 	if ( is_email( $user ) ) {
-		$meta_query = array(
-			array(
-				'key'     => '_edd_log_user_info',
-				'value'   => $user,
-				'compare' => 'LIKE'
-			)
-		);
+
+		// If we got an email, look up the customer ID and call the direct query for customer download counts.
+		return edd_count_file_downloads_of_customer( $user );
+
 	} else {
 		$meta_query = array(
 			array(
@@ -379,6 +376,27 @@ function edd_count_file_downloads_of_user( $user ) {
 			)
 		);
 	}
+
+	return $edd_logs->get_log_count( null, 'file_download', $meta_query );
+}
+
+/**
+ * Counts the total number of files a customer has downloaded.
+ *
+ * @param string|int $customer_id_or_email The email address or id of the customer.
+ *
+ * @return int The total number of files the customer has downloaded.
+ */
+function edd_count_file_downloads_of_customer( $customer_id_or_email = '' ) {
+	global $edd_logs;
+
+	$customer = new EDD_Customer( $customer_id_or_email );
+	$meta_query = array(
+		array(
+			'key'   => '_edd_log_customer_id',
+			'value' => $customer->id,
+		)
+	);
 
 	return $edd_logs->get_log_count( null, 'file_download', $meta_query );
 }


### PR DESCRIPTION
Fixes #6548

Proposed Changes:
1. Adds a migration routine to kill the `_edd_log_user_info` for the file download logs and add `_edd_log_customer_id` for the file download logs
2. Adds `edd_count_file_downloads_of_customer` to return the file download count of a customer record.
3. Updates `edd_count_file_downloads_of_user` to switch to the `edd_count_file_downloads_of_customer` function if the string is an email (this is what it was doing previously anyway, now it's explicit)
4. Updates the list table to use the proper customer ID instead of always performing searches on users (users mean nothing to EDD for the most part, customer should be our canonical).
5. Updates the file download log list table to search customers, not users (as a canonical source)
6. Updates the Customers API endpoint to send the customer ID, directly.

Overall, this is far more accurate to count a customer's download count. The previous method was doing a `LIKE` search on the user info, but if a customer changed their primary email address, the logs would not be updated, so the search would be in accurate. By converting all searches for customer download counts to use the `$customer->id` the email address is irrelevant.

By removing the log user info for this type of log, we're removing PII which makes us easier to comply with GDPR.