### PR TITLE
Fix strpos warning when using product API

### DIFF
--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -73,7 +73,7 @@ class EDD_API_V2 extends EDD_API_V1 {
 			}
 
 			if( ! empty( $args['category'] ) ) {
-				if ( is_string( $args[ 'categrory' ] ) && strpos( $args['category'], ',' ) ) {
+				if ( is_string( $args[ 'categrory' ] ) ) {
 					$args['category'] = explode( ',', $args['category'] );
 				}
 

--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -73,7 +73,7 @@ class EDD_API_V2 extends EDD_API_V1 {
 			}
 
 			if( ! empty( $args['category'] ) ) {
-				if ( strpos( $args['category'], ',' ) ) {
+				if ( is_string( $args[ 'categrory' ] ) && strpos( $args['category'], ',' ) ) {
 					$args['category'] = explode( ',', $args['category'] );
 				}
 


### PR DESCRIPTION
When passing an array of categories a warning is thrown due to the fact that there is no check if categories is a string first.

Fixes #7176

Proposed Changes:
1. Add category string check to product api to avoid PHP warnings