### PR TITLE
Strip slashes from names when updated by profile form

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -885,7 +885,7 @@ function edd_process_profile_editor_updates( $data ) {
 
 	if ( $customer->id > 0 ) {
 		$update_args = array(
-			'name'  => $first_name . ' ' . $last_name,
+			'name'  => stripslashes( $first_name . ' ' . $last_name ),
 		);
 
 		$customer->update( $update_args );


### PR DESCRIPTION
Customer names like `O'Connor` currently get saved as `O\'Connor`.

Proposed Changes:
1. Strip slashes from customer names when updating via the profile form