### PR TITLE
Remove Deprecated wpmu_new_blog Usage

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -229,26 +229,23 @@ function edd_run_install() {
  * When a new Blog is created in multisite, see if EDD is network activated, and run the installer
  *
  * @since  2.5
- * @param  int    $blog_id The Blog ID created
- * @param  int    $user_id The User ID set as the admin
- * @param  string $domain  The URL
- * @param  string $path    Site Path
- * @param  int    $site_id The Site ID
- * @param  array  $meta    Blog Meta
+ * @param  int $blog_id The Blog ID created
  * @return void
  */
-function edd_new_blog_created( $blog_id, $user_id, $domain, $path, $site_id, $meta ) {
-
-	if ( is_plugin_active_for_network( plugin_basename( EDD_PLUGIN_FILE ) ) ) {
-
-		switch_to_blog( $blog_id );
-		edd_install();
-		restore_current_blog();
-
+function edd_new_blog_created( $blog_id ) {
+	if ( ! is_plugin_active_for_network( plugin_basename( EDD_PLUGIN_FILE ) ) ) {
+		return;
 	}
 
+	switch_to_blog( $blog_id );
+	edd_install();
+	restore_current_blog();
 }
-add_action( 'wpmu_new_blog', 'edd_new_blog_created', 10, 6 );
+if ( version_compare( get_bloginfo( 'version' ), '5.1', '>=' ) ) {
+	add_action( 'wp_initialize_site', 'edd_new_blog_created' );
+} else {
+	add_action( 'wpmu_new_blog', 'edd_new_blog_created' );
+}
 
 
 /**

--- a/includes/install.php
+++ b/includes/install.php
@@ -229,15 +229,19 @@ function edd_run_install() {
  * When a new Blog is created in multisite, see if EDD is network activated, and run the installer
  *
  * @since  2.5
- * @param  int $blog_id The Blog ID created
+ * @param  int|WP_Site $blog WordPress 5.1 passes a WP_Site object.
  * @return void
  */
-function edd_new_blog_created( $blog_id ) {
+function edd_new_blog_created( $blog ) {
 	if ( ! is_plugin_active_for_network( plugin_basename( EDD_PLUGIN_FILE ) ) ) {
 		return;
 	}
 
-	switch_to_blog( $blog_id );
+	if ( ! is_int( $blog ) ) {
+		$blog_id = $blog_id->id;
+	}
+
+	switch_to_blog( $blog );
 	edd_install();
 	restore_current_blog();
 }
@@ -246,7 +250,6 @@ if ( version_compare( get_bloginfo( 'version' ), '5.1', '>=' ) ) {
 } else {
 	add_action( 'wpmu_new_blog', 'edd_new_blog_created' );
 }
-
 
 /**
  * Drop our custom tables when a mu site is deleted

--- a/includes/install.php
+++ b/includes/install.php
@@ -238,7 +238,7 @@ function edd_new_blog_created( $blog ) {
 	}
 
 	if ( ! is_int( $blog ) ) {
-		$blog_id = $blog_id->id;
+		$blog = $blog->id;
 	}
 
 	switch_to_blog( $blog );


### PR DESCRIPTION
Closes #7200

Proposed Changes:

1. Remove deprecated `wpmu_new_blog` usage in favor of `wp_initialize_site`