### PR TITLE
Add payment anonymizer/eraser that integrates with WP Core

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1402,7 +1402,7 @@ function edd_get_registered_settings_sections() {
 			'file_downloads'     => __( 'File Downloads', 'easy-digital-downloads' ),
 			'accounting'         => __( 'Accounting', 'easy-digital-downloads' ),
 			'site_terms'         => __( 'Terms of Agreement', 'easy-digital-downloads' ),
-			'privacy'            => __( 'Privacy Settings', 'easy-digital-downloads' ),
+			'privacy'            => __( 'Privacy', 'easy-digital-downloads' ),
 		) ),
 	);
 

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -903,15 +903,63 @@ function edd_get_registered_settings() {
 						'id'   => 'privacy_agree_page',
 						'name' => __( 'Privacy Agreement Page', 'easy-digital-downloads' ),
 						'desc' => __( 'If Agree to Privacy Policy is checked, select a page for the Privacy Agreement here.', 'easy-digital-downloads' ),
-						'type'        => 'select',
+						'type'        => 'se 	lect',
 						'options'     => edd_get_pages(),
 						'chosen'      => true,
 						'placeholder' => __( 'Select a page', 'easy-digital-downloads' ),
 					),
 				),
+				'privacy' => array(),
 			)
 		)
 	);
+
+	$payment_statuses = edd_get_payment_statuses();
+
+	$edd_settings['misc']['privacy'][] = array(
+		'id' => 'payment_privacy_status_action_descriptive_text',
+		'name' => '<h4>' . __( 'Payment Status Actions', 'easy-digital-downloads' ) . '</h4>',
+		'desc' => __( 'When a user requests to be anonymized or removed from a site, these are the actions that will be taken on payments associated with their customer, by status.','easy-digital-downloads' ),
+		'type' => 'descriptive_text',
+	);
+
+	foreach ( $payment_statuses as $status => $label ) {
+
+		switch ( $status ) {
+
+			case 'publish':
+			case 'refunded':
+			case 'revoked':
+				$action = 'anonymize';
+				break;
+
+			case 'failed':
+			case 'abandoned':
+				$action = 'delete';
+				break;
+
+			case 'pending':
+			case 'processing':
+			default:
+				$action = 'none';
+				break;
+
+		}
+
+		$edd_settings['misc']['privacy'][] = array(
+			'id'   => 'payment_privacy_status_action_' . $status,
+			'name' => sprintf( _x( '%s Payments', 'payment status labels: Pending Payments', 'easy-digital-downloads' ), $label ),
+			'desc' => '',
+			'type'        => 'select',
+			'options'     => array(
+				'none'      => __( 'None', 'easy-digital-downloads' ),
+				'anonymize' => __( 'Anonymize', 'easy-digital-downloads' ),
+				'delete'    => __( 'Delete', 'easy-digital-downloads' ),
+			),
+			'std'         => $action,
+		);
+
+	}
 
 	if ( ! edd_shop_supports_buy_now() ) {
 		$edd_settings['misc']['button_text']['buy_now_text']['disabled']      = true;
@@ -1354,6 +1402,7 @@ function edd_get_registered_settings_sections() {
 			'file_downloads'     => __( 'File Downloads', 'easy-digital-downloads' ),
 			'accounting'         => __( 'Accounting', 'easy-digital-downloads' ),
 			'site_terms'         => __( 'Terms of Agreement', 'easy-digital-downloads' ),
+			'privacy'            => __( 'Privacy Settings', 'easy-digital-downloads' ),
 		) ),
 	);
 

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -903,7 +903,7 @@ function edd_get_registered_settings() {
 						'id'   => 'privacy_agree_page',
 						'name' => __( 'Privacy Agreement Page', 'easy-digital-downloads' ),
 						'desc' => __( 'If Agree to Privacy Policy is checked, select a page for the Privacy Agreement here.', 'easy-digital-downloads' ),
-						'type'        => 'se 	lect',
+						'type'        => 'select',
 						'options'     => edd_get_pages(),
 						'chosen'      => true,
 						'placeholder' => __( 'Select a page', 'easy-digital-downloads' ),

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -908,6 +908,8 @@ class EDD_Payment {
 						break;
 
 					case 'email':
+						$this->payment_meta['email'] = $this->email;
+						$this->user_info['email']    = $this->email;
 						$this->update_meta( '_edd_payment_user_email', $this->email );
 						break;
 
@@ -992,8 +994,9 @@ class EDD_Payment {
 				'cart_details'  => $this->cart_details,
 				'fees'          => $this->fees,
 				'currency'      => $this->currency,
-				'user_info'     => is_array( $this->user_info ) ? array_filter( $this->user_info ) : array(),
-				'date'          => $this->date
+				'user_info'     => is_array( $this->user_info ) ? $this->user_info : array(),
+				'date'          => $this->date,
+				'email'         => $this->email,
 			);
 
 			// Do some merging of user_info before we merge it all, to honor the edd_payment_meta filter

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -198,7 +198,12 @@ function _edd_anonymize_customer( $customer_id = 0 ) {
 
 	// Now we should look at payments this customer has associated, and if there are an payments that should not be modified,
 	// do not modify the customer.
-	$payments = edd_get_payments( array( 'post__in' => implode( ',', $customer->payment_ids ), 'output' => 'payments' ) );
+	$payments = edd_get_payments( array(
+		'customer' => $customer->id,
+		'output'   => 'payments',
+		'number'   => -1,
+	) );
+
 	foreach ( $payments as $payment ) {
 		$action = _edd_privacy_get_payment_action( $payment );
 		if ( 'none' === $action ) {

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -118,6 +118,38 @@ function edd_pseudo_mask_email( $email_address ) {
 }
 
 /**
+ * Return an anonymized email address.
+ *
+ * While WP Core supports anonymizing email addresses with the wp_privacy_anonymize_data function,
+ * it turns every email address into deleted@site.invalid, which does not work when some purchase/customer records
+ * are still needed for legal and regulatory reasons.
+ *
+ * This function will anonymize the email with an MD5 that is salted
+ * and given a randomized uniqid prefixed with the store URL in order to prevent connecting a single customer across
+ * multiple stores, as well as the timestamp at the time of anonymization (so it trying the same email again will not be
+ * repeatable and therefore connected), and return the email address as <hash>@site.invalid.
+ *
+ * @since 2.9.2
+ *
+ * @param string $email_address
+ *
+ * @return string
+ */
+function edd_anonymize_email( $email_address ) {
+
+	if ( empty( $email_address ) ) {
+		return $email_address;
+	}
+
+	$email_address    = strtolower( $email_address );
+	$email_parts      = explode( '@', $email_address );
+	$anonymized_email = wp_hash( uniqid( get_option( 'site_url' ), true ) . $email_parts[0] . current_time( 'timestamp' ), 'nonce' );
+
+
+	return $anonymized_email . '@site.invalid';
+}
+
+/**
  * Register any of our Privacy Data Exporters
  *
  * @since 2.9.2

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -369,7 +369,7 @@ function _edd_anonymize_payment( $payment_id = 0 ) {
  */
 function _edd_privacy_get_payment_action( EDD_Payment $payment ) {
 
-	$action = edd_get_option( 'payment_privacy_status_action' . $payment->status, false );
+	$action = edd_get_option( 'payment_privacy_status_action_' . $payment->status, false );
 
 	// If the store owner has not saved any special settings for the actions to be taken, use defaults.
 	if ( empty( $action ) ) {

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -686,7 +686,7 @@ function edd_register_privacy_eraser_customer_id_lookup( $erasers = array() ) {
 
 	return $erasers;
 }
-add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers', 1, 5 );
+add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_eraser_customer_id_lookup', 5, 1 );
 
 /**
  * Lookup the customer ID for this email address so that we can use it later in the anonymization process.
@@ -698,13 +698,12 @@ add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers', 
  */
 function edd_privacy_prefetch_customer_id( $email_address, $page = 1 ) {
 	$customer = new EDD_Customer( $email_address );
-
 	update_option( 'edd_priv_' . md5( $email_address ), $customer->id, false );
 
 	return array(
 		'items_removed'  => false,
 		'items_retained' => false,
-		'messages'       => '',
+		'messages'       => array(),
 		'done'           => true,
 	);
 }
@@ -724,7 +723,7 @@ function edd_register_privacy_eraser_customer_id_removal( $erasers = array() ) {
 
 	return $erasers;
 }
-add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers', 1, 9999 );
+add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_eraser_customer_id_removal', 9999, 1 );
 
 /**
  * Delete the customer ID for this email address that was found in edd_privacy_prefetch_customer_id()
@@ -740,7 +739,7 @@ function edd_privacy_remove_customer_id( $email_address, $page = 1 ) {
 	return array(
 		'items_removed'  => false,
 		'items_retained' => false,
-		'messages'       => '',
+		'messages'       => array(),
 		'done'           => true,
 	);
 }
@@ -770,7 +769,7 @@ function edd_register_privacy_erasers( $erasers = array() ) {
 	return $erasers;
 
 }
-add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers' );
+add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers', 11, 1 );
 
 /**
  * Anonymize a customer record through the WP Core Privacy Data Eraser methods.

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -196,7 +196,7 @@ function _edd_anonymize_customer( $customer_id = 0 ) {
 		return array( 'success' => false, 'message' => $should_anonymize_customer['message'] );
 	}
 
-	// Now we should look at payments this customer has associated, and if there are an payments that should not be modified,
+	// Now we should look at payments this customer has associated, and if there are any payments that should not be modified,
 	// do not modify the customer.
 	$payments = edd_get_payments( array(
 		'customer' => $customer->id,

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -741,6 +741,8 @@ function edd_privacy_payment_eraser( $email_address, $page = 1 ) {
 		if ( ! is_null( $items_removed ) && ! $result['success'] ) {
 			$items_retained = true;
 		}
+
+		$messages[] = $result['message'];
 	}
 
 

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -167,7 +167,7 @@ function edd_anonymize_email( $email_address ) {
  *
  * @return array
  */
-function edd_anonymize_customer( $customer_id = 0 ) {
+function _edd_anonymize_customer( $customer_id = 0 ) {
 
 	$customer = new EDD_Customer( $customer_id );
 	if ( empty( $customer->id ) ) {
@@ -228,6 +228,153 @@ function edd_anonymize_customer( $customer_id = 0 ) {
 	$customer->add_note( __( 'Customer anonymized successfully' ) );
 	return array( 'success' => true, 'message' => sprintf( __( 'Customer ID %d successfully anonymized', 'easy-digital-downloads' ), $customer_id ) );
 
+}
+
+/**
+ * Given a payment ID, anonymize the data related to that payment.
+ *
+ * Only the payment record is affected in this function. The data that is changed:
+ * - First Name is made blank
+ * - Last  Name is made blank
+ * - All email addresses are converted to the anonymized email address on the customer
+ * - The IP address is run to only be the /24 IP Address (ending in .0) so it cannot be traced back to a user
+ * - Address line 1 is made blank
+ * - Address line 2 is made blank
+ *
+ * @param int $payment_id
+ *
+ * @return array
+ */
+function _edd_anonymize_payment( $payment_id = 0 ) {
+
+	$payment = edd_get_payment( $payment_id );
+	if ( false === $payment ) {
+		return array( 'success' => false, 'message' => sprintf( __( 'No payment with ID %d', 'easy-digital-downloads' ), $payment_id ) );
+	}
+
+	/**
+	 * Determines if this payment should be allowed to be anonymized.
+	 *
+	 * Developers and extensions can use this filter to make it possible to not anonymize a payment. A sample use case
+	 * would be if the payment is pending orders, and the payment requires shipping, anonymizing the payment may
+	 * not be ideal.
+	 *
+	 * @since 2.9.2
+	 *
+	 * @param array {
+	 *     Contains data related to if the anonymization should take place
+	 *
+	 *     @type bool   $should_anonymize If the payment should be anonymized.
+	 *     @type string $message          A message to display if the customer could not be anonymized.
+	 * }
+	 */
+	$should_anonymize_payment = apply_filters( 'edd_should_anonymize_payment', array( 'should_anonymize' => true, 'message' => array() ), $payment );
+
+	if ( ! $should_anonymize_payment['should_anonymize'] ) {
+		return array( 'success' => false, 'message' => $should_anonymize_payment['message'] );
+	}
+
+	$statues = edd_get_payment_status_keys();
+	$payment_status_actions = array();
+	foreach ( $statues as $status ) {
+
+		switch ( $status ) {
+
+			case 'publish':
+			case 'refunded':
+			case 'revoked':
+				$action = 'anonymize';
+				break;
+
+			case 'failed':
+			case 'abandoned':
+				$action = 'delete';
+				break;
+
+			case 'pending':
+			case 'processing':
+			default:
+				$action = 'none';
+				break;
+
+		}
+
+		/**
+		 * Allow filtering of what type of action should be taken for a payment.
+		 *
+		 * Developers and extensions can use this filter to modify how Easy Digital Downloads will treat an order
+		 * that has been requested to be deleted or anonymized.
+		 *
+		 * @since 2.9.2
+		 *
+		 * @param string      $action  What action will be performed (none, delete, anonymize)
+		 * @param EDD_Payment $payment The EDD_Payment object that has been requested to be anonymized or deleted.
+		 */
+		$payment_status_actions[ $status ] = apply_filters( 'edd_privacy_payment_status_action_' . $action, $action, $payment );
+	}
+
+	switch( $payment_status_actions[ $payment->status ] ) {
+
+		case 'none':
+		default:
+			$return = array(
+				'success' => false,
+				'message' => sprintf( __( 'Payment not modified, due to status: %s.', 'easy-digital-downloads' ), $payment->status )
+			);
+			break;
+
+		case 'delete':
+			edd_delete_purchase( $payment->ID, true, true );
+
+			$return = array(
+				'success' => true,
+				'message' => sprintf( __( 'Payment %d with status %s deleted.', 'easy-digital-downloads' ), $payment->ID, $payment->status )
+			);
+			break;
+
+		case 'anonymize':
+			$customer = new EDD_Customer( $payment->customer_id );
+
+			$payment->ip    = wp_privacy_anonymize_ip( $payment->ip );
+			$payment->email = $customer->email;
+
+			// Anonymize the line 1 and line 2 of the address. City, state, zip, and country are possibly needed for taxes.
+			$address = $payment->address;
+			if ( isset( $address['line1'] ) ) {
+				$address['line1'] = '';
+			}
+
+			if ( isset( $address['line2'] ) ) {
+				$address['line2'] = '';
+			}
+
+			$payment->address = $address;
+
+			$payment->first_name = '';
+			$payment->last_name  = '';
+
+
+			/**
+			 * Run further anonymization on a payment
+			 *
+			 * Developers and extensions can use the EDD_Payment object passed into the edd_anonymize_payment action
+			 * to complete further anonymization.
+			 *
+			 * @since 2.9.2
+			 *
+			 * @param EDD_Payment $payment The EDD_Payment object that was found.
+			 */
+			do_action( 'edd_anonymize_payment', $payment );
+
+			$payment->save();
+			$return = array(
+				'success' => true,
+				'message' => sprintf( __( 'Payment ID %d successfully anonymized', 'easy-digital-downloads' ), $payment_id )
+			);
+			break;
+	}
+
+	return $return;
 }
 
 /** Exporter Functions */
@@ -494,13 +641,52 @@ function edd_privacy_billing_information_exporter( $email_address = '', $page = 
  * @return array
  */
 function edd_register_privacy_erasers( $erasers = array() ) {
+
+	// The order of these matter, customer needs to be anonymized prior to the customer, so that the payment can adopt
+	// properties of the customer like email.
+
 	$erasers[] = array(
 		'eraser_friendly_name' => __( 'Customer Record', 'easy-digital-downloads' ),
 		'callback'             => 'edd_privacy_customer_eraser',
 	);
+
+	$erasers[] = array(
+		'eraser_friendly_name' => __( 'Payment Record', 'easy-digital-downloads' ),
+		'callback'             => 'edd_privacy_payment_eraser',
+	);
 	return $erasers;
+
 }
 add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers' );
+
+/**
+	 * Anonymize a customer record through the WP Core Privacy Data Eraser methods.
+	 *
+	 * @param     $email_address
+	 * @param int $page
+	 *
+	 * @return array
+	 */
+	function edd_privacy_customer_eraser( $email_address, $page = 1 ) {
+		$customer = new EDD_Customer( $email_address );
+
+		$anonymized = _edd_anonymize_customer( $customer->id );
+		if ( empty( $anonymized['success'] ) ) {
+			return array(
+				'items_removed'  => false,
+				'items_retained' => false,
+				'messages'       => array( $anonymized['message'] ),
+				'done'           => true,
+			);
+		}
+
+		return array(
+			'items_removed'  => true,
+			'items_retained' => false,
+			'messages'       => array( sprintf( __( 'Customer for %s has been anonymized.', 'easy-digital-downloads' ), $email_address ) ),
+			'done'           => true,
+		);
+}
 
 /**
  * Anonymize a customer record through the WP Core Privacy Data Eraser methods.
@@ -510,23 +696,59 @@ add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers' )
  *
  * @return array
  */
-function edd_privacy_customer_eraser( $email_address, $page = 1 ) {
+function edd_privacy_payment_eraser( $email_address, $page = 1 ) {
 	$customer = new EDD_Customer( $email_address );
 
-	$anonymized = edd_anonymize_customer( $customer->id );
-	if ( empty( $anonymized['success'] ) ) {
+	// First get any payment IDs found with this email address attached.
+	$found_payment_ids = edd_get_payments( array(
+		'fields' => 'ids',
+		'user'   => $email_address,
+		'page'   => $page
+
+	) );
+
+	// If a customer was found, also get their attached payment IDs.
+	if ( ! empty( $customer->id ) ) {
+		$found_payment_ids = array_merge( $found_payment_ids, explode( ',', $customer->payment_ids ) );
+	}
+
+	$found_payment_ids = array_map( 'trim', array_unique( $found_payment_ids ) );
+
+	if ( empty( $found_payment_ids ) ) {
+
+		$message = 1 === $page ?
+			sprintf( __( 'No payments found for %s', 'easy-digital-downloads' ), $email_address ) :
+			sprintf( __( 'All eligible payments anonymized or deleted for %s', 'easy-digital-downloads' ), $email_address );
+
 		return array(
 			'items_removed'  => false,
 			'items_retained' => false,
-			'messages'       => array( $anonymized['message'] ),
+			'messages'       => array( $message ),
 			'done'           => true,
 		);
 	}
 
+	$items_removed  = null;
+	$items_retained = null;
+	$messages       = array();
+	foreach ( $found_payment_ids as $payment_id ) {
+		$result = _edd_anonymize_payment( $payment_id );
+
+		if ( ! is_null( $items_removed ) && $result['success'] ) {
+			$items_removed = true;
+		}
+
+		if ( ! is_null( $items_removed ) && ! $result['success'] ) {
+			$items_retained = true;
+		}
+	}
+
+
+
 	return array(
-		'items_removed'  => true,
-		'items_retained' => false,
-		'messages'       => array( sprintf( __( 'Customer for %s has been anonymized.', 'easy-digital-downloads' ), $email_address ) ),
-		'done'           => true,
+		'items_removed'  => ! is_null( $items_removed ) ? $items_removed : false,
+		'items_retained' => ! is_null( $items_retained ) ? $items_retained : false,
+		'messages'       => $messages,
+		'done'           => false,
 	);
 }

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -174,13 +174,6 @@ function edd_anonymize_customer( $customer_id = 0 ) {
 		return array( 'success' => false, 'message' => sprintf( __( 'No customer with ID %d', 'easy-digital-downloads' ), $customer_id ) );
 	}
 
-	$customer->update( array(
-		'name'         => __( 'Anonymized Customer', 'easy-digital-downloads' ),
-		'email'        => edd_anonymize_email( $customer->email ),
-		'date_created' => date( 'Y-m-d H:i:s', 0 ),
-		'notes'        => '',
-	) );
-
 	// Loop through all their email addresses, and remove any additional email addresses.
 	foreach ( $customer->emails as $email ) {
 		$customer->remove_email( $email );
@@ -189,6 +182,14 @@ function edd_anonymize_customer( $customer_id = 0 ) {
 	if ( $customer->user_id > 0 ) {
 		delete_user_meta( $customer->user_id, '_edd_user_address' );
 	}
+
+	$customer->update( array(
+		'name'         => __( 'Anonymized Customer', 'easy-digital-downloads' ),
+		'email'        => edd_anonymize_email( $customer->email ),
+		'date_created' => date( 'Y-m-d H:i:s', 0 ),
+		'notes'        => '',
+		'user_id'      => 0,
+	) );
 
 	/**
 	 * Run further anonymization on a customer

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -414,6 +414,24 @@ function _edd_privacy_get_payment_action( EDD_Payment $payment ) {
 
 }
 
+/**
+ * Since our eraser callbacks need to look up a stored customer ID by hashed email address, developers can use this
+ * to retrieve the customer ID associated with an email address that's being requested to be deleted even after the
+ * customer has been anonymized.
+ *
+ * @since 2.9.2
+ *
+ * @param $email_address
+ *
+ * @return EDD_Customer
+ */
+function _edd_privacy_get_customer_id_for_email( $email_address ) {
+	$customer_id = get_option( 'edd_priv_' . md5( $email_address ), true );
+	$customer    = new EDD_Customer( $customer_id );
+
+	return $customer;
+}
+
 /** Exporter Functions */
 
 /**
@@ -780,8 +798,7 @@ add_filter( 'wp_privacy_personal_data_erasers', 'edd_register_privacy_erasers', 
  * @return array
  */
 function edd_privacy_customer_eraser( $email_address, $page = 1 ) {
-	$customer_id = get_option( 'edd_priv_' . md5( $email_address ), true );
-	$customer    = new EDD_Customer( $customer_id );
+	$customer = _edd_privacy_get_customer_id_for_email( $email_address );
 
 	$anonymized = _edd_anonymize_customer( $customer->id );
 	if ( empty( $anonymized['success'] ) ) {
@@ -810,8 +827,7 @@ function edd_privacy_customer_eraser( $email_address, $page = 1 ) {
  * @return array
  */
 function edd_privacy_payment_eraser( $email_address, $page = 1 ) {
-	$customer_id = get_option( 'edd_priv_' . md5( $email_address ), true );
-	$customer    = new EDD_Customer( $customer_id );
+	$customer = _edd_privacy_get_customer_id_for_email( $email_address );
 
 	$payments = edd_get_payments( array(
 		'customer' => $customer->id,

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -400,3 +400,60 @@ function edd_privacy_billing_information_exporter( $email_address = '', $page = 
 	);
 
 }
+
+/**
+ * Given a customer ID, anonymize the data related to that customer.
+ *
+ * Only the customer record is affected in this function. The data that is changed:
+ * - The name is changed to 'Anonymized Customer'
+ * - The email address is anonymized, but kept in a format that passes is_email checks
+ * - The date created is set to the timestamp of 0 (January 1, 1970)
+ * - Notes are fully cleared
+ * - Any additional email addresses are removed
+ *
+ * Once completed, a note is left stating when the customer was anonymized.
+ *
+ * @param int $customer_id
+ *
+ * @return array
+ */
+function edd_anonymize_customer( $customer_id = 0 ) {
+
+	$customer = new EDD_Customer( $customer_id );
+	if ( empty( $customer->id ) ) {
+		return array( 'success' => false, 'message' => sprintf( __( 'No customer with ID %d', 'easy-digital-downloads' ), $customer_id ) );
+	}
+
+	$customer->update( array(
+		'name'         => __( 'Anonymized Customer', 'easy-digital-downloads' ),
+		'email'        => edd_anonymize_email( $customer->email ),
+		'date_created' => date( 'Y-m-d H:i:s', 0 ),
+		'notes'        => '',
+	) );
+
+	// Loop through all their email addresses, and remove any additional email addresses.
+	foreach ( $customer->emails as $email ) {
+		$customer->remove_email( $email );
+	}
+
+	if ( $customer->user_id > 0 ) {
+		delete_user_meta( $customer->user_id, '_edd_user_address' );
+	}
+
+	/**
+	 * Run further anonymization on a customer
+	 *
+	 * Developers and extensions can use the EDD_Customer object passed into the edd_anonymize_customer action
+	 * to complete further anonymization.
+	 *
+	 * @since 2.9.2
+	 *
+	 * @param EDD_Customer $customer The EDD_Customer object that was found.
+	 */
+	do_action( 'edd_anonymize_customer', $customer );
+
+	$customer->add_note( __( 'Customer anonymized successfully' ) );
+	return array( 'success' => true, 'message' => sprintf( __( 'Customer ID %d successfully anonymized', 'easy-digital-downloads' ), $customer_id ) );
+
+
+}

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -274,11 +274,12 @@ function _edd_anonymize_payment( $payment_id = 0 ) {
 		return array( 'success' => false, 'message' => $should_anonymize_payment['message'] );
 	}
 
-	$statues = edd_get_payment_status_keys();
-	$payment_status_actions = array();
-	foreach ( $statues as $status ) {
+	$action = edd_get_option( 'payment_privacy_status_action' . $payment->status, false );
 
-		switch ( $status ) {
+	// If the store owner has not saved any special settings for the actions to be taken, use defaults.
+	if ( empty( $action ) ) {
+
+		switch ( $payment->status ) {
 
 			case 'publish':
 			case 'refunded':
@@ -299,21 +300,22 @@ function _edd_anonymize_payment( $payment_id = 0 ) {
 
 		}
 
-		/**
-		 * Allow filtering of what type of action should be taken for a payment.
-		 *
-		 * Developers and extensions can use this filter to modify how Easy Digital Downloads will treat an order
-		 * that has been requested to be deleted or anonymized.
-		 *
-		 * @since 2.9.2
-		 *
-		 * @param string      $action  What action will be performed (none, delete, anonymize)
-		 * @param EDD_Payment $payment The EDD_Payment object that has been requested to be anonymized or deleted.
-		 */
-		$payment_status_actions[ $status ] = apply_filters( 'edd_privacy_payment_status_action_' . $action, $action, $payment );
 	}
 
-	switch( $payment_status_actions[ $payment->status ] ) {
+	/**
+	 * Allow filtering of what type of action should be taken for a payment.
+	 *
+	 * Developers and extensions can use this filter to modify how Easy Digital Downloads will treat an order
+	 * that has been requested to be deleted or anonymized.
+	 *
+	 * @since 2.9.2
+	 *
+	 * @param string      $action  What action will be performed (none, delete, anonymize)
+	 * @param EDD_Payment $payment The EDD_Payment object that has been requested to be anonymized or deleted.
+	 */
+	$action = apply_filters( 'edd_privacy_payment_status_action_' . $action, $action, $payment );
+
+	switch( $action ) {
 
 		case 'none':
 		default:
@@ -654,6 +656,7 @@ function edd_register_privacy_erasers( $erasers = array() ) {
 		'eraser_friendly_name' => __( 'Payment Record', 'easy-digital-downloads' ),
 		'callback'             => 'edd_privacy_payment_eraser',
 	);
+
 	return $erasers;
 
 }


### PR DESCRIPTION
Fixes #6497

Proposed Changes:
1. Adds support for payment records to be anonymized or deleted.
2. Adds `_edd_anonymize_payment` to handle anonymizing or deleting a payment record
3. Modified `edd_anonymize_customer` to `_edd_anonymize_customer` to signify it's not a 'normal' function.

There is a filter in place associated with the status of a payment. By default these are the actions taken:
```
case 'publish':
case 'refunded':
case 'revoked':
	$action = 'anonymize';
	break;

case 'failed':
case 'abandoned':
	$action = 'delete';
	break;

case 'pending':
case 'processing':
default:
	$action = 'none';
	break;
```
TL;DR - Published, refunded, or revoked get anonymized, failed and abandoned get deleted, and pending or processing have no action taken as they are still possibly needed. No action is also the default.

The filter `edd_privacy_payment_status_action_' . $action` exists so that extensions and developers with custom statuses can choose what to do with their status (thinking recurring and Stripe off hand).

The data that _is_ anonymized when that action is taken is:
```
- First Name is made blank
- Last  Name is made blank
- All email addresses are converted to the anonymized email address on the customer
- The IP address is run to only be the /24 IP Address (ending in .0) so it cannot be traced back to a user
- Address line 1 is made blank
- Address line 2 is made blank
```