### PR TITLE
Use `register_meta()` correctly including full compatibility for the changes

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -15,6 +15,17 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /** All Downloads *****************************************************************/
 
 /**
+ * Gets the list of post types that should use download metadata.
+ *
+ * @since 3.1
+ * @return array List of post types.
+ */
+function edd_get_download_meta_post_types() {
+
+	return apply_filters( 'edd_download_metabox_post_types' , array( 'download' ) );
+}
+
+/**
  * Register all the meta boxes for the Download custom post type
  *
  * @since 1.0
@@ -22,7 +33,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  */
 function edd_add_download_meta_box() {
 
-	$post_types = apply_filters( 'edd_download_metabox_post_types' , array( 'download' ) );
+	$post_types = edd_get_download_meta_post_types();
 
 	foreach ( $post_types as $post_type ) {
 

--- a/includes/class-edd-register-meta.php
+++ b/includes/class-edd-register-meta.php
@@ -65,8 +65,11 @@ class EDD_Register_Meta {
 	 * @return void
 	 */
 	public function register_download_meta() {
-		register_meta(
-			'post',
+
+		$post_types = edd_get_download_meta_post_types();
+
+		$this->register_post_meta(
+			$post_types,
 			'_edd_download_earnings',
 			array(
 				'sanitize_callback' => 'edd_sanitize_amount',
@@ -75,13 +78,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		// Pre-WordPress 4.6 compatibility
-		if ( ! has_filter( 'sanitize_post_meta__edd_download_earnings' ) ) {
-			add_filter( 'sanitize_post_meta__edd_download_earnings', 'edd_sanitize_amount', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_download_sales',
 			array(
 				'sanitize_callback' => array( $this, 'intval_wrapper' ),
@@ -90,12 +88,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_download_sales' ) ) {
-			add_filter( 'sanitize_post_meta__edd_download_sales', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'edd_price',
 			array(
 				'sanitize_callback' => array( $this, 'sanitize_price' ),
@@ -105,12 +99,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta_edd_price' ) ) {
-			add_filter( 'sanitize_post_meta_edd_price', array( $this, 'sanitize_price' ), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'edd_variable_prices',
 			array(
 				'sanitize_callback' => array( $this, 'sanitize_variable_prices'),
@@ -120,12 +110,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta_edd_variable_prices' ) ) {
-			add_filter( 'sanitize_post_meta_edd_variable_prices', array( $this, 'sanitize_variable_prices'), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'edd_download_files',
 			array(
 				'sanitize_callback' => array( $this, 'sanitize_files' ),
@@ -134,12 +120,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta_edd_download_files' ) ) {
-			add_filter( 'sanitize_post_meta_edd_download_files', array( $this, 'sanitize_files' ), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_bundled_products',
 			array(
 				'sanitize_callback' => array( $this, 'sanitize_array' ),
@@ -149,12 +131,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_bundled_products' ) ) {
-			add_filter( 'sanitize_post_meta__edd_bundled_products', array( $this, 'sanitize_array' ), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_button_behavior',
 			array(
 				'sanitize_callback' => 'sanitize_text_field',
@@ -164,12 +142,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_button_behavior' ) ) {
-			add_filter( 'sanitize_post_meta__edd_button_behavior', 'sanitize_text_field', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_default_price_id',
 			array(
 				'sanitize_callback' => array( $this, 'intval_wrapper' ),
@@ -178,10 +152,6 @@ class EDD_Register_Meta {
 				'show_in_rest'      => true,
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_default_price_id' ) ) {
-			add_filter( 'sanitize_post_meta__edd_default_price_id', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
 
 	}
 
@@ -193,8 +163,10 @@ class EDD_Register_Meta {
 	 */
 	public function register_payment_meta() {
 
-		register_meta(
-			'post',
+		$post_types = array( 'edd_payment' );
+
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_user_email',
 			array(
 				'sanitize_callback' => 'sanitize_email',
@@ -203,13 +175,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		// Pre-WordPress 4.6 compatibility
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_user_email' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_user_email', 'sanitize_email', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_customer_id',
 			array(
 				'sanitize_callback' => array( $this, 'intval_wrapper' ),
@@ -218,12 +185,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_customer_id' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_customer_id', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_user_id',
 			array(
 				'sanitize_callback' => array( $this, 'intval_wrapper' ),
@@ -232,12 +195,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_user_id' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_user_id', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_user_ip',
 			array(
 				'sanitize_callback' => 'sanitize_text_field',
@@ -246,12 +205,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_user_ip' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_user_ip', 'sanitize_text_field', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_purchase_key',
 			array(
 				'sanitize_callback' => 'sanitize_text_field',
@@ -260,12 +215,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_purchase_key' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_purchase_key', 'sanitize_text_field', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_total',
 			array(
 				'sanitize_callback' => 'edd_sanitize_amount',
@@ -274,12 +225,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_total' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_total', 'edd_sanitize_amount', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_mode',
 			array(
 				'sanitize_callback' => 'sanitize_text_field',
@@ -288,12 +235,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_mode' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_mode', 'sanitize_text_field', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_gateway',
 			array(
 				'sanitize_callback' => 'sanitize_text_field',
@@ -302,12 +245,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_gateway' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_gateway', 'sanitize_text_field', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_meta',
 			array(
 				'sanitize_callback' => array( $this, 'sanitize_array' ),
@@ -316,12 +255,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_meta' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_meta', array( $this, 'sanitize_array' ), 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_payment_tax',
 			array(
 				'sanitize_callback' => 'edd_sanitize_amount',
@@ -330,12 +265,8 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_tax' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_tax', 'edd_sanitize_amount', 10, 4 );
-		}
-
-		register_meta(
-			'post',
+		$this->register_post_meta(
+			$post_types,
 			'_edd_completed_date',
 			array(
 				'sanitize_callback' => 'sanitize_text_field',
@@ -344,11 +275,46 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_completed_date' ) ) {
-			add_filter( 'sanitize_post_meta__edd_completed_date', 'sanitize_text_field', 10, 4 );
+	}
+
+	/**
+	 * Registers metadata for a post.
+	 *
+	 * Due to the changes to the `register_meta()` function in WordPress, this method provides
+	 * a convenient wrapper which accounts for those changes and ensures that the function is
+	 * always called correctly.
+	 *
+	 * @since 3.1
+	 * @param string|array $post_types One or more post types to register the metadata for.
+	 * @param string       $meta_key   Meta key to register.
+	 * @param array        $args       Data used to describe the meta key when registered.
+	 */
+	public function register_post_meta( $post_types, $meta_key, $args ) {
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '4.6', '<' ) ) {
+			$sanitize_callback = ! empty( $args['sanitize_callback'] ) ? $args['sanitize_callback'] : null;
+			$auth_callback     = ! empty( $args['auth_callback'] ) ? $args['auth_callback'] : null;
+
+			// If none of this is given, no point in registering meta.
+			if ( ! $sanitize_callback && ! $auth_callback ) {
+				return;
+			}
+
+			register_meta( 'post', $meta_key, $sanitize_callback, $auth_callback );
+			return;
 		}
 
+		if ( version_compare( $wp_version, '5.0', '<' ) ) {
+			register_meta( 'post', $meta_key, $args );
+			return;
+		}
 
+		$post_types = (array) $post_types;
+
+		foreach ( $post_types as $post_type ) {
+			register_post_meta( $post_type, $meta_key, $args );
+		}
 	}
 
 	/**


### PR DESCRIPTION
The `register_meta()` function in core has undergone several changes in the past:
* Before 4.6, it only accepted a sanitize callback and an auth callback passed as individual parameters and registered them for all posts of all post types.
* Before the upcoming 5.0 (i.e. currently), it accepts an array of arguments and registers that data for all posts of all post types. See https://core.trac.wordpress.org/changeset/37924.
* Starting with 5.0, it will support registering metadata for only a specific post type. Which is what you'd actually want, because both download and payment metadata are only relevant for a subset of posts, namely those which have one of those post types. Furthermore, it is now recommended to use the wrapper function `register_post_meta()` when registering metadata for posts. See https://core.trac.wordpress.org/changeset/43378.

EDD should use that function correctly, depending on which WordPress version is currently in use.

Proposed Changes:
1. Introduce a convenience wrapper method `register_post_meta()` which handles the above changes correctly. It ensures that the function is always called correctly, depending on the WordPress version used. The post types to register metadata can be passed to it as a string or an array. Those of course will only take effect if WordPress version 5.0 or newer is being used. Otherwise, although somewhat sub-optimal, it will register the metadata for all posts of all post types, simply because previously there was no other way to do so (this is also what the plugin currently does).
2. Use that new `register_post_meta()` method in the plugin instead of calling core's `register_meta()` directly. This makes its usage streamlined and also allows to get rid of the manual checks to add the sanitize filters in case of pre-4.6, which happens in the current code and is quite ugly.
3. To see, which post types need to have download metadata registered, the `edd_download_metabox_post_types` filter is used. This filter was previously only run in `edd_add_download_meta_box()` to see whether the download meta box should appear for a post type. By showing the download meta box, you essentially add support for that metadata to the respective post type, so it makes sense to use that data for metadata registration as well. For convenience, a `edd_get_download_meta_post_types()` function is introduced that simply runs the filter.
4. For registering payment metadata, only the `edd_payment` post type is used because that is the only place where that data needs to be present at this point.