### PR TITLE
issue/6725 - remove incorrect sales stats function parameter

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -276,7 +276,6 @@ function edd_register_overview_report( $reports ) {
 						$stats = new EDD\Orders\Stats();
 						return apply_filters( 'edd_reports_overview_sales', $stats->get_order_count( array(
 							'range'    => $filter['range'],
-							'relative' => true,
 						) ) );
 					},
 					'display_args'  => array(


### PR DESCRIPTION
Fixes #6725

Proposed Changes:
1. Remove incorrect parameter from `get_order_count()` method on Reports -> Overview - Sales tile

Note: I'm basing this PR solely off of what I learned from reading doc blocks on the `get_customer_count()` method. I believe the Sales tile in the Overview report is passing the method a value that is used for SQL functions, but SQL functions cannot be passed on that method.