### PR TITLE
(WIP) issue/6602 - improvements to memory/time related PHP function usage

### DIFF
--- a/includes/admin/reporting/class-export-customers.php
+++ b/includes/admin/reporting/class-export-customers.php
@@ -35,10 +35,7 @@ class EDD_Customers_Export extends EDD_Export {
 	 * @return void
 	 */
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) )
-			set_time_limit( 0 );
+		edd_set_time_limit();
 
 		$extra = '';
 

--- a/includes/admin/reporting/class-export-download-history.php
+++ b/includes/admin/reporting/class-export-download-history.php
@@ -36,10 +36,7 @@ class EDD_Download_History_Export extends EDD_Export {
 	 * @return void
 	 */
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) )
-			set_time_limit( 0 );
+		edd_set_time_limit();
 
 		$month = isset( $_POST['month'] ) ? absint( $_POST['month'] ) : date( 'n' );
 		$year  = isset( $_POST['year']  ) ? absint( $_POST['year']  ) : date( 'Y' );

--- a/includes/admin/reporting/class-export-payments.php
+++ b/includes/admin/reporting/class-export-payments.php
@@ -34,10 +34,7 @@ class EDD_Payments_Export extends EDD_Export {
 	 * @return void
 	 */
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) )
-			set_time_limit( 0 );
+		edd_set_time_limit();
 
 		$month = isset( $_POST['month'] ) ? absint( $_POST['month'] ) : date( 'n' );
 		$year  = isset( $_POST['year']  ) ? absint( $_POST['year']  ) : date( 'Y' );

--- a/includes/admin/reporting/class-export.php
+++ b/includes/admin/reporting/class-export.php
@@ -44,10 +44,7 @@ class EDD_Export {
 	 * @return void
 	 */
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) )
-			set_time_limit( 0 );
+		edd_set_time_limit();
 
 		nocache_headers();
 		header( 'Content-Type: text/csv; charset=utf-8' );

--- a/includes/admin/reporting/export/class-batch-export-earnings-report.php
+++ b/includes/admin/reporting/export/class-batch-export-earnings-report.php
@@ -36,11 +36,7 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 	 * @return void
 	 */
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 
 		nocache_headers();
 		header( 'Content-Type: text/csv; charset=utf-8' );

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1033,11 +1033,7 @@ function edd_tools_import_export_process_export() {
 		'edd_tax_rates' => $edd_tax_rates,
 	);
 
-	ignore_user_abort( true );
-
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		set_time_limit( 0 );
-	}
+	edd_set_time_limit();
 
 	nocache_headers();
 	header( 'Content-Type: application/json; charset=utf-8' );

--- a/includes/admin/tools/class-edd-tools-recount-all-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-all-stats.php
@@ -223,11 +223,7 @@ class EDD_Tools_Recount_All_Stats extends EDD_Batch_Export {
 	}
 
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 	}
 
 	/**

--- a/includes/admin/tools/class-edd-tools-recount-customer-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-customer-stats.php
@@ -204,11 +204,7 @@ class EDD_Tools_Recount_Customer_Stats extends EDD_Batch_Export {
 	}
 
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 	}
 
 	/**

--- a/includes/admin/tools/class-edd-tools-recount-download-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-download-stats.php
@@ -238,11 +238,7 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 	}
 
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 	}
 
 	/**

--- a/includes/admin/tools/class-edd-tools-recount-single-customer-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-single-customer-stats.php
@@ -191,11 +191,7 @@ class EDD_Tools_Recount_Single_Customer_Stats extends EDD_Batch_Export {
 	}
 
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 	}
 
 	/**

--- a/includes/admin/tools/class-edd-tools-recount-store-earnings.php
+++ b/includes/admin/tools/class-edd-tools-recount-store-earnings.php
@@ -173,11 +173,7 @@ class EDD_Tools_Recount_Store_Earnings extends EDD_Batch_Export {
 	}
 
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 	}
 
 	/**

--- a/includes/admin/tools/class-edd-tools-reset-stats.php
+++ b/includes/admin/tools/class-edd-tools-reset-stats.php
@@ -203,11 +203,7 @@ class EDD_Tools_Reset_Stats extends EDD_Batch_Export {
 	}
 
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 	}
 
 	/**

--- a/includes/admin/upgrades/classes/class-file-download-log-migration.php
+++ b/includes/admin/upgrades/classes/class-file-download-log-migration.php
@@ -162,11 +162,7 @@ class EDD_File_Download_Log_Migration extends EDD_Batch_Export {
 	}
 
 	public function headers() {
-		ignore_user_abort( true );
-
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			set_time_limit( 0 );
-		}
+		edd_set_time_limit();
 	}
 
 	/**

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -438,11 +438,7 @@ function edd_v131_upgrades() {
 		return;
 	}
 
-	ignore_user_abort( true );
-
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		set_time_limit( 0 );
-	}
+	edd_set_time_limit();
 
 	$query = new WP_Query( array(
 		'post_type' 		=> 'download',
@@ -614,11 +610,7 @@ function edd_v15_upgrades() {
 function edd_v20_upgrades() {
 	global $edd_options, $wpdb;
 
-	ignore_user_abort( true );
-
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		set_time_limit( 0 );
-	}
+	edd_set_time_limit();
 
 	// Upgrade for the anti-behavior fix - #2188
 	if ( ! empty( $edd_options['disable_ajax_cart'] ) ) {
@@ -645,7 +637,6 @@ function edd_v20_upgrades() {
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE '_wp_session_expires_%' AND option_value+0 < 2789308218" );
 
 	update_option( 'edd_settings', $edd_options );
-
 }
 
 /**
@@ -660,11 +651,7 @@ function edd_v20_upgrade_sequential_payment_numbers() {
 		wp_die( __( 'You do not have permission to do shop upgrades', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	ignore_user_abort( true );
-
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		set_time_limit( 0 );
-	}
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] )  ? absint( $_GET['step'] )  : 1;
 	$total  = isset( $_GET['total'] ) ? absint( $_GET['total'] ) : false;
@@ -735,11 +722,8 @@ function edd_v21_upgrade_customers_db() {
 		wp_die( __( 'You do not have permission to do shop upgrades', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	ignore_user_abort( true );
 
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		@set_time_limit(0);
-	}
+	edd_set_time_limit();
 
 	if ( ! get_option( 'edd_upgrade_customers_db_version' ) ) {
 		// Create the customers database on the first run
@@ -840,10 +824,7 @@ function edd_v226_upgrade_payments_price_logs_db() {
 		wp_die( __( 'You do not have permission to do shop upgrades', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	ignore_user_abort( true );
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		@set_time_limit(0);
-	}
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 	$number = 25;
@@ -950,10 +931,7 @@ function edd_v23_upgrade_payment_taxes() {
 		wp_die( __( 'You do not have permission to do shop upgrades', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	ignore_user_abort( true );
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		@set_time_limit(0);
-	}
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 	$number = 50;
@@ -1025,11 +1003,7 @@ function edd_v23_upgrade_customer_purchases() {
 		wp_die( __( 'You do not have permission to do shop upgrades', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	ignore_user_abort( true );
-
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		@set_time_limit(0);
-	}
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 	$number = 50;
@@ -1145,11 +1119,7 @@ function edd_upgrade_user_api_keys() {
 		wp_die( __( 'You do not have permission to do shop upgrades', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	ignore_user_abort( true );
-
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		@set_time_limit(0);
-	}
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 	$number = 10;
@@ -1226,11 +1196,7 @@ function edd_remove_refunded_sale_logs() {
 		wp_die( __( 'You do not have permission to do shop upgrades', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 	}
 
-	ignore_user_abort( true );
-
-	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-		@set_time_limit(0);
-	}
+	edd_set_time_limit();
 
 	$step    = isset( $_GET['step'] ) ? absint( $_GET['step'] ) : 1;
 	$total   = isset( $_GET['total'] ) ? absint( $_GET['total'] ) : edd_count_payments()->refunded;
@@ -1292,8 +1258,7 @@ function edd_discounts_migration() {
 		return;
 	}
 
-	ignore_user_abort( true );
-	set_time_limit( 0 );
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] )   ? absint( $_GET['step'] )   : 1;
 	$number = isset( $_GET['number'] ) ? absint( $_GET['number'] ) : 10;
@@ -1415,8 +1380,7 @@ function edd_remove_legacy_discounts() {
 		return;
 	}
 
-	ignore_user_abort( true );
-	set_time_limit( 0 );
+	edd_set_time_limit();
 
 	$discount_ids = $wpdb->get_results( "SELECT ID FROM $wpdb->posts WHERE post_type = 'edd_discount'" );
 	$discount_ids = wp_list_pluck( $discount_ids, 'ID' );
@@ -1456,8 +1420,7 @@ function edd_notes_migration() {
 		return;
 	}
 
-	ignore_user_abort( true );
-	set_time_limit( 0 );
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] )   ? absint( $_GET['step'] )   : 1;
 	$number = isset( $_GET['number'] ) ? absint( $_GET['number'] ) : 10;
@@ -1562,8 +1525,7 @@ function edd_remove_legacy_notes() {
 		return;
 	}
 
-	ignore_user_abort( true );
-	set_time_limit( 0 );
+	edd_set_time_limit();
 
 	$note_ids = $wpdb->get_results( "SELECT comment_ID FROM $wpdb->comments WHERE comment_type = 'edd_payment_note'" );
 	$note_ids = wp_list_pluck( $note_ids, 'comment_ID' );
@@ -1602,8 +1564,7 @@ function edd_logs_migration() {
 		return;
 	}
 
-	ignore_user_abort( true );
-	set_time_limit( 0 );
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] )   ? absint( $_GET['step'] )   : 1;
 	$number = isset( $_GET['number'] ) ? absint( $_GET['number'] ) : 10;
@@ -1769,8 +1730,7 @@ function edd_remove_legacy_logs() {
 		return;
 	}
 
-	ignore_user_abort( true );
-	set_time_limit( 0 );
+	edd_set_time_limit();
 
 	$step   = isset( $_GET['step'] )   ? absint( $_GET['step'] )   : 1;
 	$number = isset( $_GET['number'] ) ? absint( $_GET['number'] ) : 10;

--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -177,9 +177,8 @@ function edd_process_download() {
 		$file_extension = edd_get_file_extension( $requested_file );
 		$ctype          = edd_get_file_ctype( $file_extension );
 
-		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
-			@set_time_limit(0);
-		}
+		edd_set_time_limit( false );
+
 		if ( function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime() && version_compare( phpversion(), '5.4', '<' ) ) {
 			set_magic_quotes_runtime(0);
 		}
@@ -801,7 +800,8 @@ function edd_readfile_chunked( $file, $retbytes = true ) {
 
 	header( 'Accept-Ranges: bytes' );
 
-	set_time_limit( 0 );
+	edd_set_time_limit( false );
+
 	fseek( $handle, $seek_start );
 
 	while ( ! @feof( $handle ) ) {


### PR DESCRIPTION
* This replaces mulitple calls to `ignore_user_abort()` and `set_time_limit()`
* Ensures error control operators are used everywhere
* Reduces time limit from -infinity- to 6 hours (can be adjusted or filtered as necessary)
* Moves `edd_is_func_disabled()` towards bottom of file, near new function
* Adds strict type comparison in `in_array()` check

The results of this change will be improved compatibility with a myriad of hosting environments that disable certain functions, and also avoids rogue unterminated PHP processes from incomplete downloads where user aborts failed to be processed.

See #6602.