### PR TITLE
Allow setting numeric download meta to 0 #6745

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -850,7 +850,7 @@ class EDD_Download {
 
 		global $wpdb;
 
-		if ( empty( $meta_key ) || empty( $meta_value ) ) {
+		if ( empty( $meta_key ) || ( ! is_numeric( $meta_value ) && empty( $meta_value ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #6745

Proposed Changes:
1. Fixes `EDD_Download::update_meta` to only return `false` for an empty `$meta_value` if the `$meta_value` _is not_ numeric.
