### PR TITLE
issue/6605 - Add sleep() if PayPal PDT is used.

### DIFF
--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -334,7 +334,7 @@ add_action( 'edd_gateway_paypal', 'edd_process_paypal_purchase' );
  */
 function edd_listen_for_paypal_ipn() {
 	// Regular PayPal IPN
-	if ( isset( $_GET['edd-listener'] ) && $_GET['edd-listener'] == 'IPN' ) {
+	if ( isset( $_GET['edd-listener'] ) && 'IPN' === $_GET['edd-listener'] ) {
 
 		edd_debug_log( 'PayPal IPN endpoint loaded' );
 
@@ -343,14 +343,14 @@ function edd_listen_for_paypal_ipn() {
 		/**
 		 * This is necessary to delay execution of PayPal PDT and to avoid a race condition causing the order status
 		 * updates to be triggered twice.
-         *
-         * @since 2.9.4
-         * @see https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6605
+		 *
+		 * @since 2.9.4
+		 * @see https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6605
 		 */
 		$token = edd_get_option( 'paypal_identity_token' );
 		if ( $token ) {
-		    sleep( 5 );
-        }
+			sleep( 5 );
+		}
 	}
 }
 add_action( 'init', 'edd_listen_for_paypal_ipn' );

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -334,7 +334,7 @@ add_action( 'edd_gateway_paypal', 'edd_process_paypal_purchase' );
  */
 function edd_listen_for_paypal_ipn() {
 	// Regular PayPal IPN
-	if ( isset( $_GET['edd-listener'] ) && 'IPN' === $_GET['edd-listener'] ) {
+	if ( isset( $_GET['edd-listener'] ) && 'ipn' === strtolower( $_GET['edd-listener'] ) ) {
 
 		edd_debug_log( 'PayPal IPN endpoint loaded' );
 

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -1,4 +1,4 @@
-Attempting to verify PayPal payment with PDT<?php
+<?php
 /**
  * PayPal Standard Gateway
  *

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -1,4 +1,4 @@
-<?php
+Attempting to verify PayPal payment with PDT<?php
 /**
  * PayPal Standard Gateway
  *
@@ -339,6 +339,18 @@ function edd_listen_for_paypal_ipn() {
 		edd_debug_log( 'PayPal IPN endpoint loaded' );
 
 		do_action( 'edd_verify_paypal_ipn' );
+
+		/**
+		 * This is necessary to delay execution of PayPal PDT and to avoid a race condition causing the order status
+		 * updates to be triggered twice.
+         *
+         * @since 2.9.4
+         * @see https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6605
+		 */
+		$token = edd_get_option( 'paypal_identity_token' );
+		if ( $token ) {
+		    sleep( 5 );
+        }
 	}
 }
 add_action( 'init', 'edd_listen_for_paypal_ipn' );

--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -338,8 +338,6 @@ function edd_listen_for_paypal_ipn() {
 
 		edd_debug_log( 'PayPal IPN endpoint loaded' );
 
-		do_action( 'edd_verify_paypal_ipn' );
-
 		/**
 		 * This is necessary to delay execution of PayPal PDT and to avoid a race condition causing the order status
 		 * updates to be triggered twice.
@@ -351,6 +349,8 @@ function edd_listen_for_paypal_ipn() {
 		if ( $token ) {
 			sleep( 5 );
 		}
+
+		do_action( 'edd_verify_paypal_ipn' );
 	}
 }
 add_action( 'init', 'edd_listen_for_paypal_ipn' );


### PR DESCRIPTION
Fixes #6605

Proposed Changes:
1. Call `sleep()` on IPN actions if PDT is enabled too. PayPal PDT and IPN both sending data back to the site can cause a race condition to develop whereby the status of a payment is changed to `complete` twice triggering all the completed purchase actions to be triggered twice: double the license keys, double referrals in AffiliateWP etc.
