### PR TITLE
issue/5844 - Allow for currency to be passed to `edd_currency_decimal_filter`

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -191,12 +191,17 @@ function edd_currency_filter( $price = '', $currency = '' ) {
  * Set the number of decimal places per currency
  *
  * @since 1.4.2
- * @param int $decimals Number of decimal places
- * @return int $decimals
+ * @since 3.0 Updated to allow currency to be passed in.
+ *
+ * @param int    $decimals Number of decimal places.
+ * @param string $currency Currency.
+ *
+ * @return int $decimals Number of decimal places for currency.
 */
-function edd_currency_decimal_filter( $decimals = 2 ) {
-
-	$currency = edd_get_currency();
+function edd_currency_decimal_filter( $decimals = 2, $currency = '' ) {
+	$currency = empty( $currency )
+		? edd_get_currency()
+		: $currency;
 
 	switch ( $currency ) {
 		case 'RIAL' :

--- a/tests/tests-formatting.php
+++ b/tests/tests-formatting.php
@@ -101,4 +101,12 @@ class Tests_Formatting extends EDD_UnitTestCase {
 		// Reset the option
 		edd_update_option( 'currency', $initial_currency );
 	}
+
+	public function test_decimal_filter_with_currency_passed_should_return_0() {
+		$this->assertSame( 0, edd_currency_decimal_filter( 2, 'RIAL' ) );
+
+		$this->assertSame( 0, edd_currency_decimal_filter( 2, 'HUF' ) );
+
+		$this->assertSame( 0, edd_currency_decimal_filter( 2, 'JPY' ) );
+	}
 }


### PR DESCRIPTION
Fixes #5844

Proposed Changes:
1. Introduce `currency` parameter to `edd_currency_decimal_filter()`