### PR TITLE
issue/2721 - Refunds API

### DIFF
--- a/includes/database/schemas/class-logs.php
+++ b/includes/database/schemas/class-logs.php
@@ -47,7 +47,8 @@ class Logs extends Base {
 			'length'     => '20',
 			'unsigned'   => true,
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'cache_key'  => true,
 		),
 
 		// object_type
@@ -56,7 +57,19 @@ class Logs extends Base {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => '',
-			'sortable'   => true
+			'sortable'   => true,
+			'cache_key'  => true,
+		),
+
+		// user_id
+		array(
+			'name'       => 'user_id',
+			'type'       => 'bigint',
+			'length'     => '20',
+			'unsigned'   => true,
+			'default'    => '0',
+			'sortable'   => true,
+			'cache_key'  => true,
 		),
 
 		// type

--- a/includes/database/tables/class-logs.php
+++ b/includes/database/tables/class-logs.php
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
 final class Logs extends Base {
 
 	/**
-	 * Table name
+	 * Table name.
 	 *
 	 * @access protected
 	 * @since 3.0
@@ -30,16 +30,27 @@ final class Logs extends Base {
 	protected $name = 'edd_logs';
 
 	/**
-	 * Database version
+	 * Database version.
 	 *
 	 * @access protected
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201805220001;
+	protected $version = 201807240001;
 
 	/**
-	 * Setup the database schema
+	 * Array of upgrade versions and methods.
+	 *
+	 * @since 3.0
+	 *
+	 * @var array
+	 */
+	protected $upgrades = array(
+		'201807240001' => 201807240001
+	);
+
+	/**
+	 * Setup the database schema.
 	 *
 	 * @access protected
 	 * @since 3.0
@@ -49,6 +60,7 @@ final class Logs extends Base {
 		$this->schema = "id bigint(20) unsigned NOT NULL auto_increment,
 		object_id bigint(20) unsigned NOT NULL default '0',
 		object_type varchar(20) DEFAULT NULL,
+		user_id bigint(20) unsigned NOT NULL default '0',
 		type varchar(20) DEFAULT NULL,
 		title varchar(200) DEFAULT NULL,
 		content longtext DEFAULT NULL,
@@ -56,7 +68,26 @@ final class Logs extends Base {
 		date_modified datetime NOT NULL default '0000-00-00 00:00:00',
 		PRIMARY KEY (id),
 		KEY object_id_type (object_id,object_type(20)),
+		KEY user_id (user_id),
 		KEY type (type(20)),
 		KEY date_created (date_created)";
+	}
+
+	/**
+	 * Upgrade to version 201807230001
+	 * - Add `user_id` column.
+	 *
+	 * @since 3.0
+	 *
+	 * @return bool
+	 */
+	protected function __201807240001() {
+
+		// Alter the database
+		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN user_id bigint(20) unsigned NOT NULL default '0' AFTER object_type" );
+		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX user_id (user_id)" );
+
+		// Return success/fail
+		return $this->is_success( true );
 	}
 }

--- a/includes/logs/class-log.php
+++ b/includes/logs/class-log.php
@@ -6,7 +6,7 @@
  * @subpackage  Logs
  * @copyright   Copyright (c) 2018, Easy Digital Downloads, LLC
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
- * @since       3.0.0
+ * @since       3.0
  */
 namespace EDD\Logs;
 
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
  * @property int $id
  * @property int $object_id
  * @property string $object_type
+ * @property int $user_id
  * @property string $type
  * @property string $title
  * @property string $content
@@ -34,7 +35,7 @@ class Log extends Base_Object {
 	/**
 	 * Log ID.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    int
 	 */
@@ -43,7 +44,7 @@ class Log extends Base_Object {
 	/**
 	 * Object ID.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    int
 	 */
@@ -52,16 +53,25 @@ class Log extends Base_Object {
 	/**
 	 * Object type.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    string
 	 */
 	protected $object_type;
 
 	/**
+	 * User ID.
+	 *
+	 * @since  3.0
+	 * @access protected
+	 * @var    int
+	 */
+	protected $user_id;
+
+	/**
 	 * Log type.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    string
 	 */
@@ -70,7 +80,7 @@ class Log extends Base_Object {
 	/**
 	 * Log title.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    string
 	 */
@@ -79,7 +89,7 @@ class Log extends Base_Object {
 	/**
 	 * Log content.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    string
 	 */
@@ -88,7 +98,7 @@ class Log extends Base_Object {
 	/**
 	 * Date log was created.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    string
 	 */
@@ -97,7 +107,7 @@ class Log extends Base_Object {
 	/**
 	 * Date log was last modified.
 	 *
-	 * @since  3.0.0
+	 * @since  3.0
 	 * @access protected
 	 * @var    string
 	 */

--- a/includes/orders/functions.php
+++ b/includes/orders/functions.php
@@ -1830,6 +1830,7 @@ function edd_refund_order( $order_id = 0 ) {
 	edd_add_log( array(
 		'object_id'   => $order_id,
 		'object_type' => 'order',
+		'user_id'     => get_current_user_id(),
 		'type'        => 'refund',
 		'title'       => __( 'Refund issued', 'easy-digital-downloads' ),
 		'content'     => __( 'A refund for the entire order was issued.', 'easy-digital-downloads' ),

--- a/includes/orders/functions.php
+++ b/includes/orders/functions.php
@@ -1776,3 +1776,37 @@ function edd_count_order_transactions( $args = array() ) {
 	// Return count(s).
 	return absint( $transactions->found_items );
 }
+
+/** Refunds ******************************************************************/
+
+/**
+ * Refund entire order.
+ *
+ * @since 3.0
+ *
+ * @param int $order_id Order ID.
+ * @return boolean True if refund was successful, false otherwise.
+ */
+function edd_refund_order( $order_id = 0 ) {
+
+	// Bail if no order ID was passed.
+	if ( empty( $order_id ) ) {
+		return false;
+	}
+}
+
+/**
+ * Refund order item (partial refund).
+ *
+ * @since 3.0
+ *
+ * @param int $order_item_id Order Item ID.
+ * @return boolean True if partial refund was successful, false otherwise.
+ */
+function edd_refund_order_item( $order_item_id = 0 ) {
+
+	// Bail if no order item ID was passed.
+	if ( empty( $order_item_id ) ) {
+		return false;
+	}
+}


### PR DESCRIPTION
**WIP - Do not merge.**

See #2721.

- Introduces a new refunds API for processing full/partial refunds.
- Adds a `user_id` column to the `edd_logs` table so that refund actions are logged.
- Introduces `edd_refund_order()` and `edd_refund_order_item()`.
