### PR TITLE
edd_payment_is_recoverable filter

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1922,7 +1922,7 @@ class EDD_Payment {
 			$recoverable = true;
 		}
 
-		return $recoverable;
+		return apply_filters( 'edd_payment_is_recoverable', $recoverable, $this );
 	}
 
 	/**


### PR DESCRIPTION
allows for filtering on more than just status.

I've had customers recover abandoned payments of over a year old that broke license upgrades, had old prices and many other issues. This would allow me to put a time limit on recoverability.