### PR TITLE
Fixing adding new items to orders with a price ID of 0 #6938

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -947,7 +947,7 @@ function edd_ajax_add_order_item() {
 	if ( $d ) {
 		$name = $d->get_name();
 
-		if ( empty( $download['price_id'] ) ) {
+		if ( ! $d->has_variable_prices() ) {
 			$amount = floatval( $d->get_price() );
 		} else {
 			$prices = $d->get_prices();

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -154,7 +154,7 @@ function edd_is_free_download( $download_id = 0, $price_id = false ) {
 function edd_get_download_name( $download_id = 0, $price_id = 0 ) {
 
 	// Bail if no download ID was passed.
-	if ( empty( $download_id ) || ! is_numeric( $download_id ) ) {
+	if ( empty( $download_id ) || ! is_numeric( $download_id ) ) {  
 		return false;
 	}
 
@@ -164,7 +164,7 @@ function edd_get_download_name( $download_id = 0, $price_id = 0 ) {
 	$retval = $download->get_name();
 
 	// Check for variable pricing
-	if ( ! empty( $price_id ) && is_numeric( $price_id ) ) {
+	if ( $download->has_variable_prices() && is_numeric( $price_id ) ) {
 
 		// Check for price option name
 		$price_name = edd_get_price_option_name( $download_id, $price_id );

--- a/includes/orders/classes/class-order-item.php
+++ b/includes/orders/classes/class-order-item.php
@@ -241,8 +241,9 @@ class Order_Item extends \EDD\Database\Rows\Order_Item {
 	 */
 	public function get_order_item_name() {
 
+		$download = edd_get_download( $this->product_id );
 		// Return product name if not a variable price
-		if ( empty( $this->price_id ) ) {
+		if ( ! $download->has_variable_prices() ) {
 			return $this->product_name;
 		}
 


### PR DESCRIPTION
Fixes #6938

Proposed Changes:
1. Updates the AJAX Call to check if a product has variable prices, not if the price ID is `0`.
2. Fixed display issue of names to avoid checking `empty` on price Id, and instead check the product for variable pricing.