### PR TITLE
Add hooks to allow further customization of Customers table

### DIFF
--- a/includes/admin/customers/class-customer-table.php
+++ b/includes/admin/customers/class-customer-table.php
@@ -87,7 +87,9 @@ class EDD_Customer_Reports_Table extends WP_List_Table {
 	 * @return void
 	 */
 	public function search_box( $text, $input_id ) {
-		$input_id = $input_id . '-search-input';
+		$search_input_id = $input_id . '-search-input';
+		
+		do_action( 'edd_report_customer_search_box_before', $input_id );
 
 		if ( ! empty( $_REQUEST['orderby'] ) )
 			echo '<input type="hidden" name="orderby" value="' . esc_attr( $_REQUEST['orderby'] ) . '" />';
@@ -95,11 +97,13 @@ class EDD_Customer_Reports_Table extends WP_List_Table {
 			echo '<input type="hidden" name="order" value="' . esc_attr( $_REQUEST['order'] ) . '" />';
 		?>
 		<p class="search-box">
-			<label class="screen-reader-text" for="<?php echo $input_id ?>"><?php echo $text; ?>:</label>
-			<input type="search" id="<?php echo $input_id ?>" name="s" value="<?php _admin_search_query(); ?>" />
+			<label class="screen-reader-text" for="<?php echo $search_input_id ?>"><?php echo $text; ?>:</label>
+			<input type="search" id="<?php echo $search_input_id ?>" name="s" value="<?php _admin_search_query(); ?>" />
 			<?php submit_button( $text, 'button', false, false, array('ID' => 'search-submit') ); ?>
 		</p>
 		<?php
+		
+		do_action( 'edd_report_customer_search_box_after', $input_id );
 	}
 
 	/**

--- a/includes/admin/customers/class-customer-table.php
+++ b/includes/admin/customers/class-customer-table.php
@@ -206,7 +206,7 @@ class EDD_Customer_Reports_Table extends WP_List_Table {
 	 * @return void
 	 */
 	public function bulk_actions( $which = '' ) {
-		// These aren't really bulk actions but this outputs the markup in the right place
+		do_action( 'edd_report_customer_bulk_actions', $which );
 	}
 
 	/**


### PR DESCRIPTION
Allow devs to customize what is shown where Bulk Actions normally take place.

Related to #6735 and #6736—I want to add search filters, and this'd be a good place to tap in.

Proposed Changes:

1. Add `edd_report_customer_bulk_actions` action to Customers table
1. Add `edd_report_customer_search_box_before` and `edd_report_customer_search_box_after` actions before and after the search box