### PR TITLE
Leave an empty array if no tax rates are found #6676

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1188,6 +1188,15 @@ function edd_settings_sanitize_taxes( $input ) {
 
 	$new_rates = ! empty( $_POST['tax_rates'] ) ? array_values( $_POST['tax_rates'] ) : array();
 
+	foreach ( $new_rates as $key => $rate ) {
+		$rate = array_filter( $rate );
+		if ( empty( $rate ) ) {
+			unset( $new_rates[ $key ] );
+		}
+	}
+
+	$new_rates = ! empty( $new_rates ) ? array_values( $new_rates ) : array();
+
 	update_option( 'edd_tax_rates', $new_rates );
 
 	return $input;
@@ -2119,7 +2128,6 @@ function edd_shop_states_callback($args) {
  */
 function edd_tax_rates_callback($args) {
 	$rates = edd_get_tax_rates();
-
 	$class = edd_sanitize_html_class( $args['field_class'] );
 
 	ob_start(); ?>


### PR DESCRIPTION
Fixes #6676

Proposed Changes:
1. When tax rates are saved with no tax rates entered, the array stored is an empty array instead of an array of keys with empty values.