### PR TITLE
Pass all available contextual arguments to edd_requested_file filter.

### DIFF
--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -131,7 +131,7 @@ function edd_process_download() {
 		}
 
 		// Allow the file to be altered before any headers are sent
-		$requested_file = apply_filters( 'edd_requested_file', $requested_file, $download_files, $args['file_key'] );
+		$requested_file = apply_filters( 'edd_requested_file', $requested_file, $download_files, $args['file_key'], $args );
 
 		if( 'x_sendfile' == $method && ( ! function_exists( 'apache_get_modules' ) || ! in_array( 'mod_xsendfile', apache_get_modules() ) ) ) {
 			// If X-Sendfile is selected but is not supported, fallback to Direct


### PR DESCRIPTION
Proposed Changes:
1. Provides `$args` array to edd_requested_file filter, providing additional context 

This is necessary for plugins that need to make changes to the download delivery that uses information from the purchase or purchaser. 