### PR TITLE
Issue/6787

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1189,7 +1189,6 @@ input[class*="edd-price-field"] {
 .edd-admin-box-inside span.label {
 	display: inline-block;
 	width: 85px;
-	white-space: nowrap;
 	text-align: right;
 	margin-right: 10px;
 }

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -646,7 +646,7 @@ function edd_order_details_extras( $order ) {
 				<?php if ( $transaction_id ) : ?>
 					<div class="edd-order-tx-id edd-admin-box-inside">
 						<span class="label"><?php esc_html_e( 'Transaction ID', 'easy-digital-downloads' ); ?>:</span>
-						<span><?php echo esc_html( $transaction_id ); ?></span>
+						<span><?php echo $transaction_id; ?></span>
 					</div>
 				<?php endif; ?>
 


### PR DESCRIPTION
Fixes #6787

Proposed Changes:
1. Remove `nowrap` CSS rule on Order screen metabox labels.
2. Remove escape function from transaction ID output
