### PR TITLE
add missing nonce data attribute to country select - issue/7035

### DIFF
--- a/includes/admin/payments/view-order-details.php
+++ b/includes/admin/payments/view-order-details.php
@@ -733,6 +733,7 @@ $customer       = new EDD_Customer( $payment->customer_id );
 															'data'             => array(
 																'search-type'        => 'no_ajax',
 																'search-placeholder' => __( 'Type to search all Countries', 'easy-digital-downloads' ),
+																'nonce'              => wp_create_nonce( 'edd-country-field-nonce' )
 															),
 														) );
 														?>


### PR DESCRIPTION
Fixes #7035

EDD 2.9.4 added nonces to AJAX actions. See: https://easydigitaldownloads.com/development/2018/07/09/important-update-to-ajax-requests-in-easy-digital-downloads-2-9-4/

Proposed Changes:
1. Add missing nonce attribute to the Country select field (chosen) on the Edit Payment screen. The corresponding nonce support already exists in the JS for editing the payment.
