### PR TITLE
Pass download_id to download_history_files action

### DIFF
--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -67,7 +67,7 @@ if ( $purchases ) :
 												</a>
 											</div>
 
-											<?php do_action( 'edd_download_history_files', $filekey, $file, $id, $payment->ID, $purchase_data );
+											<?php do_action( 'edd_download_history_files', $filekey, $file, $download['id'], $payment->ID, $purchase_data );
 										endforeach;
 
 									else :


### PR DESCRIPTION
The 'edd_download_history_files' action call passes the (probably leftover?) $id variable holding the current page id instead of a (more desirable) download_id.
