### PR TITLE
Account for DateTimeZone look-ups i PHP 5.3 and 5.4 when a GMT is selected #7130

### DIFF
--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -379,7 +379,7 @@ class Utilities {
 				 * will stop DateTimeZone from causing a fatal error in these circumstances. We are not accounting for DST here
 				 * since the user has picked a numeric offset, and thus shouldn't expect the DST to take affect.
 				 */
-				$retval = timezone_name_from_abbr('', $gmt_offset, 0);
+				$retval = timezone_name_from_abbr('', $gmt_offset, 0 );
 
 			} else {
 

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -367,11 +367,30 @@ class Utilities {
 
 		// Use GMT offset to calculate
 		} elseif ( is_numeric( $gmt_offset ) ) {
-			$hours   = abs( floor( $gmt_offset / HOUR_IN_SECONDS ) );
-			$minutes = abs( floor( ( $gmt_offset / MINUTE_IN_SECONDS ) % MINUTE_IN_SECONDS ) );
-			$math    = ( $gmt_offset >= 0 ) ? '+' : '-';
-			$value   = ! empty( $minutes )  ? "{$hours}:{$minutes}" : $hours;
-			$retval  = "GMT{$math}{$value}";
+
+			if ( version_compare( phpversion(), '5.5', '<' ) ) {
+
+				/**
+				 * In the event the user has PHP 5.3 or 5.4 and is using a GMT offset like "GMT-5"
+				 * instead of a Country/City based timezone setting in the WordPress settings, we have to attempt a lookup
+				 * of the string timezone since DateTimeZone doesn't support instantiation from a GMT offset in these versions of PHP.
+				 *
+				 * timezone_name_from_abbr allows us to look up a TimeZone string like "America/Chicago" from the offset, which
+				 * will stop DateTimeZone from causing a fatal error in these circumstances. We are not accounting for DST here
+				 * since the user has picked a numeric offset, and thus shouldn't expect the DST to take affect.
+				 */
+				$retval = timezone_name_from_abbr('', $gmt_offset, 0);
+
+			} else {
+
+				$hours   = abs( floor( $gmt_offset / HOUR_IN_SECONDS ) );
+				$minutes = abs( floor( ( $gmt_offset / MINUTE_IN_SECONDS ) % MINUTE_IN_SECONDS ) );
+				$math    = ( $gmt_offset >= 0 ) ? '+' : '-';
+				$value   = ! empty( $minutes )  ? "{$hours}:{$minutes}" : $hours;
+				$retval  = "GMT{$math}{$value}";
+
+			}
+
 		}
 
 		// Set

--- a/tests/tests-date-functions.php
+++ b/tests/tests-date-functions.php
@@ -67,7 +67,7 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 		if ( version_compare( phpversion(), '5.5', '<' ) ) {
 
 			// Tests our logic around a shortcoming in PHP 5.3 and 5.4 with DateTimeZone
-			$expected = timezone_name_from_abbr('', get_option( 'gmt_offset' ), 0 );
+			$expected = timezone_name_from_abbr('', get_option( 'gmt_offset', 0 ) * HOUR_IN_SECONDS, 0 );
 			$this->assertSame( $expected, edd_get_timezone_id() );
 
 		} else {

--- a/tests/tests-date-functions.php
+++ b/tests/tests-date-functions.php
@@ -64,7 +64,15 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 	 * @covers ::edd_get_timezone_id()
 	 */
 	public function test_get_timezone_should_return_the_current_timezone_based_on_WP_settings() {
-		$this->assertSame( 'GMT-5', edd_get_timezone_id() );
+		if ( version_compare( phpversion(), '5.5', '<' ) ) {
+
+			// Tests our logic around a shortcoming in PHP 5.3 and 5.4 with DateTimeZone
+			$expected = timezone_name_from_abbr('', get_option( 'gmt_offset' ), 0 );
+			$this->assertSame( $expected, edd_get_timezone_id() );
+
+		} else {
+			$this->assertSame( 'GMT-5', edd_get_timezone_id() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7130

Proposed Changes:
1. In the event of PHP 5.3 or 5.4, we determine a string based timezone from a lookup of the GMT offset in order to allow the instantiation of `DateTimeZone` without a fatal error.