### PR TITLE
Don't allow new customer email address to match an existing customer when editing an order #6378

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -191,6 +191,8 @@ function edd_update_payment_details( $data ) {
 				$customer = new EDD_Customer( $curr_customer_id );
 				edd_set_error( 'edd-payment-new-customer-fail', __( 'Error creating new customer', 'easy-digital-downloads' ) );
 			}
+		} else {
+			wp_die( sprintf( __( 'A customer with the email address %s already exists. Please go back and use the dropdown to assign this payment to them.', 'easy-digital-downloads' ), $email ) );
 		}
 
 		$new_customer_id = $customer->id;

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -192,7 +192,7 @@ function edd_update_payment_details( $data ) {
 				edd_set_error( 'edd-payment-new-customer-fail', __( 'Error creating new customer', 'easy-digital-downloads' ) );
 			}
 		} else {
-			wp_die( sprintf( __( 'A customer with the email address %s already exists. Please go back and use the dropdown to assign this payment to them.', 'easy-digital-downloads' ), $email ) );
+			wp_die( sprintf( __( 'A customer with the email address %s already exists. Please go back and use the "Assign to another customer" link to assign this payment to them.', 'easy-digital-downloads' ), $email ) );
 		}
 
 		$new_customer_id = $customer->id;


### PR DESCRIPTION
Fixes #6378 

Proposed Changes:
1. When editing an order, and selecting 'new customer', instead of selecting an existing customer we now throw an error that stops the rest of the process, in order to prevent an incorrect association and data overwrite.