### PR TITLE
Fix counts not updating with order list table filters #7079

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -633,15 +633,25 @@ class EDD_Payment_History_Table extends List_Table {
 	 */
 	public function get_payment_counts() {
 
-		// Get the type to get counts for
-		$type = ! empty( $_GET['order_type'] )
-			? sanitize_key( $_GET['order_type'] )
-			: 'sale';
+		$args = $this->parse_args();
+
+		// Remove some args that aren't used for counts.
+		if ( isset( $args['orderby'] ) ) {
+			unset( $args['orderby'] );
+		}
+
+		if ( isset( $args['order'] ) ) {
+			unset( $args['order'] );
+		}
+
+		if ( isset( $args['per_page'] ) ) {
+			unset( $args['per_page'] );
+		}
+
+		$args['paged'] = false;
 
 		// Get order counts by type
-		$this->counts = edd_get_order_counts( array(
-			'type' => $type
-		) );
+		$this->counts = edd_get_order_counts( $args );
 	}
 
 	/**
@@ -652,9 +662,44 @@ class EDD_Payment_History_Table extends List_Table {
 	 * @return array $payment_data Array of all the data for the orders.
 	 */
 	public function payments_data() {
-		$args = array();
-
 		$per_page   = $this->per_page;
+		$args       = $this->parse_args();
+
+		// Drop in our per_page argument.
+		$args['per_page'] = $per_page;
+
+		// No empties
+		$r = wp_parse_args( array_filter( $args ) );
+
+		// Force EDD\Orders\Order objects to be returned
+		$r['output'] = 'orders';
+		$items = edd_get_orders( $r );
+
+		// Get customer IDs and count from payments
+		$customer_ids = array_unique( wp_list_pluck( $items, 'customer_id' ) );
+		$cust_count   = count( $customer_ids );
+
+		// Maybe prime customer objects (if more than number of queries)
+		if ( $cust_count > 1 ) {
+			edd_get_customers( array(
+				'id__in'        => $customer_ids,
+				'no_found_rows' => true,
+				'number'        => $cust_count
+			) );
+		}
+
+		// Return items
+		return $items;
+	}
+
+	/**
+	 * Builds an array of arguments for getting orders for the list table, counts, and pagination.
+	 *
+	 * @since 3.0
+	 *
+	 * @return array Array of arguments to use for querying orders.
+	 */
+	private function parse_args () {
 		$status     = $this->get_status();
 		$paged      = isset( $_GET['paged'] )      ? absint( $_GET['paged'] )                   : null;
 		$user       = isset( $_GET['user'] )       ? absint( $_GET['user'] )                    : null;
@@ -687,7 +732,6 @@ class EDD_Payment_History_Table extends List_Table {
 		}
 
 		$args = array(
-			'number'   => $per_page,
 			'paged'    => $paged,
 			'orderby'  => $orderby,
 			'order'    => $order,
@@ -765,28 +809,7 @@ class EDD_Payment_History_Table extends List_Table {
 			$args['region'] = $region;
 		}
 
-		// No empties
-		$r = wp_parse_args( array_filter( $args ) );
-
-		// Force EDD\Orders\Order objects to be returned
-		$r['output'] = 'orders';
-		$items = edd_get_orders( $r );
-
-		// Get customer IDs and count from payments
-		$customer_ids = array_unique( wp_list_pluck( $items, 'customer_id' ) );
-		$cust_count   = count( $customer_ids );
-
-		// Maybe prime customer objects (if more than number of queries)
-		if ( $cust_count > 1 ) {
-			edd_get_customers( array(
-				'id__in'        => $customer_ids,
-				'no_found_rows' => true,
-				'number'        => $cust_count
-			) );
-		}
-
-		// Return items
-		return $items;
+		return $args;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7079

Proposed Changes:
1. Updates the collection of orders for the list table to include the `$_GET` variables for the counts as well