### PR TITLE
issue/6724 - fix incorrect setting ID for showing privacy policy on checkout

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1075,7 +1075,7 @@ function edd_get_registered_settings() {
 						'size'        => 'regular',
 					),
 					'show_privacy_policy_on_checkout' => array(
-						'id'    => 'show_to_privacy_policy_on_checkout',
+						'id'    => 'show_privacy_policy_on_checkout',
 						'name'  => __( 'Privacy Policy on Checkout',                     'easy-digital-downloads' ),
 						'check' => __( 'Display the entire Privacy Policy at checkout.', 'easy-digital-downloads' ) . ' <a href="' . esc_attr( admin_url( 'privacy.php' ) ) . '">' . __( 'Set your Privacy Policy here', 'easy-digital-downloads' ) .'</a>.',
 						'desc'  => __( 'Display your Privacy Policy on checkout.', 'easy-digital-downloads' ) . ' <a href="' . esc_attr( admin_url( 'privacy.php' ) ) . '">' . __( 'Set your Privacy Policy here', 'easy-digital-downloads' ) .'</a>.',


### PR DESCRIPTION
Fixes #6724

Proposed Changes:
1. Fix copy [& edit] pasta on the setting ID for showing Privacy Policy on checkout.
