### PR TITLE
issue/6549 - Fix absolute Windows paths resulting in fatal errors

### DIFF
--- a/includes/reports/data/class-table-endpoint.php
+++ b/includes/reports/data/class-table-endpoint.php
@@ -157,7 +157,7 @@ final class Table_Endpoint extends Endpoint {
 	 * @param string $file Class file.
 	 */
 	private function set_class_file( $file ) {
-		if ( 0 === validate_file( $file ) ) {
+		if ( false === strpos( $file, '..' ) && false === strpos( $file, './' ) ) {
 			$this->class_file = $file;
 		}
 	}


### PR DESCRIPTION
Fixes #6549 

Proposed Changes:
1. Absolute Windows paths return `-2` when passed to `validate_file()` meaning Windows users get fatal errors when loading the reports.  The logic has been tweaked to allow for absolute paths to be loaded too.