### PR TITLE
Update mongolia to a 5 digit postal code verification #6708

### DIFF
--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -1074,7 +1074,7 @@ function edd_purchase_form_validate_cc_zip( $zip = 0, $country_code = '' ) {
 		"MG" => "\d{3}",
 		"MH" => "969[67]\d([ \-]\d{4})?",
 		"MK" => "\d{4}",
-		"MN" => "\d{6}",
+		"MN" => "\d{5}",
 		"MP" => "9695[012]([ \-]\d{4})?",
 		"MQ" => "9[78]2\d{2}",
 		"MT" => "[A-Z]{3}[ ]?\d{2,4}",


### PR DESCRIPTION
Fixes #6708

Proposed Changes:
1. Updates the 'MN' regex for postal code verification to look for a 5 digit number instead of 6.