### PR TITLE
Fix incorrect param type in method documentation.

### DIFF
--- a/includes/cart/functions.php
+++ b/includes/cart/functions.php
@@ -244,7 +244,7 @@ function edd_get_cart_item_price_name( $item = array() ) {
  * Get cart item title
  *
  * @since 2.4.3
- * @param int $item Cart item array
+ * @param array $item Cart item array
  * @return string item title
  */
 function edd_get_cart_item_name( $item = array() ) {


### PR DESCRIPTION
Proposed Changes:
1. Fix incorrect `edd_get_cart_item_name( $item = array() )` param documentation from **int** to **array**.