### PR TITLE
issue/6950 - use correct class name when inserting purchase link

### DIFF
--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -72,8 +72,6 @@ function edd_admin_footer_for_thickbox() {
 
 				if ( 'text link' == style ) {
 					style = 'plain';
-				} else {
-					style = 'button';
 				}
 
 				// Send the shortcode to the editor

--- a/includes/admin/thickbox.php
+++ b/includes/admin/thickbox.php
@@ -64,10 +64,16 @@ function edd_admin_footer_for_thickbox() {
 					return;
 				}
 
-				if( '2' == direct ) {
+				if ( '2' == direct ) {
 					direct = ' direct="true"';
 				} else {
 					direct = '';
+				}
+
+				if ( 'text link' == style ) {
+					style = 'plain';
+				} else {
+					style = 'button';
 				}
 
 				// Send the shortcode to the editor


### PR DESCRIPTION
Fixes #6950 

Proposed Changes:
1. Keeps the current system in place of just using the select option value as a class in the shortcode and purchase link output. But before inserting that class, check its value against the `text link` option and adjust it to `plain` if necessary.