### PR TITLE
[3.0] Remove Gray Box on Vertical Sections

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2810,7 +2810,6 @@ body.download_page_edd-reports {
 		font-size: 18px;
 	}
 	.edd-item-has-tabs  .edd-sections-wrap .section-wrap {
-		border-top: 1px solid #e5e5e5;
 		border-left: 0;
 		margin-top: -1px;
 	}

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2518,6 +2518,7 @@ body.download_page_edd-reports {
 	height: 0;
 }
 .edd-sections-wrap {
+	display: table;
 	clear: both;
 }
 .edd-sections-wrap .section-wrap {
@@ -2995,20 +2996,21 @@ body.download_page_edd-reports {
 -------------------------------------------------------------- */
 
 .edd-vertical-sections {
-	overflow: visible;
 	background-color: #f5f5f5;
+	display: table-row;
 }
 
 .edd-vertical-sections .section-nav {
 	float: left;
 	position: relative;
-	width: 20%;
+	width: 200px;
 	line-height: 1em;
 	margin: 0 -1px 0 0;
 	padding: 0;
 	box-sizing: border-box;
-	max-width: 200px;
 	border-right: 1px solid #e5e5e5;
+	display: table-cell;
+	vertical-align: top;
 }
 
 .edd-vertical-sections .section-nav li {
@@ -3156,19 +3158,19 @@ body.download_page_edd-reports {
 /* Content wrapper */
 
 .edd-vertical-sections .section-wrap {
-	width: 80%;
+	width: 100%;
+	display: table-cell;
+	vertical-align: top;
 }
 
 @media only screen and ( min-width: 1200px ) {
-	#edd-graphs-filter,
-	.edd-vertical-sections:not(.meta-box) .section-wrap {
+	#edd-graphs-filter {
 		width: calc( 100% - 200px );
 	}
 }
 
 @media only screen and ( max-width: 782px ) {
-	#edd-graphs-filter,
-	.edd-vertical-sections .section-wrap {
+	#edd-graphs-filter {
 		width: calc( 100% - 48px );
 	}
 }

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2996,29 +2996,24 @@ body.download_page_edd-reports {
 
 .edd-vertical-sections {
 	overflow: visible;
-	background: linear-gradient( 90deg, #f5f5f5 0%, #f5f5f5 20%, #fff 20%, #fff 100% );
-}
-
-@media only screen and ( max-width: 782px ) {
-	.edd-vertical-sections {
-		background: linear-gradient( 90deg, #f5f5f5 0%, #f5f5f5 48px, #fff 48px, #fff 100% );
-	}
+	display: table-row;
 }
 
 .edd-vertical-sections .section-nav {
+	display: table-cell;
+	vertical-align: top;
 	position: relative;
-	float: left;
 	width: 20%;
 	line-height: 1em;
-	margin: 0 -1px -1px 0;
+	margin: 0;
 	padding: 0;
-	background-color: #fcfcfc;
-	border-right: 1px solid #e5e5e5;
+	background-color: #f5f5f5;
 	box-sizing: border-box;
 	max-width: 200px;
 }
 
 .edd-vertical-sections .section-nav li {
+	background-color: #fcfcfc;
 	display: block;
 	position: relative;
 	margin: 0;
@@ -3055,55 +3050,72 @@ body.download_page_edd-reports {
 	font-weight: bold;
 	color: #555;
 	background-color: #fff;
-	border-right: none;
-	margin-right: -1px;
+	border-left-width: 5px;
+	border-left-style: solid;
+}
+
+.edd-vertical-sections .section-nav li[aria-selected="true"] a:after {
+	content: '';
+	width: 1px;
+	height: 100%;
+	background: #fff;
+	position: absolute;
+	right: -1px;
+	top: 0;
+	bottom: 0;
+	z-index: 3;
+}
+
+/* Fresh */
+.admin-color-fresh .edd-vertical-sections .section-nav li[aria-selected="true"] a {
+	border-left-color: #0073aa;
 }
 
 /* Blue */
 .admin-color-blue .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #096484;
+	border-left-color: #096484;
 }
 
 /* Coffee */
 .admin-color-coffee .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #096484;
+	border-left-color: #c7a589;
 }
 
 /* Ectoplasm */
 .admin-color-ectoplasm .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #a3b745;
+	border-left-color: #a3b745;
 }
 
 /* Midnight */
 .admin-color-midnight .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #26292c;
+	border-left-color: #26292c;
 }
 
 /* Ocean */
 .admin-color-ocean .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #627c83;
+	border-left-color: #627c83;
 }
 
 /* Sunrise */
 .admin-color-sunrise .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #be3631;
+	border-left-color: #be3631;
 }
 
 /* Light */
 .admin-color-light .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #888;
+	border-left-color: #888;
 }
 
 /* bbPress Color Schemes */
 
 /* Evergreen */
 .admin-color-evergreen .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #36533f;
+	border-left-color: #36533f;
 }
 
 /* Mint */
 .admin-color-mint .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #4f6d59;
+	border-left-color: #4f6d59;
 }
 
 .edd-vertical-sections .section-nav li[aria-selected="true"] .dashicons {
@@ -3145,7 +3157,8 @@ body.download_page_edd-reports {
 /* Content wrapper */
 
 .edd-vertical-sections .section-wrap {
-	float: left;
+	display: table-cell;
+	vertical-align: top;
 	width: 80%;
 }
 

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2996,20 +2996,19 @@ body.download_page_edd-reports {
 
 .edd-vertical-sections {
 	overflow: visible;
-	display: table-row;
+	background-color: #f5f5f5;
 }
 
 .edd-vertical-sections .section-nav {
-	display: table-cell;
-	vertical-align: top;
+	float: left;
 	position: relative;
 	width: 20%;
 	line-height: 1em;
-	margin: 0;
+	margin: 0 -1px 0 0;
 	padding: 0;
-	background-color: #f5f5f5;
 	box-sizing: border-box;
 	max-width: 200px;
+	border-right: 1px solid #e5e5e5;
 }
 
 .edd-vertical-sections .section-nav li {
@@ -3157,8 +3156,6 @@ body.download_page_edd-reports {
 /* Content wrapper */
 
 .edd-vertical-sections .section-wrap {
-	display: table-cell;
-	vertical-align: top;
 	width: 80%;
 }
 

--- a/includes/admin/class-sections.php
+++ b/includes/admin/class-sections.php
@@ -139,7 +139,6 @@ class Sections {
 				<div class="section-wrap">
 					<?php echo $this->get_all_section_contents(); ?>
 				</div>
-				<br class="clear" />
 			</div>
 			<?php $this->nonce_field();
 

--- a/includes/admin/payments/class-order-sections.php
+++ b/includes/admin/payments/class-order-sections.php
@@ -39,7 +39,6 @@ class Order_Sections extends Sections {
 				<div class="section-wrap">
 					<?php echo $this->get_all_section_contents(); ?>
 				</div>
-				<br class="clear">
 			</div>
 		</div>
 

--- a/includes/admin/reporting/class-reports-sections.php
+++ b/includes/admin/reporting/class-reports-sections.php
@@ -40,7 +40,6 @@ class Reports_Sections extends Sections {
 				<div class="section-wrap">
 					<?php echo $this->get_all_section_contents(); ?>
 				</div>
-				<br class="clear">
 			</div>
 		</div>
 


### PR DESCRIPTION
Fixes #7080

Proposed Changes:
1. Remove Gray Box on Vertical Sections 3.0 UI component.

---

A more ideal solution is to just use `flexbox`, but I think IE9 is still supposed to be supported? https://caniuse.com/#search=flexbox -- instead it uses some semi-hacky `table` solution to the columns are equal height.

This also (what I assume) fixes the active state for items based on the default admin color scheme.