### PR TITLE
Settings Saving Consistencies 

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -994,6 +994,7 @@ function edd_settings_sanitize( $input = array() ) {
 		$doing_section = true;
 	}
 
+	$settings      = edd_get_registered_settings();
 	$setting_types = edd_get_registered_settings_types();
 	$input         = $input ? $input : array();
 
@@ -1041,6 +1042,8 @@ function edd_settings_sanitize( $input = array() ) {
 		}
 
 		if ( $doing_section ) {
+			$registered_setting = $settings[ $tab ][ $section ][ $key ];
+
 			switch( $type ) {
 				case 'checkbox':
 				case 'gateways':
@@ -1050,10 +1053,17 @@ function edd_settings_sanitize( $input = array() ) {
 						unset( $output[ $key ] );
 					}
 					break;
+				case 'rich_editor':
 				case 'text':
 					if ( array_key_exists( $key, $input ) && ! isset( $input[ $key ] ) ) {
 						unset( $output[ $key ] );
 					}
+					
+					// Override a blank setting with the standard.
+					if ( isset( $registered_setting['allow_blank'] ) && ! $registered_setting['allow_blank'] && '' === $input[ $key ] ) {
+						$output[ $key ] = $registered_setting['std'];
+					}
+
 					break;
 				default:
 					if ( ( array_key_exists( $key, $output ) && ! array_key_exists( $key, $input ) ) ) {


### PR DESCRIPTION
Fixes #6891 

Proposed Changes:

1. When outputting the value of fields registered with the settings API avoid unneeded logic for determining the default value and instead use the `$default` argument in `edd_get_option( $key, $default );`
2. When looking for a setting in `edd_get_option()` check if the key is set at all, and use that value if it is. Otherwise use the default. Previously checking for `empty()` would fail on things like blank strings or `0` strings.
3. Allow empty setting values to be saved in settings.
4. Respect `allow_blank` being set to `false`. No longer save a blank value and incorrect display the option value on the frontend. Blank options for text and rich editor fields are sanitized on input instead of output.
