### PR TITLE
Revert #6648 EDD Session to start in wp-admin

### DIFF
--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -354,6 +354,11 @@ class EDD_Session {
 				$start_session = false;
 			}
 
+			if( is_admin() && false === strpos( $uri, 'wp-admin/admin-ajax.php' ) ) {
+				// We do not want to start sessions in the admin unless we're processing an ajax request
+				$start_session = false;
+			}
+
 			if( false !== strpos( $uri, 'wp_scrape_key' ) ) {
 				// Starting sessions while saving the file editor can break the save process, so don't start
 				$start_session = false;


### PR DESCRIPTION
Per #6648, the original change to allow EDD sessions in the admin for all page requests, even when FES isn't even installed, and not limited to edit and/or admin views of the download screen should be reverted in EDD core to prevent against extremely dangerous amounts of sessions being started, and instead (as outlined on the ticket) should be implemented using the existing filter by using it in FES, so the behavior is only altered for FES users.

This also allows FES a lot more flexibility in the future.

FES PR: https://github.com/easydigitaldownloads/edd-fes/pull/1413