### PR TITLE
(WIP) - Issue/6572 - Just in time database column value validation

### DIFF
--- a/includes/database/schemas/class-column.php
+++ b/includes/database/schemas/class-column.php
@@ -365,18 +365,18 @@ class Column {
 		$this->set_args( $r );
 
 		// Return array
-		return $this->sanitize_args( $r );
+		return $this->validate_args( $r );
 	}
 
 	/**
-	 * Sanitize arguments after they are parsed.
+	 * Validate arguments after they are parsed.
 	 *
 	 * @since 3.0
 	 * @access private
 	 * @param array $args
 	 * @return array
 	 */
-	private function sanitize_args( $args = array() ) {
+	private function validate_args( $args = array() ) {
 
 		// Sanitization callbacks
 		$callbacks = array(
@@ -435,12 +435,33 @@ class Column {
 	 * @return boolean
 	 */
 	public function is_numeric() {
-		return (bool) in_array( strtolower( $this->type ), array(
+		return $this->is_type( array(
 			'tinyint',
 			'int',
 			'mediumint',
 			'bigint'
-		), true );
+		) );
+	}
+
+	/**
+	 * Return if this column is of a certain type.
+	 *
+	 * @since 3.0
+	 * @param mixed $type The type to check. Accepts an array.
+	 * @return boolean True if of type, False if not
+	 */
+	private function is_type( $type = '' ) {
+
+		// If string, cast to array
+		if ( is_string( $type ) ) {
+			$type = (array) $type;
+		}
+
+		// Make them lowercase
+		$types = array_map( 'strtolower', $type );
+
+		// Return if match or not
+		return (bool) in_array( strtolower( $this->type ), $types, true );
 	}
 
 	/**
@@ -485,8 +506,49 @@ class Column {
 	 * @return string
 	 */
 	private function sanitize_validation( $callback = '' ) {
-		return is_callable( $callback )
-			? $callback
-			: '';
+
+		// Return callback if it's callable
+		if ( is_callable( $callback ) ) {
+			return $callback;
+		}
+
+		// Intval fallback
+		if ( $this->is_type( array( 'tinyint', 'int' ) ) ) {
+			$callback = 'intval';
+
+		// Datetime fallback
+		} elseif ( $this->is_type( 'datetime' ) ) {
+			$callback = array( $this, 'validate_datetime' );
+		}
+
+		// Return the callback
+		return $callback;
+	}
+
+	/**
+	 * Fallback to validate a datetime value if no other is set.
+	 *
+	 * @since 3.0
+	 * @param string $value
+	 */
+	public function validate_datetime( $value = '0000-00-00 00:00:00' ) {
+
+		// Fallback for empty values
+		if ( empty( $value ) ) {
+			$value = ! empty( $this->default )
+				? $this->default
+				: '0000-00-00 00:00:00';
+
+		// Fallback if WordPress function exists
+		} elseif ( function_exists( 'date_i18n' ) ) {
+			$value = date_i18n( 'Y-m-d H:i:s', strtotime( $value ), true );
+
+		// Fallback if only PHP date function exists
+		} elseif ( function_exists( 'date' ) ) {
+			$value = date( 'Y-m-d H:i:s', strtotime( $value ) );
+		}
+
+		// Return the validated value
+		return $value;
 	}
 }

--- a/includes/database/schemas/class-column.php
+++ b/includes/database/schemas/class-column.php
@@ -230,8 +230,16 @@ class Column {
 	public $transition = false;
 
 	/**
-	 * Array of possible aliases this column can be referred to as.
+	 * Maybe validate this data before it is written to the database.
 	 *
+	 * @since 3.0
+	 * @access public
+	 * @var string
+	 */
+	public $validate = false;
+
+	/**
+	 * Array of possible aliases this column can also be referred to.
 	 *
 	 * @since 3.0
 	 * @access public
@@ -269,6 +277,9 @@ class Column {
 	 *     @type boolean  $date_query  Is this column a datetime?
 	 *     @type boolean  $in          Is __in supported?
 	 *     @type boolean  $not_in      Is __not_in supported?
+	 *     @type boolean  $cache_key   Is this column queried independently?
+	 *     @type boolean  $transition  Does this column transition between changes?
+	 *     @type string   $validate    A callback function used to validate on save.
 	 * }
 	 */
 	public function __construct( $args = array() ) {
@@ -338,6 +349,9 @@ class Column {
 			// Cache
 			'cache_key'  => false,
 
+			// Validation
+			'validate'   => '',
+
 			// Backwards Compatibility
 			'aliases'    => array()
 		) );
@@ -389,6 +403,7 @@ class Column {
 			'in'         => 'wp_validate_boolean',
 			'not_in'     => 'wp_validate_boolean',
 			'cache_key'  => 'wp_validate_boolean',
+			'validate'   => array( $this, 'sanitize_validation' ),
 			'aliases'    => array( $this, 'sanitize_aliases' )
 		);
 
@@ -440,7 +455,7 @@ class Column {
 	}
 
 	/**
-	 * Sanitize a pattern
+	 * Sanitize the pattern
 	 *
 	 * @since 3.0
 	 * @param mixed $pattern
@@ -460,5 +475,18 @@ class Column {
 		return $this->is_numeric()
 			? '%d'
 			: '%s';
+	}
+
+	/**
+	 * Sanitize the validation callback
+	 *
+	 * @since 3.0
+	 * @param string $callback
+	 * @return string
+	 */
+	private function sanitize_validation( $callback = '' ) {
+		return is_callable( $callback )
+			? $callback
+			: '';
 	}
 }


### PR DESCRIPTION
Ready for initial merge into `release/3.0`.

We will need to introduce more exact validation functions and methods as they are identified and needed. In some cases these might be magic fallbacks, others may be able to use generic WordPress validation functions, and others might require unique solutions (BIGINT, LONGTEXT, etc...)

This PR includes an example fallback method for `DATETIME` columns. I've put it in the `EDD\DB\Column` class, because all columns of those types could use it. I can imagine having a dedicated interface class for fallback validation methods, but this seems OK for now.

See #6572.