### PR TITLE
Add API access logs to export and support deleting #6501

### DIFF
--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -804,6 +804,11 @@ function edd_privacy_api_access_log_exporter( $email_address = '', $page = 1 ) {
 	global $edd_logs;
 
 	$user = get_user_by_email( $email_address );
+
+	if ( false === $user ) {
+		return array( 'data' => array(), 'done' => true );
+	}
+
 	$log_query = array(
 		'log_type'               => 'api_access',
 		'posts_per_page'         => 100,


### PR DESCRIPTION
Fixes #6501

Proposed Changes:
1. Adds API Access logs to the data exporter
2. Deletes API Access logs on erasure request.
3. Fixed an issue where no customer is found yet an empty table was being displayed for the customer record on export.