### PR TITLE
Fix showing variable prices in the best selling downloads report #6930

### DIFF
--- a/includes/reports/data/downloads/class-top-selling-downloads-list-table.php
+++ b/includes/reports/data/downloads/class-top-selling-downloads-list-table.php
@@ -74,10 +74,10 @@ class Top_Selling_Downloads_List_Table extends List_Table {
 		$title = $download->object->post_title;
 
 		if ( $download->object->has_variable_prices() ) {
-			$prices = array_values( wp_filter_object_list( $download->object->get_prices(), array( 'index' => absint( $download->price_id ) ) ) );
+			$prices = array_values( $download->object->get_prices() );
 
-			if ( is_array( $prices ) ) {
-				$prices = $prices[0];
+			if ( is_array( $prices ) && isset( $prices[ $download->price_id ] ) ) {
+				$prices = $prices[ $download->price_id ];
 				$title .= ' &mdash; ' . $prices['name'];
 			}
 		}
@@ -99,10 +99,10 @@ class Top_Selling_Downloads_List_Table extends List_Table {
 		}
 
 		if ( $download->object->has_variable_prices() ) {
-			$prices = array_values( wp_filter_object_list( $download->object->get_prices(), array( 'index' => absint( $download->price_id ) ) ) );
+			$prices = array_values( $download->object->get_prices() );
 
-			if ( is_array( $prices ) ) {
-				$prices = $prices[0];
+			if ( is_array( $prices ) && isset( $prices[ $download->price_id ] ) ) {
+				$prices = $prices[ $download->price_id ];
 
 				return edd_currency_filter( edd_format_amount( $prices['amount'] ) );
 			}


### PR DESCRIPTION
Fixes #6930 

Proposed Changes:
1. Removes the call to `wp_filter_object_list` as that was being incorrectly used.
2. Finds the actual Price ID of the item and displays it instead of always assuming price ID `0`