### PR TITLE
Remove query strings from file extensions before returning them #6817

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -172,7 +172,13 @@ function edd_is_odd( $int ) {
  */
 function edd_get_file_extension( $str ) {
 	$parts = explode( '.', $str );
-	return end( $parts );
+	$file_extension = end( $parts );
+
+	if ( false !== strpos( $file_extension, '?' ) ) {
+		$file_extension = substr( $file_extension, 0, strpos( $file_extension, '?' ) );
+	}
+
+	return $file_extension;
 }
 
 /**

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -56,6 +56,10 @@ class Test_Misc extends EDD_UnitTestCase {
 		$this->assertEquals( 'php', edd_get_file_extension( 'file.php' ) );
 	}
 
+	public function test_get_file_extension_with_query_string() {
+		$this->assertEquals( 'pdf', edd_get_file_extension( 'file.pdf?test=1' ) );
+	}
+
 	public function test_string_is_image_url() {
 		$this->assertTrue( edd_string_is_image_url( 'jpg' ) );
 		$this->assertFalse( edd_string_is_image_url( 'php' ) );


### PR DESCRIPTION
Fixes #6817

Proposed Changes:
1. Adds a check for query strings in file extension detection.
2. Adds unit test to verify the new case.