### PR TITLE
Backfill date_completed times #7225

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -410,12 +410,6 @@ class Data_Migrator {
 
 		}
 
-		// Maybe convert the date completed to UTC.
-		$non_completed_statuses = apply_filters( 'edd_30_noncomplete_statuses', array ( 'pending', 'cancelled', 'abandoned', 'processing' ) );
-		if ( ! in_array( $order_status, $non_completed_statuses ) && '0000-00-00 00:00:00' !== $date_completed ) {
-			$date_completed = EDD()->utils->date( $date_completed, edd_get_timezone_id() )->setTimezone( 'UTC' )->toDateTimeString();
-		}
-
 		// Account for a situation where the post_date_gmt is set to 0000-00-00 00:00:00
 		$date_created_gmt = $data->post_date_gmt;
 		if ( '0000-00-00 00:00:00' === $date_created_gmt ) {
@@ -446,6 +440,18 @@ class Data_Migrator {
 			}
 
 			$date_created_gmt = $date_created_gmt->format('Y-m-d H:i:s');
+		}
+
+		// Maybe convert the date completed to UTC or backfill the date_completed.
+		$non_completed_statuses = apply_filters( 'edd_30_noncomplete_statuses', array ( 'pending', 'cancelled', 'abandoned', 'processing' ) );
+		if ( ! in_array( $order_status, $non_completed_statuses ) ) {
+
+			if ( '0000-00-00 00:00:00' !== $date_completed ) {  // Update the data_completed to the UTC.
+				$date_completed = EDD()->utils->date( $date_completed, edd_get_timezone_id() )->setTimezone( 'UTC' )->toDateTimeString();
+			} elseif ( '0000-00-00 00:00:00' === $date_completed ) { // Backfill a missing date_completed (for things like recurring payments).
+				$date_completed = $date_created_gmt;
+			}
+
 		}
 
 		// Find the parent payment, if there is one.


### PR DESCRIPTION
Fixes #7225

Proposed Changes:
1. If an order is migrated and is _not_ in a _non-completed_ status, and has a missing date_completed, use the post_date_gmt