### PR TITLE
issue/6553 - encode email string when removing email address

### DIFF
--- a/templates/shortcode-profile-editor.php
+++ b/templates/shortcode-profile-editor.php
@@ -112,7 +112,7 @@ if ( is_user_logged_in() ):
 									$remove_url = wp_nonce_url(
 										add_query_arg(
 											array(
-												'email'      => $email,
+												'email'      => rawurlencode( $email ),
 												'edd_action' => 'profile-remove-email',
 												'redirect'   => esc_url( edd_get_current_page_url() ),
 											)


### PR DESCRIPTION
Fixes #6553

Proposed Changes:
1. Encode the email address when it's being removed via [edd_profile_editor]