### PR TITLE
Proposed: Convert all debug entries to UTF-8 #6243

### DIFF
--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -525,6 +525,7 @@ function edd_debug_log( $message = '', $force = false ) {
 
 	if ( edd_is_debug_mode() || $force ) {
 
+		$message = mb_convert_encoding( $message, 'UTF-8' );
 		$edd_logs->log_to_file( $message );
 
 	}


### PR DESCRIPTION
Fixes #6243

Proposed Changes:
1. When `edd_debug_log` is called, converts the message to UTF-8 to avoid issues with character encoding.


So far the only sample set we have is from PayPal, but if someone has a way to replicate this easily, that'd be ideal.