### PR TITLE
Fix race condition with user info and discounts

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -512,9 +512,9 @@ class EDD_Payment {
 		$this->customer_id     = $this->order->customer_id;
 		$this->user_id         = $this->setup_user_id();
 		$this->email           = $this->setup_email();
-		$this->user_info       = $this->setup_user_info();
 		$this->address         = $this->setup_address();
 		$this->discounts       = $this->setup_discounts();
+		$this->user_info       = $this->setup_user_info();
 		$this->first_name      = $this->user_info['first_name'];
 		$this->last_name       = $this->user_info['last_name'];
 


### PR DESCRIPTION
Fixes https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7215

Since user info uses discounts, wait until discounts have been set up, then run user setup. 

