### PR TITLE
issue/7174

### DIFF
--- a/includes/error-tracking.php
+++ b/includes/error-tracking.php
@@ -140,10 +140,16 @@ function _edd_die_handler() {
  */
 function edd_die( $message = '', $title = '', $status = 400 ) {
 	
+	
+	if( defined( 'EDD_DOING_API' ) && true === EDD_DOING_API ) {
+		exit;
+	}
+
 	if( defined( 'EDD_UNIT_TESTS' ) ) {
 		add_filter( 'wp_die_ajax_handler', '_edd_die_handler', 10, 3 );
 		add_filter( 'wp_die_handler', '_edd_die_handler', 10, 3 );
-		wp_die( $message, $title, array( 'response' => $status ));
+
 	}
-	exit;
+
+	wp_die( $message, $title, array( 'response' => $status ));
 }

--- a/includes/error-tracking.php
+++ b/includes/error-tracking.php
@@ -139,19 +139,9 @@ function _edd_die_handler() {
  * @return void
  */
 function edd_die( $message = '', $title = '', $status = 400 ) {
-
-	$doing_unit_tests = defined( 'EDD_UNIT_TESTS' ) && true === EDD_UNIT_TESTS;
-	$doing_api_call   = defined( 'EDD_DOING_API' )  && true === EDD_DOING_API;
-
-	if ( $doing_api_call && ! $doing_unit_tests ) {
-		exit;
-	}
-
-	if ( $doing_unit_tests ) {
-		add_filter( 'wp_die_ajax_handler', '_edd_die_handler', 10, 3 );
-		add_filter( 'wp_die_handler', '_edd_die_handler', 10, 3 );
-
-	}
+	add_filter( 'wp_die_ajax_handler', '_edd_die_handler', 10, 3 );
+	add_filter( 'wp_die_handler'     , '_edd_die_handler', 10, 3 );
+	add_filter( 'wp_die_json_handler', '_edd_die_handler', 10, 3 );
 
 	wp_die( $message, $title, array( 'response' => $status ));
 }

--- a/includes/error-tracking.php
+++ b/includes/error-tracking.php
@@ -139,13 +139,15 @@ function _edd_die_handler() {
  * @return void
  */
 function edd_die( $message = '', $title = '', $status = 400 ) {
-	
-	
-	if( defined( 'EDD_DOING_API' ) && true === EDD_DOING_API ) {
+
+	$doing_unit_tests = defined( 'EDD_UNIT_TESTS' ) && true === EDD_UNIT_TESTS;
+	$doing_api_call   = defined( 'EDD_DOING_API' )  && true === EDD_DOING_API;
+
+	if ( $doing_api_call && ! $doing_unit_tests ) {
 		exit;
 	}
 
-	if( defined( 'EDD_UNIT_TESTS' ) ) {
+	if ( $doing_unit_tests ) {
 		add_filter( 'wp_die_ajax_handler', '_edd_die_handler', 10, 3 );
 		add_filter( 'wp_die_handler', '_edd_die_handler', 10, 3 );
 

--- a/includes/error-tracking.php
+++ b/includes/error-tracking.php
@@ -139,7 +139,11 @@ function _edd_die_handler() {
  * @return void
  */
 function edd_die( $message = '', $title = '', $status = 400 ) {
-	add_filter( 'wp_die_ajax_handler', '_edd_die_handler', 10, 3 );
-	add_filter( 'wp_die_handler', '_edd_die_handler', 10, 3 );
-	wp_die( $message, $title, array( 'response' => $status ));
+	
+	if( defined( 'EDD_UNIT_TESTS' ) ) {
+		add_filter( 'wp_die_ajax_handler', '_edd_die_handler', 10, 3 );
+		add_filter( 'wp_die_handler', '_edd_die_handler', 10, 3 );
+		wp_die( $message, $title, array( 'response' => $status ));
+	}
+	exit;
 }


### PR DESCRIPTION
Fixes #7174

Proposed Changes:
1. Makes edd_die() synonymous with `exit()` when EDD API is running
2.Only register custom die handler when unit tests are running
