### PR TITLE
change manage_shop_settings to view_shop_reports for editing tax exclusion on a product level #6662

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -967,7 +967,7 @@ function edd_render_dowwn_tax_options( $post_id = 0 ) {
  * @return void
  */
 function edd_render_down_tax_options( $post_id = 0 ) {
-	if( ! current_user_can( 'manage_shop_settings' ) || ! edd_use_taxes() ) {
+	if( ! current_user_can( 'view_shop_reports' ) || ! edd_use_taxes() ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #6662 

Proposed Changes:
1. Changes the role of `manage_shop_settings` to `view_shop_reports` for the Exclude Tax download setting.