### PR TITLE
Send item_id along with the activation deactivation and weekly checks #6835

### DIFF
--- a/includes/class-edd-license-handler.php
+++ b/includes/class-edd-license-handler.php
@@ -248,6 +248,10 @@ class EDD_License {
 			'url'        => home_url()
 		);
 
+		if ( ! empty( $this->item_id ) ) {
+			$api_params['item_id'] = $this->item_id;
+		}
+
 		// Call the API
 		$response = wp_remote_post(
 			$this->api_url,
@@ -306,6 +310,10 @@ class EDD_License {
 				'url'        => home_url()
 			);
 
+			if ( ! empty( $this->item_id ) ) {
+				$api_params['item_id'] = $this->item_id;
+			}
+
 			// Call the API
 			$response = wp_remote_post(
 				$this->api_url,
@@ -348,6 +356,10 @@ class EDD_License {
 			'item_name' => urlencode( $this->item_name ),
 			'url'       => home_url()
 		);
+
+		if ( ! empty( $this->item_id ) ) {
+			$api_params['item_id'] = $this->item_id;
+		}
 
 		// Call the API
 		$response = wp_remote_post(


### PR DESCRIPTION
Fixes #6835

Proposed Changes:
1. Adds the `item_id` parameter to the `activate_license`, `deactivate_license`, and `weekly_license_check` API requests at the store URLs