### PR TITLE
Adding DCO to the CONTRIBUTING.MD file #7166

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,12 @@ When contributing please ensure you follow the guidelines below so that we can k
 
 __Please Note:__ GitHub is for bug reports and contributions only - if you have a support question or a request for a customization don't post here, go to our [Support page](https://easydigitaldownloads.com/support/) instead.
 
+## Developer Certificate of Origin
+By contributing to Easy Digital Downloads, you agree to the Developer Certificate of Origin, which can be reviewed here:
+[https://developercertificate.org](https://developercertificate.org/)
+
+In it's simplest form, the DCO states that you have permission to supply the code submitted to Easy Digital Downloads. Please take a moment to review this agreement before you make your first contribution.
+
 ## Getting Started
 
 * __Do not report potential security vulnerabilities here. Email them privately to our security team at [security@easydigitaldownloads.com](mailto:security@easydigitaldownloads.com)__

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,6 @@ When contributing please ensure you follow the guidelines below so that we can k
 
 __Please Note:__ GitHub is for bug reports and contributions only - if you have a support question or a request for a customization don't post here, go to our [Support page](https://easydigitaldownloads.com/support/) instead.
 
-## Developer Certificate of Origin
-By contributing to Easy Digital Downloads, you agree to the Developer Certificate of Origin, which can be reviewed here:
-[https://developercertificate.org](https://developercertificate.org/)
-
-In its simplest form, the DCO states that you have permission to supply the code submitted to Easy Digital Downloads. Please take a moment to review this agreement before you make your first contribution.
-
 ## Getting Started
 
 * __Do not report potential security vulnerabilities here. Email them privately to our security team at [security@easydigitaldownloads.com](mailto:security@easydigitaldownloads.com)__
@@ -39,6 +33,50 @@ In its simplest form, the DCO states that you have permission to supply the code
 * Finally, please use tabs and not spaces. The tab indent size should be 4 for all EDD code.
 
 At this point you're waiting on us to merge your pull request. We'll review all pull requests, and make suggestions and changes if necessary.
+
+## Developer Certificate of Origin
+By contributing to Easy Digital Downloads, you agree to the Developer Certificate of Origin.
+
+In its simplest form, the DCO states that you have permission to supply the code submitted to Easy Digital Downloads. Here is the DCO in detail:
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
 
 # Additional Resources
 * [EDD Developer's API](https://easydigitaldownloads.com/docs/developers-intro-to-easy-digital-downloads/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ __Please Note:__ GitHub is for bug reports and contributions only - if you have 
 By contributing to Easy Digital Downloads, you agree to the Developer Certificate of Origin, which can be reviewed here:
 [https://developercertificate.org](https://developercertificate.org/)
 
-In it's simplest form, the DCO states that you have permission to supply the code submitted to Easy Digital Downloads. Please take a moment to review this agreement before you make your first contribution.
+In its simplest form, the DCO states that you have permission to supply the code submitted to Easy Digital Downloads. Please take a moment to review this agreement before you make your first contribution.
 
 ## Getting Started
 


### PR DESCRIPTION
Resolves #7166

Proposed Changes:
1. Adds a section to the `CONTRIBUTING.MD` that links to the DCO