### PR TITLE
Issue/6907 - Prevent vertical scrollbar in Firefox when hovering over tooltip

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -52,6 +52,7 @@ a.edd-delete:hover {
 }
 
 .edd-ui-tooltip {
+	position: absolute;
 	background: #333 !important;
 	border-width: 1px !important;
 	border-radius: 3px !important;


### PR DESCRIPTION
Fixes #6907