### PR TITLE
Fixes a few items of feedback from 3rd party developers I had review the GDPR release.

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -853,14 +853,6 @@ function edd_get_registered_settings() {
 					),
 				),
 				'site_terms'     => array(
-					array(
-					'id'   => 'terms_settings',
-						'name' => '<h3>' . __( 'Terms and Privacy Policy', 'easy-digital-downloads' ) . '</h3>',
-						'desc' => '',
-						'type' => 'header',
-						'tooltip_title' => __( 'Terms and Privacy Policy Settings', 'easy-digital-downloads' ),
-						'tooltip_desc'  => __( 'Depending on legal and regulatory requirements, it may be necessary for your site to show checkboxes for Terms of Agreement and/or Privacy Policy.','easy-digital-downloads' ),
-					),
 					'show_agree_to_terms' => array(
 						'id'   => 'show_agree_to_terms',
 						'name' => __( 'Agree to Terms', 'easy-digital-downloads' ),
@@ -1412,7 +1404,6 @@ function edd_get_registered_settings_sections() {
 			'file_downloads'     => __( 'File Downloads', 'easy-digital-downloads' ),
 			'accounting'         => __( 'Accounting', 'easy-digital-downloads' ),
 			'site_terms'         => __( 'Terms of Agreement', 'easy-digital-downloads' ),
-			'privacy'            => __( 'Privacy', 'easy-digital-downloads' ),
 		) ),
 		'privacy'    => apply_filters( 'edd_settings_section_privacy', array(
 			'general'      => __( 'General', 'easy-digital-downloads' ),

--- a/includes/install.php
+++ b/includes/install.php
@@ -214,7 +214,8 @@ function edd_run_install() {
 			'upgrade_payment_taxes',
 			'upgrade_customer_payments_association',
 			'upgrade_user_api_keys',
-			'remove_refunded_sale_logs'
+			'remove_refunded_sale_logs',
+			'update_file_download_log_data',
 		);
 
 		foreach ( $upgrade_routines as $upgrade ) {

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -268,7 +268,7 @@ function _edd_anonymize_customer( $customer_id = 0 ) {
 	 */
 	$should_anonymize_customer = apply_filters( 'edd_should_anonymize_customer', array( 'should_anonymize' => true, 'message' => '' ), $customer );
 
-	if ( ! $should_anonymize_customer['should_anonymize'] ) {
+	if ( empty( $should_anonymize_customer['should_anonymize'] ) ) {
 		return array( 'success' => false, 'message' => $should_anonymize_customer['message'] );
 	}
 
@@ -364,7 +364,7 @@ function _edd_anonymize_payment( $payment_id = 0 ) {
 	 */
 	$should_anonymize_payment = apply_filters( 'edd_should_anonymize_payment', array( 'should_anonymize' => true, 'message' => '' ), $payment );
 
-	if ( ! $should_anonymize_payment['should_anonymize'] ) {
+	if ( empty( $should_anonymize_payment['should_anonymize'] ) ) {
 		return array( 'success' => false, 'message' => $should_anonymize_payment['message'] );
 	}
 

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -417,6 +417,9 @@ function _edd_anonymize_payment( $payment_id = 0 ) {
 				'post_name'  => sanitize_title( __( 'Anonymized Customer', 'easy-digital-downloads' ) ),
 			) );
 
+			// Because we changed the post_name, WordPress sets a meta on the item for the `old slug`, we need to kill that.
+			delete_post_meta( $payment->ID, '_wp_old_slug' );
+
 			/**
 			 * Run further anonymization on a payment
 			 *

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -266,7 +266,7 @@ function _edd_anonymize_customer( $customer_id = 0 ) {
 	 *     @type string $message          A message to display if the customer could not be anonymized.
 	 * }
 	 */
-	$should_anonymize_customer = apply_filters( 'edd_should_anonymize_customer', array( 'should_anonymize' => true, 'message' => array() ), $customer );
+	$should_anonymize_customer = apply_filters( 'edd_should_anonymize_customer', array( 'should_anonymize' => true, 'message' => '' ), $customer );
 
 	if ( ! $should_anonymize_customer['should_anonymize'] ) {
 		return array( 'success' => false, 'message' => $should_anonymize_customer['message'] );
@@ -362,7 +362,7 @@ function _edd_anonymize_payment( $payment_id = 0 ) {
 	 *     @type string $message          A message to display if the customer could not be anonymized.
 	 * }
 	 */
-	$should_anonymize_payment = apply_filters( 'edd_should_anonymize_payment', array( 'should_anonymize' => true, 'message' => array() ), $payment );
+	$should_anonymize_payment = apply_filters( 'edd_should_anonymize_payment', array( 'should_anonymize' => true, 'message' => '' ), $payment );
 
 	if ( ! $should_anonymize_payment['should_anonymize'] ) {
 		return array( 'success' => false, 'message' => $should_anonymize_payment['message'] );
@@ -617,6 +617,8 @@ function edd_privacy_customer_record_exporter( $email_address = '', $page = 1 ) 
 		}
 	}
 
+	$export_data = apply_filters( 'edd_privacy_customer_record', $export_data, $customer );
+
 	return array( 'data' => array( $export_data ), 'done' => true );
 }
 
@@ -858,6 +860,8 @@ function edd_privacy_file_download_log_exporter( $email_address = '', $page = 1 
 			),
 		);
 
+		$data_points = apply_filters( 'edd_privacy_file_download_log_item', $data_points, $log, $log_meta );
+
 		$export_items[] = array(
 			'group_id'    => 'edd-file-download-logs',
 			'group_label' => __( 'File Download Logs', 'easy-digital-downloads' ),
@@ -935,6 +939,8 @@ function edd_privacy_api_access_log_exporter( $email_address = '', $page = 1 ) {
 			),
 		);
 
+		$data_points = apply_filters( 'edd_privacy_api_access_log_item', $data_points, $log );
+
 		$export_items[] = array(
 			'group_id'    => 'edd-api-access-logs',
 			'group_label' => __( 'API Access Logs', 'easy-digital-downloads' ),
@@ -943,7 +949,6 @@ function edd_privacy_api_access_log_exporter( $email_address = '', $page = 1 ) {
 		);
 
 	}
-
 
 	// Add the data to the list, and tell the exporter to come back for the next page of payments.
 	return array(


### PR DESCRIPTION
Proposed Changes:
1. Removes the `Privacy` sub-section from the `Misc` tab after we moved `Privacy` to its own tab.
2. Removes the `Terms and Privacy Agreements` header in the `Misc -> Terms of Agreement` tab.
3. Sets the `update_file_download_log_data` upgrade as complete on a fresh install.
4. Adds some missing filters and incorrectly documented filters.