### PR TITLE
Fix alternate checkouts with better edd_is_checkout and edd_get_checkout_uri detection #6668

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -22,6 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 */
 function edd_get_actions() {
 	$key = ! empty( $_GET['edd_action'] ) ? sanitize_key( $_GET['edd_action'] ) : false;
+
+	$is_delayed_action = edd_is_delayed_action( $key );
+
+	if ( $is_delayed_action ) {
+		return;
+	}
+
 	if ( ! empty( $key ) ) {
 		do_action( "edd_{$key}" , $_GET );
 	}
@@ -38,8 +45,91 @@ add_action( 'init', 'edd_get_actions' );
 */
 function edd_post_actions() {
 	$key = ! empty( $_POST['edd_action'] ) ? sanitize_key( $_POST['edd_action'] ) : false;
+
+	$is_delayed_action = edd_is_delayed_action( $key );
+
+	if ( $is_delayed_action ) {
+		return;
+	}
+
 	if ( ! empty( $key ) ) {
 		do_action( "edd_{$key}", $_POST );
 	}
 }
 add_action( 'init', 'edd_post_actions' );
+
+/**
+ * Call any actions that should have been delayed, in order to be sure that all necessary information
+ * has been loaded by WP Core.
+ *
+ * Hooks EDD actions, when present in the $_GET superglobal. Every edd_action
+ * present in $_POST is called using WordPress's do_action function. These
+ * functions are called on template_redirect.
+ *
+ * @since 2.9.4
+ * @return void
+ */
+function edd_delayed_get_actions() {
+	$key = ! empty( $_GET['edd_action'] ) ? sanitize_key( $_GET['edd_action'] ) : false;
+	$is_delayed_action = edd_is_delayed_action( $key );
+
+	if ( ! $is_delayed_action ) {
+		return;
+	}
+
+	if ( ! empty( $key ) ) {
+		do_action( "edd_{$key}", $_GET );
+	}
+}
+add_action( 'template_redirect', 'edd_delayed_get_actions' );
+
+/**
+ * Call any actions that should have been delayed, in order to be sure that all necessary information
+ * has been loaded by WP Core.
+ *
+ * Hooks EDD actions, when present in the $_POST superglobal. Every edd_action
+ * present in $_POST is called using WordPress's do_action function. These
+ * functions are called on template_redirect.
+ *
+ * @since 2.9.4
+ * @return void
+ */
+function edd_delayed_post_actions() {
+	$key = ! empty( $_POST['edd_action'] ) ? sanitize_key( $_POST['edd_action'] ) : false;
+	$is_delayed_action = edd_is_delayed_action( $key );
+
+	if ( ! $is_delayed_action ) {
+		return;
+	}
+
+	if ( ! empty( $key ) ) {
+		do_action( "edd_{$key}", $_POST );
+	}
+}
+add_action( 'template_redirect', 'edd_delayed_post_actions' );
+
+/**
+ * Get the list of actions that EDD has determined need to be delayed past init.
+ *
+ * @since 2.9.4
+ *
+ * @return array
+ */
+function edd_delayed_actions_list() {
+	return (array) apply_filters( 'edd_delayed_actions', array(
+		'add_to_cart'
+	) );
+}
+
+/**
+ * Determine if the requested action needs to be delayed or not.
+ *
+ * @since 2.9.4
+ *
+ * @param string $action
+ *
+ * @return bool
+ */
+function edd_is_delayed_action( $action = '' ) {
+	return in_array( $action, edd_delayed_actions_list() );
+}

--- a/includes/cart/actions.php
+++ b/includes/cart/actions.php
@@ -84,8 +84,8 @@ function edd_process_add_to_cart( $data ) {
 		$query_part 	= strpos( $query_args, "?" );
 		$url_parameters = '';
 
-		if ( false !== $query_part ) { 
-			$url_parameters = substr( $query_args, $query_part ); 
+		if ( false !== $query_part ) {
+			$url_parameters = substr( $query_args, $query_part );
 		}
 
 		wp_redirect( edd_get_checkout_uri() . $url_parameters, 303 );

--- a/includes/checkout/functions.php
+++ b/includes/checkout/functions.php
@@ -19,12 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * @return bool True if on the Checkout page, false otherwise
  */
 function edd_is_checkout() {
-	global $is_checkout;
-
-	if ( ! is_null( $is_checkout ) ) {
-		return $is_checkout;
-	}
-
 	global $wp_query;
 
 	$is_object_set    = isset( $wp_query->queried_object );
@@ -46,9 +40,7 @@ function edd_is_checkout() {
 		$is_checkout = true;
 	}
 
-	$is_checkout = apply_filters( 'edd_is_checkout', $is_checkout );
-
-	return $is_checkout;
+	return apply_filters( 'edd_is_checkout', $is_checkout );
 }
 
 /**
@@ -124,10 +116,15 @@ function edd_send_to_success_page( $query_string = null ) {
  * @return mixed Full URL to the checkout page, if present | null if it doesn't exist
  */
 function edd_get_checkout_uri( $args = array() ) {
+	$uri = false;
+
 	if ( edd_is_checkout() ) {
 		global $post;
-		$uri = get_permalink( $post->ID );
-	} else {
+		$uri = $post instanceof WP_Post ? get_permalink( $post->ID ) : NULL;
+	}
+
+	// If we are not on a checkout page, determine the URI from the default.
+	if ( empty( $uri ) ) {
 		$uri = edd_get_option( 'purchase_page', false );
 		$uri = isset( $uri ) ? get_permalink( $uri ) : NULL;
 	}

--- a/includes/checkout/functions.php
+++ b/includes/checkout/functions.php
@@ -19,6 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * @return bool True if on the Checkout page, false otherwise
  */
 function edd_is_checkout() {
+	global $is_checkout;
+
+	if ( ! is_null( $is_checkout ) ) {
+		return $is_checkout;
+	}
 
 	global $wp_query;
 
@@ -41,7 +46,9 @@ function edd_is_checkout() {
 		$is_checkout = true;
 	}
 
-	return apply_filters( 'edd_is_checkout', $is_checkout );
+	$is_checkout = apply_filters( 'edd_is_checkout', $is_checkout );
+
+	return $is_checkout;
 }
 
 /**
@@ -117,8 +124,13 @@ function edd_send_to_success_page( $query_string = null ) {
  * @return mixed Full URL to the checkout page, if present | null if it doesn't exist
  */
 function edd_get_checkout_uri( $args = array() ) {
-	$uri = edd_get_option( 'purchase_page', false );
-	$uri = isset( $uri ) ? get_permalink( $uri ) : NULL;
+	if ( edd_is_checkout() ) {
+		global $post;
+		$uri = get_permalink( $post->ID );
+	} else {
+		$uri = edd_get_option( 'purchase_page', false );
+		$uri = isset( $uri ) ? get_permalink( $uri ) : NULL;
+	}
 
 	if ( ! empty( $args ) ) {
 		// Check for backward compatibility


### PR DESCRIPTION
#6668

Proposed Changes:
1. ~Updates `edd_is_checkout` to use a global to cache for this thread, in order to reduce a number of calls to the function over and over.~
2. Adds a condition to `edd_get_checkout_uri` to detect if the current URL is a checkout, to return itself, instead of the default checkout URI only.
3. Adds new 'delayed hooks', so that things like `edd_add_to_cart` can run later than `init` in order to allow proper page detection, which allows determining what checkout page to redirect to.