### PR TITLE
Anonymize customer records when user delete requests are executed #6498

### DIFF
--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -118,6 +118,38 @@ function edd_pseudo_mask_email( $email_address ) {
 }
 
 /**
+ * Return an anonymized email address.
+ *
+ * While WP Core supports anonymizing email addresses with the wp_privacy_anonymize_data function,
+ * it turns every email address into deleted@site.invalid, which does not work when some purchase/customer records
+ * are still needed for legal and regulatory reasons.
+ *
+ * This function will anonymize the email with an MD5 that is salted
+ * and given a randomized uniqid prefixed with the store URL in order to prevent connecting a single customer across
+ * multiple stores, as well as the timestamp at the time of anonymization (so it trying the same email again will not be
+ * repeatable and therefore connected), and return the email address as <hash>@site.invalid.
+ *
+ * @since 2.9.2
+ *
+ * @param string $email_address
+ *
+ * @return string
+ */
+function edd_anonymize_email( $email_address ) {
+
+	if ( empty( $email_address ) ) {
+		return $email_address;
+	}
+
+	$email_address    = strtolower( $email_address );
+	$email_parts      = explode( '@', $email_address );
+	$anonymized_email = wp_hash( uniqid( get_option( 'site_url' ), true ) . $email_parts[0] . current_time( 'timestamp' ), 'nonce' );
+
+
+	return $anonymized_email . '@site.invalid';
+}
+
+/**
  * Register any of our Privacy Data Exporters
  *
  * @since 2.9.2

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -174,13 +174,6 @@ function edd_anonymize_customer( $customer_id = 0 ) {
 		return array( 'success' => false, 'message' => sprintf( __( 'No customer with ID %d', 'easy-digital-downloads' ), $customer_id ) );
 	}
 
-	$customer->update( array(
-		'name'         => __( 'Anonymized Customer', 'easy-digital-downloads' ),
-		'email'        => edd_anonymize_email( $customer->email ),
-		'date_created' => date( 'Y-m-d H:i:s', 0 ),
-		'notes'        => '',
-	) );
-
 	// Loop through all their email addresses, and remove any additional email addresses.
 	foreach ( $customer->emails as $email ) {
 		$customer->remove_email( $email );
@@ -189,6 +182,14 @@ function edd_anonymize_customer( $customer_id = 0 ) {
 	if ( $customer->user_id > 0 ) {
 		delete_user_meta( $customer->user_id, '_edd_user_address' );
 	}
+
+	$customer->update( array(
+		'name'         => __( 'Anonymized Customer', 'easy-digital-downloads' ),
+		'email'        => edd_anonymize_email( $customer->email ),
+		'date_created' => date( 'Y-m-d H:i:s', 0 ),
+		'notes'        => '',
+		'user_id'      => 0,
+	) );
 
 	/**
 	 * Run further anonymization on a customer

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -400,3 +400,60 @@ function edd_privacy_billing_information_exporter( $email_address = '', $page = 
 	);
 
 }
+
+/**
+ * Given a customer ID, anonymize the data related to that customer.
+ *
+ * Only the customer record is affected in this function. The data that is changed:
+ * - The name is changed to 'Anonymized Customer'
+ * - The email address is anonymized, but kept in a format that passes is_email checks
+ * - The date created is set to the timestamp of 0 (January 1, 1970)
+ * - Notes are fully cleared
+ * - Any additional email addresses are removed
+ *
+ * Once completed, a note is left stating when the customer was anonymized.
+ *
+ * @param int $customer_id
+ *
+ * @return array
+ */
+function edd_anonymize_customer( $customer_id = 0 ) {
+
+	$customer = new EDD_Customer( $customer_id );
+	if ( empty( $customer->id ) ) {
+		return array( 'success' => false, 'message' => sprintf( __( 'No customer with ID %d', 'easy-digital-downloads' ), $customer_id ) );
+	}
+
+	$customer->update( array(
+		'name'         => __( 'Anonymized Customer', 'easy-digital-downloads' ),
+		'email'        => edd_anonymize_email( $customer->email ),
+		'date_created' => date( 'Y-m-d H:i:s', 0 ),
+		'notes'        => '',
+	) );
+
+	// Loop through all their email addresses, and remove any additional email addresses.
+	foreach ( $customer->emails as $email ) {
+		$customer->remove_email( $email );
+	}
+
+	if ( $customer->user_id > 0 ) {
+		delete_user_meta( $customer->user_id, '_edd_user_address' );
+	}
+
+	/**
+	 * Run further anonymization on a customer
+	 *
+	 * Developers and extensions can use the EDD_Customer object passed into the edd_anonymize_customer action
+	 * to complete further anonymization.
+	 *
+	 * @since 2.9.2
+	 *
+	 * @param EDD_Customer $customer The EDD_Customer object that was found.
+	 */
+	do_action( 'edd_anonymize_customer', $customer );
+
+	$customer->add_note( __( 'Customer anonymized successfully' ) );
+	return array( 'success' => true, 'message' => sprintf( __( 'Customer ID %d successfully anonymized', 'easy-digital-downloads' ), $customer_id ) );
+
+
+}


### PR DESCRIPTION
Fixes #6498

Proposed Changes:
1. Adds `edd_anonymize_email`, which hashes an email address with `<hash>@site.invalid`
2. Adds `edd_anonymize_customer`, which does the following:
```
- The name is changed to 'Anonymized Customer'
- The email address is anonymized, but kept in a format that passes is_email checks
- The date created is set to the timestamp of 0 (January 1, 1970)
- Notes are fully cleared
- Any additional email addresses are removed
```
3. Adds the `edd_register_privacy_erasers` function to help us register our erasers/anonymizers
4. Adds `edd_privacy_customer_eraser` which executes on the eraser/anonymizer
