### PR TITLE
Check if set_time_limit is enabled before using it in chunked file download #6886

### DIFF
--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -800,7 +800,10 @@ function edd_readfile_chunked( $file, $retbytes = true ) {
 
 	header( 'Accept-Ranges: bytes' );
 
-	set_time_limit( 0 );
+	if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
+		@set_time_limit(0);
+	}
+
 	fseek( $handle, $seek_start );
 
 	while ( ! @feof( $handle ) ) {


### PR DESCRIPTION
Fixes #6886

Proposed Changes:
1. In the chunked file download, we were using `set_time_limit` without verifyign it is available with `edd_is_func_disabled()`
