### PR TITLE
[3.0] Fix Customer Creation from New/Edit Order Screens

### DIFF
--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -365,7 +365,10 @@ function edd_add_manual_order( $args = array() ) {
 		edd_update_order_meta( $order_id, 'unlimited_downloads', 1 );
 	}
 
-	$customer->recalculate_stats();
+	if ( ! empty( $customer ) ) {
+		$customer->recalculate_stats();
+	}
+
 	edd_increase_total_earnings( $order_total );
 
 	// Setup order number.


### PR DESCRIPTION
Fixes #7096
Fixes #7052 

Proposed Changes:
1. Avoid fatal errors when creating a customer via the new order or edit order screens.

---

- Fixes referencing unavailable input fields causing the validation to fail.
- Fixes referencing an undefined `$status` variable
- Fixes a few instances of potentially accessing an unavailable `$customer` object.

There are still more places where `$customer` is referenced with the assumption that the customer was properly created. I had a database that did not contain the `uuid` column which caused the customer creation to always fail. This is likely the original cause of #6791 as well.