### PR TITLE
Respect prices inclusive of tax when modifying a cart item #6563

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1402,6 +1402,11 @@ class EDD_Payment {
 
 		$merged_item = array_merge( $current_args, $args );
 
+		// Format the item_price correctly now
+		$merged_item['item_price']  = edd_sanitize_amount( $merged_item['item_price'] );
+		$new_subtotal               = floatval( $merged_item['item_price'] ) * $merged_item['quantity'];
+		$merged_item['price']       = edd_prices_include_tax() ? $new_subtotal : $new_subtotal + $merged_item['tax'];
+
 		// Sort the current and new args, and checksum them. If no changes. No need to fire a modification.
 		ksort( $current_args );
 		ksort( $merged_item );
@@ -1410,11 +1415,6 @@ class EDD_Payment {
 			return false;
 		}
 
-		// Format the item_price correctly now
-		$merged_item['item_price'] = edd_sanitize_amount( $merged_item['item_price'] );
-
-		$new_subtotal                       = floatval( $merged_item['item_price'] ) * $merged_item['quantity'];
-		$merged_item['price']               = edd_prices_include_tax() ? $new_subtotal : $new_subtotal + $merged_item['tax'];
 		$this->cart_details[ $cart_index ]  = $merged_item;
 		$modified_download                  = $merged_item;
 		$modified_download['action']        = 'modify';

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1414,7 +1414,7 @@ class EDD_Payment {
 		$merged_item['item_price'] = edd_sanitize_amount( $merged_item['item_price'] );
 
 		$new_subtotal                       = floatval( $merged_item['item_price'] ) * $merged_item['quantity'];
-		$merged_item['price']               = $new_subtotal + $merged_item['tax'];
+		$merged_item['price']               = edd_prices_include_tax() ? $new_subtotal : $new_subtotal + $merged_item['tax'];
 		$this->cart_details[ $cart_index ]  = $merged_item;
 		$modified_download                  = $merged_item;
 		$modified_download['action']        = 'modify';


### PR DESCRIPTION
Fixes #6563

Proposed Changes:
1. Changes the `price` value of `EDD_Payment::modify_cart_item` to account for prices inclusive of tax.