### PR TITLE
Remove checks for upgrade_user_api_keys upgrade routine #7058

### DIFF
--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -390,11 +390,7 @@ class EDD_API {
 		$user = get_transient( md5( 'edd_api_user_' . $key ) );
 
 		if ( false === $user ) {
-			if ( edd_has_upgrade_completed( 'upgrade_user_api_keys' ) ) {
-				$user = $wpdb->get_var( $wpdb->prepare( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = %s LIMIT 1", $key ) );
-			} else {
-				$user = $wpdb->get_var( $wpdb->prepare( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = 'edd_user_public_key' AND meta_value = %s LIMIT 1", $key ) );
-			}
+			$user = $wpdb->get_var( $wpdb->prepare( "SELECT user_id FROM $wpdb->usermeta WHERE meta_key = %s LIMIT 1", $key ) );
 			set_transient( md5( 'edd_api_user_' . $key ), $user, DAY_IN_SECONDS );
 		}
 
@@ -418,11 +414,7 @@ class EDD_API {
 		$user_public_key = get_transient( $cache_key );
 
 		if ( empty( $user_public_key ) ) {
-			if ( edd_has_upgrade_completed( 'upgrade_user_api_keys' ) ) {
-				$user_public_key = $wpdb->get_var( $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE meta_value = 'edd_user_public_key' AND user_id = %d", $user_id ) );
-			} else {
-				$user_public_key = $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM $wpdb->usermeta WHERE meta_key = 'edd_user_public_key' AND user_id = %d", $user_id ) );
-			}
+			$user_public_key = $wpdb->get_var( $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE meta_value = 'edd_user_public_key' AND user_id = %d", $user_id ) );
 			set_transient( $cache_key, $user_public_key, HOUR_IN_SECONDS );
 		}
 
@@ -440,11 +432,7 @@ class EDD_API {
 		$user_secret_key = get_transient( $cache_key );
 
 		if ( empty( $user_secret_key ) ) {
-			if ( edd_has_upgrade_completed( 'upgrade_user_api_keys' ) ) {
-				$user_secret_key = $wpdb->get_var( $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE meta_value = 'edd_user_secret_key' AND user_id = %d", $user_id ) );
-			} else {
-				$user_secret_key = $wpdb->get_var( $wpdb->prepare( "SELECT meta_value FROM $wpdb->usermeta WHERE meta_key = 'edd_user_secret_key' AND user_id = %d", $user_id ) );
-			}
+			$user_secret_key = $wpdb->get_var( $wpdb->prepare( "SELECT meta_key FROM $wpdb->usermeta WHERE meta_value = 'edd_user_secret_key' AND user_id = %d", $user_id ) );
 			set_transient( $cache_key, $user_secret_key, HOUR_IN_SECONDS );
 		}
 


### PR DESCRIPTION
Fixes #7058

Proposed Changes:
1. Removes checks for the completed upgrade for the migration of the api keys to the new format for performance, as it's nearly 4 years old (EDD 2.4).