### PR TITLE
issue/7027 - refactor Privacy Policy and Agree to Terms output

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -775,38 +775,38 @@ function edd_terms_agreement() {
 
 	/**
 	 * No terms agreement output of any kind should ever show unless the checkbox
-     * is present for the customer to check: 'Agree to Terms' setting.
-     */
+	 * is present for the customer to check: 'Agree to Terms' setting.
+	 */
 	if ( edd_get_option( 'show_agree_to_terms', false ) ) {
 
 		$agree_text  = edd_get_option( 'agree_text', '' );
 		$agree_label = edd_get_option( 'agree_label', __( 'Agree to Terms?', 'easy-digital-downloads' ) );
 
 		ob_start();
-        ?>
+		?>
 
 		<fieldset id="edd_terms_agreement">
 
 			<?php
-                // Show Agreement Text output only if content exists. Remember that the Agree to Terms
-                // label supports anchors tags, so the terms may be on a separate page.
-                if ( ! empty( $agree_text ) ) {
-                    ?>
+			// Show Agreement Text output only if content exists. Remember that the Agree to Terms
+			// label supports anchors tags, so the terms may be on a separate page.
+			if ( ! empty( $agree_text ) ) {
+				?>
 
-                    <div id="edd_terms" class="edd-terms" style="display:none;">
-                        <?php
-                            do_action( 'edd_before_terms' );
-                            echo wpautop( stripslashes( $agree_text ) );
-                            do_action( 'edd_after_terms' );
-                        ?>
-                    </div>
-                    <div id="edd_show_terms" class="edd-show-terms">
-                        <a href="#" class="edd_terms_links"><?php _e( 'Show Terms', 'easy-digital-downloads' ); ?></a>
-                        <a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Terms', 'easy-digital-downloads' ); ?></a>
-                    </div>
-                    <?php
-                }
-            ?>
+				<div id="edd_terms" class="edd-terms" style="display:none;">
+					<?php
+					do_action( 'edd_before_terms' );
+					echo wpautop( stripslashes( $agree_text ) );
+					do_action( 'edd_after_terms' );
+					?>
+				</div>
+				<div id="edd_show_terms" class="edd-show-terms">
+					<a href="#" class="edd_terms_links"><?php _e( 'Show Terms', 'easy-digital-downloads' ); ?></a>
+					<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Terms', 'easy-digital-downloads' ); ?></a>
+				</div>
+				<?php
+			}
+			?>
 
 			<div class="edd-terms-agreement">
 				<input name="edd_agree_to_terms" class="required" type="checkbox" id="edd_agree_to_terms" value="1"/>
@@ -814,7 +814,7 @@ function edd_terms_agreement() {
 			</div>
 		</fieldset>
 
-        <?php
+		<?php
 		$html_output = ob_get_clean();
 
 		echo apply_filters( 'edd_checkout_terms_agreement_html', $html_output );
@@ -833,22 +833,22 @@ add_action( 'edd_purchase_form_before_submit', 'edd_terms_agreement' );
  */
 function edd_privacy_agreement() {
 
-    $show_privacy_policy_checkbox = edd_get_option( 'show_agree_to_privacy_policy', false );
+	$show_privacy_policy_checkbox = edd_get_option( 'show_agree_to_privacy_policy', false );
 	$show_privacy_policy_text     = edd_get_option( 'show_privacy_policy_on_checkout', false );
 
 	/**
 	 * Privacy Policy output has dual functionality, unlike Agree to Terms output:
-     *
-     * 1. A checkbox (and associated label) can show on checkout if the 'Agree to Privacy Policy' setting
-     *    is checked. This is because a Privacy Policy can be agreed upon without displaying the policy
-     *    itself. Keep in mind the label field supports anchor tags, so the policy can be linked to.
-     *
+	 *
+	 * 1. A checkbox (and associated label) can show on checkout if the 'Agree to Privacy Policy' setting
+	 *    is checked. This is because a Privacy Policy can be agreed upon without displaying the policy
+	 *    itself. Keep in mind the label field supports anchor tags, so the policy can be linked to.
+	 *
 	 * 2. The Privacy Policy text, which is post_content pulled from the WP core Privacy Policy page when
 	 *    you have the 'Show the Privacy Policy on checkout' setting checked, can be displayed on checkout
-     *    regardless of whether or not the customer has to explicitly agreed to the policy by checking the
-     *    checkbox from point #1 above.
-     *
-     * Because these two display options work independently, having either setting checked triggers output.
+	 *    regardless of whether or not the customer has to explicitly agreed to the policy by checking the
+	 *    checkbox from point #1 above.
+	 *
+	 * Because these two display options work independently, having either setting checked triggers output.
 	 */
 	if ( '1' === $show_privacy_policy_checkbox || '1' === $show_privacy_policy_text ) {
 
@@ -858,40 +858,42 @@ function edd_privacy_agreement() {
 
 		ob_start();
 		?>
+
 		<fieldset id="edd-privacy-policy-agreement">
 
 			<?php
-                // Show Privacy Policy text if the setting is checked, the WP Privacy Page is set, and content exists.
-                if ( '1' === $show_privacy_policy_text && ( $privacy_page && ! empty( $privacy_text ) ) ) {
-                    ?>
-                    <div id="edd-privacy-policy" class="edd-terms" style="display:none;">
-                        <?php
-                        do_action( 'edd_before_privacy_policy' );
-                        echo wpautop( do_shortcode( stripslashes( $privacy_text ) ) );
-                        do_action( 'edd_after_privacy_policy' );
-                        ?>
-                    </div>
-                    <div id="edd-show-privacy-policy" class="edd-show-terms">
-                        <a href="#"
-                           class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
-                        <a href="#" class="edd_terms_links"
-                           style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
-                    </div>
-                    <?php
-                }
-
-                // Show Privacy Policy checkbox and label if the setting is checked.
-				if ( '1' === $show_privacy_policy_checkbox ) {
+			// Show Privacy Policy text if the setting is checked, the WP Privacy Page is set, and content exists.
+			if ( '1' === $show_privacy_policy_text && ( $privacy_page && ! empty( $privacy_text ) ) ) {
+				?>
+				<div id="edd-privacy-policy" class="edd-terms" style="display:none;">
+					<?php
+					do_action( 'edd_before_privacy_policy' );
+					echo wpautop( do_shortcode( stripslashes( $privacy_text ) ) );
+					do_action( 'edd_after_privacy_policy' );
 					?>
-                    <div class="edd-privacy-policy-agreement">
-                        <input name="edd_agree_to_privacy_policy" class="required" type="checkbox" id="edd-agree-to-privacy-policy" value="1"/>
-                        <label for="edd-agree-to-privacy-policy"><?php echo stripslashes( $agree_label ); ?></label>
-                    </div>
-                    <?php
-                }
-            ?>
+				</div>
+				<div id="edd-show-privacy-policy" class="edd-show-terms">
+					<a href="#"
+					   class="edd_terms_links"><?php _e( 'Show Privacy Policy', 'easy-digital-downloads' ); ?></a>
+					<a href="#" class="edd_terms_links"
+					   style="display:none;"><?php _e( 'Hide Privacy Policy', 'easy-digital-downloads' ); ?></a>
+				</div>
+				<?php
+			}
+
+			// Show Privacy Policy checkbox and label if the setting is checked.
+			if ( '1' === $show_privacy_policy_checkbox ) {
+				?>
+				<div class="edd-privacy-policy-agreement">
+					<input name="edd_agree_to_privacy_policy" class="required" type="checkbox" id="edd-agree-to-privacy-policy" value="1"/>
+					<label for="edd-agree-to-privacy-policy"><?php echo stripslashes( $agree_label ); ?></label>
+				</div>
+				<?php
+			}
+			?>
 
 		</fieldset>
+
 		<?php
 		$html_output = ob_get_clean();
 

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -786,17 +786,28 @@ function edd_terms_agreement() {
         ?>
 
 		<fieldset id="edd_terms_agreement">
-			<div id="edd_terms" class="edd-terms" style="display:none;">
-				<?php
-					do_action( 'edd_before_terms' );
-					echo wpautop( stripslashes( $agree_text ) );
-					do_action( 'edd_after_terms' );
-				?>
-			</div>
-			<div id="edd_show_terms" class="edd-show-terms">
-				<a href="#" class="edd_terms_links"><?php _e( 'Show Terms', 'easy-digital-downloads' ); ?></a>
-				<a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Terms', 'easy-digital-downloads' ); ?></a>
-			</div>
+
+			<?php
+                // Show Agreement Text output only if content exists. Remember that the Agree to Terms
+                // label supports anchors tags, so the terms may be on a separate page.
+                if ( ! empty( $agree_text ) ) {
+                    ?>
+
+                    <div id="edd_terms" class="edd-terms" style="display:none;">
+                        <?php
+                            do_action( 'edd_before_terms' );
+                            echo wpautop( stripslashes( $agree_text ) );
+                            do_action( 'edd_after_terms' );
+                        ?>
+                    </div>
+                    <div id="edd_show_terms" class="edd-show-terms">
+                        <a href="#" class="edd_terms_links"><?php _e( 'Show Terms', 'easy-digital-downloads' ); ?></a>
+                        <a href="#" class="edd_terms_links" style="display:none;"><?php _e( 'Hide Terms', 'easy-digital-downloads' ); ?></a>
+                    </div>
+                    <?php
+                }
+            ?>
+
 			<div class="edd-terms-agreement">
 				<input name="edd_agree_to_terms" class="required" type="checkbox" id="edd_agree_to_terms" value="1"/>
 				<label for="edd_agree_to_terms"><?php echo stripslashes( $agree_label ); ?></label>
@@ -850,7 +861,6 @@ function edd_privacy_agreement() {
 		<fieldset id="edd-privacy-policy-agreement">
 
 			<?php
-
                 // Show Privacy Policy text if the setting is checked, the WP Privacy Page is set, and content exists.
                 if ( '1' === $show_privacy_policy_text && ( $privacy_page && ! empty( $privacy_text ) ) ) {
                     ?>


### PR DESCRIPTION
Fixes #7027, #6598

Proposed Changes:
1. Remove Privacy Policy related output from `edd_terms_agreement()` function so that nothing related to the Privacy Policy depends on separate Agree to Terms functionality.
2. Refactor `edd_privacy_agreement()` so that **Agree to Privacy Policy** setting output (checkbox and label) and **Show the Privacy Policy on checkout** setting output (expandable/collapsible policy content) can display independently.
3. Only show Agreement Text container if there is actual content to display.
