### PR TITLE
Force cart->contents to be an array when requested #6674

### DIFF
--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -198,7 +198,7 @@ class EDD_Cart {
 
 		do_action( 'edd_cart_contents_loaded' );
 
-		return $this->contents;
+		return (array) $this->contents;
 	}
 
 	/**
@@ -358,7 +358,8 @@ class EDD_Cart {
 	 * @return boolean
 	 */
 	public function is_empty() {
-		return 0 === sizeof( $this->contents );
+		$contents = array( $this->contents );
+		return 0 === sizeof( $contents );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6674

Proposed Changes:
1. Changes the `EDD_Cart::is_empty` method to return an array.
2. Forces the `EDD_Cart::get_contents` method to return an array.