### PR TITLE
Create a better UX when managing tax settings

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -778,26 +778,6 @@ function edd_get_registered_settings() {
 						'tooltip_desc'  => __( 'This option will determine whether the product price displays with or without tax on checkout.', 'easy-digital-downloads' ),
 					),
 				),
-				'rates' => array(
-					'tax_rate' => array(
-						'id'            => 'tax_rate',
-						'name'          => __( 'Default Rate', 'easy-digital-downloads' ),
-						'desc'          => __( 'Customers not in a region below will be charged this tax rate instead. Enter <code>6.5</code> for 6.5%. ', 'easy-digital-downloads' ),
-						'type'          => 'number',
-						'size'          => 'small',
-						'step'          => '0.0001',
-						'min'           => '0',
-						'max'           => '99',
-						'tooltip_title' => __( 'Default Rate', 'easy-digital-downloads' ),
-						'tooltip_desc'  => __( 'If the customer\'s address fails to meet the below tax rules, you can define a default tax rate to be applied to all other customers. Enter a percentage, such as 6.5 for 6.5%.', 'easy-digital-downloads' ),
-					),
-					'tax_rates' => array(
-						'id'   => 'tax_rates',
-						'name' => '<strong>' . __( 'Regional Rates', 'easy-digital-downloads' ) . '</strong>',
-						'desc' => __( 'Add tax rates for specific regions to override the base rate.', 'easy-digital-downloads' ),
-						'type' => 'tax_rates',
-					),
-				)
 			) ),
 
 			// Extension Settings
@@ -1165,6 +1145,65 @@ function edd_get_registered_settings() {
 	// Filter & return
 	return apply_filters( 'edd_registered_settings', $edd_settings );
 }
+
+/**
+ * Add "Rates" subtab to "Taxes" tab when global taxes are enabled.
+ *
+ * @since 3.0
+ *
+ * @param array $tax_tabs
+ *
+ * @return array
+ */
+function edd_settings_sections_taxes( $tax_tabs ) {
+	if ( ! edd_get_option( 'enable_taxes' ) ) {
+		return $tax_tabs;
+	}
+
+	$tax_tabs['rates'] = __( 'Rates', 'easy-digital-downloads' );
+
+	return $tax_tabs;
+}
+add_filter( 'edd_settings_sections_taxes', 'edd_settings_sections_taxes' );
+
+/**
+ * Add "Rates" subtab settings to "Taxes" tab when global taxes are enabled.
+ *
+ * @since 3.0
+ *
+ * @param array $tax_settings
+ *
+ * @return array
+ */
+function edd_settings_taxes( $tax_settings ) {
+	if ( ! edd_get_option( 'enable_taxes' ) ) {
+		return $tax_settings;
+	}
+
+	$tax_settings['rates'] = array(
+		'tax_rate' => array(
+			'id'            => 'tax_rate',
+			'name'          => __( 'Default Rate', 'easy-digital-downloads' ),
+			'desc'          => __( 'Customers not in a region below will be charged this tax rate instead. Enter <code>6.5</code> for 6.5%. ', 'easy-digital-downloads' ),
+			'type'          => 'number',
+			'size'          => 'small',
+			'step'          => '0.0001',
+			'min'           => '0',
+			'max'           => '99',
+			'tooltip_title' => __( 'Default Rate', 'easy-digital-downloads' ),
+			'tooltip_desc'  => __( 'If the customer\'s address fails to meet the below tax rules, you can define a default tax rate to be applied to all other customers. Enter a percentage, such as 6.5 for 6.5%.', 'easy-digital-downloads' ),
+		),
+		'tax_rates' => array(
+			'id'   => 'tax_rates',
+			'name' => '<strong>' . __( 'Regional Rates', 'easy-digital-downloads' ) . '</strong>',
+			'desc' => __( 'Add tax rates for specific regions to override the base rate.', 'easy-digital-downloads' ),
+			'type' => 'tax_rates',
+		),
+	);
+
+	return $tax_settings;
+}
+add_filter( 'edd_settings_taxes', 'edd_settings_taxes' );
 
 /**
  * Settings Sanitization
@@ -1635,7 +1674,6 @@ function edd_get_registered_settings_sections() {
 			) ),
 			'taxes'      => apply_filters( 'edd_settings_sections_taxes', array(
 				'main'               => __( 'General', 'easy-digital-downloads' ),
-				'rates'              => __( 'Rates',   'easy-digital-downloads' ),
 			) ),
 			'privacy'    => apply_filters( 'edd_settings_section_privacy', array(
 				'main'               => __( 'Privacy Policy',     'easy-digital-downloads' ),

--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -31,34 +31,6 @@ function edd_use_taxes() {
 }
 
 /**
- * Filter tax usage based on existing acive tax rates.
- *
- * Registered at 9 priority to allow existing filters to continue to
- * override the expected option value.
- *
- * Filtering the option retrieval vs. the function return so the settings
- * UI properly reflects the status.
- *
- * @since 3.0
- *
- * @param bool $enable_taxes If taxes are enabled (via database option).
- * @return bool Enable taxes if there is an active tax rate.
- */
-function edd_force_use_taxes( $enable_taxes ) {
-	$rates = edd_get_tax_rates( array(
-		'number' => 1,
-		'status' => 'active',
-	) );
-
-	if ( ! empty( $rates ) ) {
-		return true;
-	}
-
-	return $enable_taxes;
-}
-add_filter( 'edd_get_option_enable_taxes', 'edd_force_use_taxes', 9 );
-
-/**
  * Retrieve tax rates
  *
  * @since 1.6

--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -31,6 +31,34 @@ function edd_use_taxes() {
 }
 
 /**
+ * Filter tax usage based on existing acive tax rates.
+ *
+ * Registered at 9 priority to allow existing filters to continue to
+ * override the expected option value.
+ *
+ * Filtering the option retrieval vs. the function return so the settings
+ * UI properly reflects the status.
+ *
+ * @since 3.0
+ *
+ * @param bool $enable_taxes If taxes are enabled (via database option).
+ * @return bool Enable taxes if there is an active tax rate.
+ */
+function edd_force_use_taxes( $enable_taxes ) {
+	$rates = edd_get_tax_rates( array(
+		'number' => 1,
+		'status' => 'active',
+	) );
+
+	if ( ! empty( $rates ) ) {
+		return true;
+	}
+
+	return $enable_taxes;
+}
+add_filter( 'edd_get_option_enable_taxes', 'edd_force_use_taxes', 9 );
+
+/**
  * Retrieve tax rates
  *
  * @since 1.6


### PR DESCRIPTION
Fixes #7109

~- Force enable taxes to be enabled if a rate was created (and is active) without previously globally enabling taxes.~
- Hide "Rates" subtab until global taxes are enabled

---

Someone may want to add a test case for the `edd_use_taxes()` being enabled via the option filter. I don't have a test environment setup on this machine currently.