### PR TITLE
Enqueue the edd-admin-tools-export.js on the upgrade page #6856

### DIFF
--- a/includes/admin/upgrades/upgrades.php
+++ b/includes/admin/upgrades/upgrades.php
@@ -34,7 +34,7 @@ function edd_upgrades_screen() {
 		// Until we have fully migrated all upgrade scripts to this new system,
 		// we will selectively enqueue the necessary scripts.
 		add_filter( 'edd_load_admin_scripts', '__return_true' );
-		edd_load_admin_scripts( '' );
+		edd_load_admin_scripts( 'edd-admin-upgrades' );
 
 		// This is the new method to register an upgrade routine, so we can use
 		// an ajax and progress bar to display any needed upgrades.

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -300,7 +300,6 @@ function edd_register_admin_scripts() {
 	wp_register_script( 'edd-admin-tax-rates',             $js_dir . 'edd-admin-tax-rates.js',               array( 'wp-backbone', 'jquery-chosen' ), $version, true );
 	wp_register_script( 'edd-admin-email-tags',            $js_dir . 'edd-admin-email-tags.js',              array( 'thickbox', 'wp-util' ), $version );
 	wp_register_script( 'edd-admin-scripts-compatibility', $js_dir . 'edd-admin-backwards-compatibility.js', array( 'jquery', 'edd-admin-scripts' ), $version );
-	wp_register_script( 'edd-admin-tools-export',          $js_dir . 'edd-admin-tools-export.js',            array( 'jquery' ), $version );
 
 	// Individual admin pages.
 	$admin_pages = array(

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -300,6 +300,7 @@ function edd_register_admin_scripts() {
 	wp_register_script( 'edd-admin-tax-rates',             $js_dir . 'edd-admin-tax-rates.js',               array( 'wp-backbone', 'jquery-chosen' ), $version, true );
 	wp_register_script( 'edd-admin-email-tags',            $js_dir . 'edd-admin-email-tags.js',              array( 'thickbox', 'wp-util' ), $version );
 	wp_register_script( 'edd-admin-scripts-compatibility', $js_dir . 'edd-admin-backwards-compatibility.js', array( 'jquery', 'edd-admin-scripts' ), $version );
+	wp_register_script( 'edd-admin-tools-export',          $js_dir . 'edd-admin-tools-export.js',            array( 'jquery' ), $version );
 
 	// Individual admin pages.
 	$admin_pages = array(
@@ -392,6 +393,11 @@ function edd_enqueue_admin_scripts( $hook = '' ) {
 	// Downloads page.
 	if ( edd_is_admin_page( 'download' ) ) {
 		wp_enqueue_script( 'edd-admin-downloads' );
+	}
+
+	// Upgrades Page
+	if ( 'edd-admin-upgrades' === $hook ) {
+		wp_enqueue_script( 'edd-admin-tools-export' );
 	}
 }
 add_action( 'admin_enqueue_scripts', 'edd_enqueue_admin_scripts' );


### PR DESCRIPTION
Fixes #6856 

Proposed Changes:
1. Adds the JS for the export tools to allow the AJAX handling of the upgrades
2. Sends in a `$hook` so that we can enqueue the JS for this page only when needed.