### PR TITLE
Verify an email address is returned before setting a user to pending and attaching payments #6619

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -483,6 +483,10 @@ function edd_add_past_purchases_to_new_user( $user_id ) {
 
 	$email    = get_the_author_meta( 'user_email', $user_id );
 
+	if ( empty( $email ) ) {
+		return;
+	}
+
 	$payments = edd_get_payments( array( 's' => $email, 'output' => 'payments' ) );
 
 	if( $payments ) {


### PR DESCRIPTION
Fixes #6619

Proposed Changes:
1. Verifies that an email address is returned from `get_the_author_meta` before continuing to set them to pending.