### PR TITLE
Force email tags to be an array #6604

### DIFF
--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -34,7 +34,7 @@ class EDD_Email_Template_Tags {
 	 *
 	 * @since 1.9
 	 */
-	private $tags;
+	private $tags = array();
 
 	/**
 	 * Payment ID

--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -205,7 +205,7 @@ function edd_get_emails_tags_list() {
 	$list = '';
 
 	// Get all tags
-	$email_tags = edd_get_email_tags();
+	$email_tags = (array) edd_get_email_tags();
 
 	// Check
 	if ( count( $email_tags ) > 0 ) {


### PR DESCRIPTION
Fixes #6604

Proposed Changes:
1. Defines `EDD_Email_Template_Tags $tags` as an array on instantiation.
2. Forces `edd_get_emails_tags_list` to format the return of `edd_get_email_tags` as an `(array)`