### PR TITLE
Be more strignent with policy checkbox settings and variable naming #6596

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -892,7 +892,7 @@ function edd_get_registered_settings() {
 						'size' => 'regular',
 					),
 					'show_privacy_policy_on_checkout' => array(
-						'id'   => 'show_agree_to_privacy_policy_on_checkout',
+						'id'   => 'show_privacy_policy_on_checkout',
 						'name' => __( 'Show the Privacy Policy on checkout', 'easy-digital-downloads' ),
 						'desc' => __( 'Display your Privacy Policy on checkout.', 'easy-digital-downloads' ) . ' <a href="' . esc_attr( admin_url( 'privacy.php' ) ) . '">' . __( 'Set your Privacy Policy here', 'easy-digital-downloads' ) .'</a>.',
 						'type' => 'checkbox',

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -46,6 +46,15 @@ function edd_do_automatic_upgrades() {
 		$tracking->send_checkin( false, true );
 	}
 
+	$fix_show_privacy_policy_setting = edd_get_option( 'show_agree_to_privacy_policy_on_checkout', false );
+	if ( ! empty( $fix_show_privacy_policy_setting ) ) {
+
+		edd_update_option( 'show_privacy_policy_on_checkout', $fix_show_privacy_policy_setting );
+
+		edd_delete_option( 'show_agree_to_privacy_policy_on_checkout' );
+
+	}
+
 }
 add_action( 'admin_init', 'edd_do_automatic_upgrades' );
 

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -783,18 +783,17 @@ function edd_terms_agreement() {
 				<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Terms', 'easy-digital-downloads' ); ?></a>
 			</div>
 
-			<?php if ( '1' !== edd_get_option( 'show_agree_to_privacy_policy', false ) && '1' === edd_get_option( 'show_agree_to_privacy_policy_on_checkout', false ) ) : ?>
+			<?php if ( '1' !== edd_get_option( 'show_agree_to_privacy_policy', false ) && '1' === edd_get_option( 'show_privacy_policy_on_checkout', false ) ) : ?>
 				<?php
-				$agree_page      = get_option( 'wp_page_for_privacy_policy' );
-				$agree_label     = edd_get_option( 'privacy_agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
-				$agreement_text  = get_post_field( 'post_content', $agree_page );
+				$privacy_page    = get_option( 'wp_page_for_privacy_policy' );
+				$privacy_text    = get_post_field( 'post_content', $privacy_page );
 				?>
 
-				<?php if ( ! empty( $agreement_text ) ) : ?>
+				<?php if ( ! empty( $privacy_text ) ) : ?>
 					<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
 						<?php
 						do_action( 'edd_before_privacy_policy' );
-						echo wpautop( do_shortcode( stripslashes( $agreement_text ) ) );
+						echo wpautop( do_shortcode( stripslashes( $privacy_text ) ) );
 						do_action( 'edd_after_privacy_policy' );
 						?>
 					</div>
@@ -829,14 +828,15 @@ add_action( 'edd_purchase_form_before_submit', 'edd_terms_agreement' );
  * @return void
  */
 function edd_privacy_agreement() {
-	if ( edd_get_option( 'show_agree_to_privacy_policy', false ) === '1' ) {
+	if ( '1' === edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
+		echo 'here';
 		$agree_label     = edd_get_option( 'privacy_agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
 
 		ob_start();
 		?>
 		<fieldset id="edd-privacy-policy-agreement">
 
-			<?php if ( edd_get_option( 'show_agree_to_privacy_policy_on_checkout', false ) ) : ?>
+			<?php if ( '1' === edd_get_option( 'show_privacy_policy_on_checkout', false ) ) : ?>
 
 				<?php
 				$agree_page      = get_option( 'wp_page_for_privacy_policy' );

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -829,7 +829,6 @@ add_action( 'edd_purchase_form_before_submit', 'edd_terms_agreement' );
  */
 function edd_privacy_agreement() {
 	if ( '1' === edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
-		echo 'here';
 		$agree_label     = edd_get_option( 'privacy_agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
 
 		ob_start();

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -841,25 +841,32 @@ function edd_privacy_agreement() {
 		<fieldset id="edd-privacy-policy-agreement">
 
 			<?php if ( '1' === edd_get_option( 'show_privacy_policy_on_checkout', false ) ) : ?>
-
 				<?php
-				$agree_page      = get_option( 'wp_page_for_privacy_policy' );
-				$agreement_text  = get_post_field( 'post_content', $agree_page );
-				?>
 
-				<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
-					<?php
-					do_action( 'edd_before_privacy_policy' );
-					echo wpautop( do_shortcode( stripslashes( $agreement_text ) ) );
-					do_action( 'edd_after_privacy_policy' );
-					?>
-				</div>
-				<div id="edd-show-privacy-policy" class="edd-show-terms">
-					<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
-					<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
-				</div>
+				$privacy_page    = get_option( 'wp_page_for_privacy_policy' );
 
-			<?php endif; ?>
+				if ( ! empty( $privacy_page ) ) {
+
+					$privacy_text    = get_post_field( 'post_content', $privacy_page );
+
+					if ( ! empty( $privacy_text  ) ) {
+						?>
+						<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
+							<?php
+							do_action( 'edd_before_privacy_policy' );
+							echo wpautop( do_shortcode( stripslashes( $privacy_text ) ) );
+							do_action( 'edd_after_privacy_policy' );
+							?>
+						</div>
+						<div id="edd-show-privacy-policy" class="edd-show-terms">
+							<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
+							<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
+						</div>
+						<?php
+					}
+
+				}
+			endif ?>
 
 			<div class="edd-privacy-policy-agreement">
 				<input name="edd_agree_to_privacy_policy" class="required" type="checkbox" id="edd-agree-to-privacy-policy" value="1"/>

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -785,26 +785,31 @@ function edd_terms_agreement() {
 
 			<?php if ( '1' !== edd_get_option( 'show_agree_to_privacy_policy', false ) && '1' === edd_get_option( 'show_privacy_policy_on_checkout', false ) ) : ?>
 				<?php
+
 				$privacy_page    = get_option( 'wp_page_for_privacy_policy' );
-				$privacy_text    = get_post_field( 'post_content', $privacy_page );
-				?>
 
-				<?php if ( ! empty( $privacy_text ) ) : ?>
-					<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
-						<?php
-						do_action( 'edd_before_privacy_policy' );
-						echo wpautop( do_shortcode( stripslashes( $privacy_text ) ) );
-						do_action( 'edd_after_privacy_policy' );
+				if ( ! empty( $privacy_page ) ) {
+
+					$privacy_text    = get_post_field( 'post_content', $privacy_page );
+
+					if ( ! empty( $privacy_text  ) ) {
 						?>
-					</div>
-					<div id="edd-show-privacy-policy" class="edd-show-terms">
-						<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
-						<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
-					</div>
-				<?php endif; ?>
+						<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
+								<?php
+								do_action( 'edd_before_privacy_policy' );
+								echo wpautop( do_shortcode( stripslashes( $privacy_text ) ) );
+								do_action( 'edd_after_privacy_policy' );
+								?>
+						</div>
+						<div id="edd-show-privacy-policy" class="edd-show-terms">
+							<a href="#" class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
+							<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
+						</div>
+						<?php
+					}
 
-			<?php endif; ?>
-
+				}
+			endif ?>
 			<div class="edd-terms-agreement">
 				<input name="edd_agree_to_terms" class="required" type="checkbox" id="edd_agree_to_terms" value="1"/>
 				<label for="edd_agree_to_terms"><?php echo stripslashes( $agree_label ); ?></label>

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -190,7 +190,7 @@ function edd_log_terms_and_privacy_times( $payment_id, $payment_data ) {
 	}
 
 	if ( ! empty( $payment_data['agree_to_privacy_time'] ) ) {
-		$customer->add_meta( 'agree_to_privacy_time', $payment_data['agree_to_terms_time'] );
+		$customer->add_meta( 'agree_to_privacy_time', $payment_data['agree_to_privacy_time'] );
 	}
 }
 add_action( 'edd_insert_payment', 'edd_log_terms_and_privacy_times', 10, 2 );

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -264,12 +264,12 @@ function edd_purchase_form_validate_fields() {
 	);
 
 	// Validate agree to terms
-	if ( edd_get_option( 'show_agree_to_terms', false ) ) {
+	if ( '1' === edd_get_option( 'show_agree_to_terms', false ) ) {
 		edd_purchase_form_validate_agree_to_terms();
 	}
 
 	// Validate agree to privacy policy
-	if ( edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
+	if ( '1' === edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
 		edd_purchase_form_validate_agree_to_privacy_policy();
 	}
 


### PR DESCRIPTION
Fixes #6596

Proposed Changes:
1. Forces all checks for terms and privacy policy checkboxes to be explicitly strict type checked.
2. Updates the variable naming to make it more clear what is going on during the process ( as it was hard to debug due to naming conventions)
3. Fixes an issue with logging the privacy policy time on the customer meta, due to an incorrect array index
4. Fixes an issue causing some timeouts when no privacy policy page is selected in the Settings > Privacy of WP Core yet EDD is being told to show the privacy policy on checkout.