### PR TITLE
Issue/7208 - Paged/Limit/Offset handling between List Table & Query class

### DIFF
--- a/includes/admin/class-list-table.php
+++ b/includes/admin/class-list-table.php
@@ -200,8 +200,8 @@ abstract class List_Table extends \WP_List_Table {
 			'orderby' => $orderby
 		) );
 
-		// Return (filtered & uniqued) args
-		return array_filter( array_unique( $r ) );
+		// Return args
+		return array_filter( $r );
 	}
 
 	/**

--- a/includes/admin/class-list-table.php
+++ b/includes/admin/class-list-table.php
@@ -27,6 +27,14 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 abstract class List_Table extends \WP_List_Table {
 
 	/**
+	 * Arguments for the data set.
+	 *
+	 * @since 3.0
+	 * @var   array
+	 */
+	public $args = array();
+
+	/**
 	 * Number of results to show per page.
 	 *
 	 * @since 3.0
@@ -156,6 +164,44 @@ abstract class List_Table extends \WP_List_Table {
 		}
 
 		return $views;
+	}
+
+	/**
+	 * Parse pagination query arguments into keys & values that the Query class
+	 * can understand and use to retrieve the correct results from the database.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $args
+	 *
+	 * @return array
+	 */
+	public function parse_pagination_args( $args = array() ) {
+
+		// Get pagination values
+		$order   = isset( $_GET['order']   ) ? sanitize_text_field( $_GET['order']   ) : 'DESC'; // WPCS: CSRF ok.
+		$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'id'; // WPCS: CSRF ok.
+		$paged   = $this->get_paged();
+
+		// Only perform paged math if numeric and greater than 1
+		if ( ! empty( $paged ) && is_numeric( $paged ) && ( $paged > 1 ) ) {
+			$offset = ceil( $this->per_page * ( $paged - 1 ) );
+
+		// Otherwise, default to the first page of results
+		} else {
+			$offset = 0;
+		}
+
+		// Parse pagination args into passed args
+		$r = wp_parse_args( $args, array(
+			'number'  => $this->per_page,
+			'offset'  => $offset,
+			'order'   => $order,
+			'orderby' => $orderby
+		) );
+
+		// Return (filtered & uniqued) args
+		return array_filter( array_unique( $r ) );
 	}
 
 	/**

--- a/includes/admin/customers/class-customer-addresses-table.php
+++ b/includes/admin/customers/class-customer-addresses-table.php
@@ -24,14 +24,6 @@ use EDD\Admin\List_Table;
 class EDD_Customer_Addresses_Table extends List_Table {
 
 	/**
-	 * The arguments for the data set
-	 *
-	 * @var array
-	 * @since  2.6
-	 */
-	public $args = array();
-
-	/**
 	 * Get things started
 	 *
 	 * @since 3.0
@@ -323,21 +315,9 @@ class EDD_Customer_Addresses_Table extends List_Table {
 	 * @return array $data All the row data
 	 */
 	public function get_data() {
-		$data    = array();
-		$paged   = $this->get_paged();
-		$offset  = $this->per_page * ( $paged - 1 );
-		$search  = $this->get_search();
-		$status  = $this->get_status();
-		$order   = isset( $_GET['order']   ) ? sanitize_text_field( $_GET['order']   ) : 'DESC'; // WPCS: CSRF ok.
-		$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'id'; // WPCS: CSRF ok.
-
-		$args = array(
-			'limit'   => $this->per_page,
-			'offset'  => $offset,
-			'order'   => $order,
-			'orderby' => $orderby,
-			'status'  => $status,
-		);
+		$data   = array();
+		$search = $this->get_search();
+		$args   = array( 'status' => $this->get_status() );
 
 		// Customer ID
 		if ( strpos( $search, 'c:' ) !== false ) {
@@ -373,10 +353,13 @@ class EDD_Customer_Addresses_Table extends List_Table {
 			$args['search_columns'] = array( 'address', 'address2', 'city', 'region', 'country', 'postal_code' );
 		}
 
-		$this->args = $args;
-		$addresses  = edd_get_customer_addresses( $args );
+		// Parse pagination
+		$this->args = $this->parse_pagination_args( $args );
 
-		if ( $addresses ) {
+		// Get the data
+		$addresses = edd_get_customer_addresses( $this->args );
+
+		if ( ! empty( $addresses ) ) {
 			foreach ( $addresses as $address ) {
 				$data[] = array(
 					'id'            => $address->id,

--- a/includes/admin/customers/class-customer-email-addresses-table.php
+++ b/includes/admin/customers/class-customer-email-addresses-table.php
@@ -24,14 +24,6 @@ use EDD\Admin\List_Table;
 class EDD_Customer_Email_Addresses_Table extends List_Table {
 
 	/**
-	 * The arguments for the data set
-	 *
-	 * @var array
-	 * @since  2.6
-	 */
-	public $args = array();
-
-	/**
 	 * Get things started
 	 *
 	 * @since 3.0
@@ -314,21 +306,9 @@ class EDD_Customer_Email_Addresses_Table extends List_Table {
 	 * @return array $data All the row data
 	 */
 	public function get_data() {
-		$data    = array();
-		$paged   = $this->get_paged();
-		$offset  = $this->per_page * ( $paged - 1 );
-		$search  = $this->get_search();
-		$status  = $this->get_status();
-		$order   = isset( $_GET['order']   ) ? sanitize_text_field( $_GET['order']   ) : 'DESC'; // WPCS: CSRF ok.
-		$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'id'; // WPCS: CSRF ok.
-
-		$args = array(
-			'limit'   => $this->per_page,
-			'offset'  => $offset,
-			'order'   => $order,
-			'orderby' => $orderby,
-			'status'  => $status,
-		);
+		$data   = array();
+		$search = $this->get_search();
+		$args   = array( 'status'  => $this->get_status() );
 
 		// Email
 		if ( is_email( $search ) ) {
@@ -348,10 +328,13 @@ class EDD_Customer_Email_Addresses_Table extends List_Table {
 			$args['search_columns'] = array( 'email' );
 		}
 
-		$this->args = $args;
-		$emails  = edd_get_customer_email_addresses( $args );
+		// Parse pagination
+		$this->args = $this->parse_pagination_args( $args );
 
-		if ( $emails ) {
+		// Get the data
+		$emails = edd_get_customer_email_addresses( $args );
+
+		if ( ! empty( $emails ) ) {
 			foreach ( $emails as $customer ) {
 				$data[] = array(
 					'id'           => $customer->id,

--- a/includes/admin/customers/class-customer-email-addresses-table.php
+++ b/includes/admin/customers/class-customer-email-addresses-table.php
@@ -332,7 +332,7 @@ class EDD_Customer_Email_Addresses_Table extends List_Table {
 		$this->args = $this->parse_pagination_args( $args );
 
 		// Get the data
-		$emails = edd_get_customer_email_addresses( $args );
+		$emails = edd_get_customer_email_addresses( $this->args );
 
 		if ( ! empty( $emails ) ) {
 			foreach ( $emails as $customer ) {

--- a/includes/admin/customers/class-customer-table.php
+++ b/includes/admin/customers/class-customer-table.php
@@ -24,14 +24,6 @@ use EDD\Admin\List_Table;
 class EDD_Customer_Reports_Table extends List_Table {
 
 	/**
-	 * The arguments for the data set
-	 *
-	 * @var array
-	 * @since  2.6
-	 */
-	public $args = array();
-
-	/**
 	 * Get things started
 	 *
 	 * @since 1.5
@@ -283,21 +275,9 @@ class EDD_Customer_Reports_Table extends List_Table {
 	 * @return array $data All the row data.
 	 */
 	public function get_data() {
-		$data    = array();
-		$paged   = $this->get_paged();
-		$offset  = $this->per_page * ( $paged - 1 );
-		$search  = $this->get_search();
-		$status  = $this->get_status();
-		$order   = isset( $_GET['order']   ) ? sanitize_text_field( $_GET['order']   ) : 'DESC'; // WPCS: CSRF ok.
-		$orderby = isset( $_GET['orderby'] ) ? sanitize_text_field( $_GET['orderby'] ) : 'id'; // WPCS: CSRF ok.
-
-		$args = array(
-			'limit'   => $this->per_page,
-			'offset'  => $offset,
-			'order'   => $order,
-			'orderby' => $orderby,
-			'status'  => $status,
-		);
+		$data   = array();
+		$search = $this->get_search();
+		$args   = array( 'status' => $this->get_status() );
 
 		// Email search
 		if ( is_email( $search ) ) {
@@ -321,10 +301,13 @@ class EDD_Customer_Reports_Table extends List_Table {
 			$args['search_columns'] = array( 'name', 'email' );
 		}
 
-		$this->args = $args;
-		$customers  = edd_get_customers( $args );
+		// Parse pagination
+		$this->args = $this->parse_pagination_args( $args );
 
-		if ( $customers ) {
+		// Get the data
+		$customers  = edd_get_customers( $this->args );
+
+		if ( ! empty( $customers ) ) {
 			foreach ( $customers as $customer ) {
 				$data[] = array(
 					'id'           => $customer->id,
@@ -362,7 +345,7 @@ class EDD_Customer_Reports_Table extends List_Table {
 		$this->set_pagination_args( array(
 			'total_pages' => ceil( $this->counts[ $status ] / $this->per_page ),
 			'total_items' => $this->counts[ $status ],
-			'per_page'    => $this->per_page
+			'per_page'    => $this->per_page,
 		) );
 	}
 }

--- a/includes/admin/discounts/class-discount-codes-table.php
+++ b/includes/admin/discounts/class-discount-codes-table.php
@@ -367,14 +367,15 @@ class EDD_Discount_Codes_Table extends List_Table {
 	 * @return array Discount codes table data.
 	 */
 	public function get_data() {
-		return edd_get_discounts( array(
-			'number'  => $this->per_page,
-			'paged'   => $this->get_paged(),
-			'orderby' => sanitize_text_field( $this->get_request_var( 'orderby', 'id'   ) ),
-			'order'   => sanitize_text_field( $this->get_request_var( 'order',   'DESC' ) ),
-			'status'  => $this->get_status(),
-			'search'  => $this->get_search()
+
+		// Parse pagination
+		$this->args = $this->parse_pagination_args( array(
+			'status' => $this->get_status(),
+			'search' => $this->get_search(),
 		) );
+
+		// Return data
+		return edd_get_discounts( $this->args );
 	}
 
 	/**
@@ -394,9 +395,9 @@ class EDD_Discount_Codes_Table extends List_Table {
 
 		// Setup pagination
 		$this->set_pagination_args( array(
+			'total_pages' => ceil( $this->counts[ $status ] / $this->per_page ),
 			'total_items' => $this->counts[ $status ],
 			'per_page'    => $this->per_page,
-			'total_pages' => ceil( $this->counts[ $status ] / $this->per_page )
 		) );
 	}
 }

--- a/includes/admin/payments/class-order-adjustments-table.php
+++ b/includes/admin/payments/class-order-adjustments-table.php
@@ -367,24 +367,19 @@ class Order_Adjustments_Table extends List_Table {
 		}
 
 		// Query args
-		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( $_GET['orderby'] ) : 'id';
-		$order   = isset( $_GET['order'] ) ? sanitize_key( $_GET['order'] ) : 'DESC';
-		$type    = isset( $_GET['type'] ) ? sanitize_key( $_GET['type'] ) : '';
-		$search  = isset( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : null;
-		$paged   = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
-		$id      = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
+		$type   = isset( $_GET['type'] ) ? sanitize_key( $_GET['type'] ) : '';
+		$search = isset( $_GET['s']    ) ? sanitize_text_field( $_GET['s'] ) : null;
+		$id     = isset( $_GET['id']   ) ? absint( $_GET['id'] ) : 0;
 
-		// Get order_adjustments
-		return edd_get_order_adjustments( array(
+		$this->args = $this->parse_pagination_args( array(
 			'object_id'   => $id,
 			'object_type' => 'order',
-			'number'      => $this->per_page,
-			'paged'       => $paged,
-			'orderby'     => $orderby,
-			'order'       => $order,
 			'type'        => $type,
 			'search'      => $search,
 		) );
+
+		// Get order_adjustments
+		return edd_get_order_adjustments( $this->args );
 	}
 
 	/**
@@ -407,9 +402,9 @@ class Order_Adjustments_Table extends List_Table {
 
 		// Setup pagination
 		$this->set_pagination_args( array(
+			'total_pages' => ceil( $this->counts[ $type ] / $this->per_page ),
 			'total_items' => $this->counts[ $type ],
 			'per_page'    => $this->per_page,
-			'total_pages' => ceil( $this->counts[ $type ] / $this->per_page ),
 		) );
 	}
 

--- a/includes/admin/payments/class-order-items-table.php
+++ b/includes/admin/payments/class-order-items-table.php
@@ -400,23 +400,19 @@ class Order_Items_Table extends List_Table {
 		}
 
 		// Query args.
-		$status  = $this->get_status();
-		$orderby = isset( $_GET['orderby'] ) ? sanitize_key( $_GET['orderby'] ) : 'id';
-		$order   = isset( $_GET['order'] ) ? sanitize_key( $_GET['order'] ) : 'DESC';
-		$search  = isset( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : null;
-		$paged   = isset( $_GET['paged'] ) ? absint( $_GET['paged'] ) : 1;
-		$id      = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
+		$status = $this->get_status();
+		$search = isset( $_GET['s']  ) ? sanitize_text_field( $_GET['s'] ) : null;
+		$id     = isset( $_GET['id'] ) ? absint( $_GET['id'] ) : 0;
 
-		// Get order items.
-		return edd_get_order_items( array(
+		// Set args.
+		$this->args = $this->parse_pagination_args( array(
 			'order_id' => $id,
-			'number'   => $this->per_page,
-			'paged'    => $paged,
-			'orderby'  => $orderby,
-			'order'    => $order,
 			'status'   => $status,
 			'search'   => $search,
 		) );
+
+		// Get order items.
+		return edd_get_order_items( $this->args );
 	}
 
 	/**
@@ -438,9 +434,9 @@ class Order_Items_Table extends List_Table {
 		// Maybe setup pagination.
 		if ( ! edd_is_add_order_page() ) {
 			$this->set_pagination_args( array(
+				'total_pages' => ceil( $this->counts[ $status ] / $this->per_page ),
 				'total_items' => $this->counts[ $status ],
 				'per_page'    => $this->per_page,
-				'total_pages' => ceil( $this->counts[ $status ] / $this->per_page ),
 			) );
 		}
 	}

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -638,22 +638,8 @@ class EDD_Payment_History_Table extends List_Table {
 	 */
 	public function get_payment_counts() {
 
-		$args = $this->parse_args();
-
-		// Remove some args that aren't used for counts.
-		if ( isset( $args['orderby'] ) ) {
-			unset( $args['orderby'] );
-		}
-
-		if ( isset( $args['order'] ) ) {
-			unset( $args['order'] );
-		}
-
-		if ( isset( $args['per_page'] ) ) {
-			unset( $args['per_page'] );
-		}
-
-		$args['paged'] = false;
+		// Get the args (without pagination)
+		$args = $this->parse_args( false );
 
 		// Get order counts by type
 		$this->counts = edd_get_order_counts( $args );
@@ -681,20 +667,15 @@ class EDD_Payment_History_Table extends List_Table {
 	 * @return array Orders table data.
 	 */
 	public function get_data() {
-		$args = array();
 
-		$per_page   = $this->per_page;
-		$args       = $this->parse_args();
-
-		// Drop in our per_page argument.
-		$args['per_page'] = $per_page;
-
-		// No empties
-		$r = wp_parse_args( array_filter( $args ) );
+		// Parse args (with pagination)
+		$this->args = $this->parse_args( true );
 
 		// Force EDD\Orders\Order objects to be returned
-		$r['output'] = 'orders';
-		$items = edd_get_orders( $r );
+		$this->args['output'] = 'orders';
+
+		// Get data
+		$items = edd_get_orders( $this->args );
 
 		// Get customer IDs and count from payments
 		$customer_ids = array_unique( wp_list_pluck( $items, 'customer_id' ) );
@@ -718,15 +699,14 @@ class EDD_Payment_History_Table extends List_Table {
 	 *
 	 * @since 3.0
 	 *
+	 * @param bool $paginate Whether to add pagination arguments
+	 *
 	 * @return array Array of arguments to use for querying orders.
 	 */
-	private function parse_args () {
+	private function parse_args( $paginate = true ) {
 		$status     = $this->get_status();
-		$paged      = isset( $_GET['paged'] )      ? absint( $_GET['paged'] )                   : null;
 		$user       = isset( $_GET['user'] )       ? absint( $_GET['user'] )                    : null;
 		$customer   = isset( $_GET['customer'] )   ? absint( $_GET['customer'] )                : null;
-		$orderby    = isset( $_GET['orderby'] )    ? sanitize_key( $_GET['orderby'] )           : 'date_created';
-		$order      = isset( $_GET['order'] )      ? sanitize_key( $_GET['order'] )             : 'DESC';
 		$search     = isset( $_GET['s'] )          ? sanitize_text_field( $_GET['s'] )          : null;
 		$start_date = isset( $_GET['start-date'] ) ? sanitize_text_field( $_GET['start-date'] ) : null;
 		$end_date   = isset( $_GET['end-date'] )   ? sanitize_text_field( $_GET['end-date'] )   : $start_date;
@@ -753,9 +733,6 @@ class EDD_Payment_History_Table extends List_Table {
 		}
 
 		$args = array(
-			'paged'    => $paged,
-			'orderby'  => $orderby,
-			'order'    => $order,
 			'user'     => $user,
 			'customer' => $customer,
 			'status'   => $status,
@@ -830,7 +807,10 @@ class EDD_Payment_History_Table extends List_Table {
 			$args['region'] = $region;
 		}
 
-		return $args;
+		// Return args, possibly with pagination
+		return ( true === $paginate )
+			? $this->parse_pagination_args( $args )
+			: $args;
 	}
 
 	/**
@@ -850,9 +830,9 @@ class EDD_Payment_History_Table extends List_Table {
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 
 		$this->set_pagination_args( array(
+			'total_pages' => ceil( $this->counts[ $status ] / $this->per_page ),
 			'total_items' => $this->counts[ $status ],
 			'per_page'    => $this->per_page,
-			'total_pages' => ceil( $this->counts[ $status ] / $this->per_page )
 		) );
 	}
 }

--- a/includes/admin/reporting/class-base-logs-list-table.php
+++ b/includes/admin/reporting/class-base-logs-list-table.php
@@ -319,13 +319,13 @@ class EDD_Base_Log_List_Table extends List_Table {
 		);
 
 		$this->items = $this->get_data();
-		$log_query   = $this->get_query_args();
+		$log_query   = $this->get_query_args( false );
 		$total_items = $this->get_total( $log_query );
 
 		$this->set_pagination_args( array(
+			'total_pages' => ceil( $total_items / $this->per_page ),
 			'total_items' => $total_items,
 			'per_page'    => $this->per_page,
-			'total_pages' => ceil( $total_items / $this->per_page )
 		) );
 	}
 
@@ -334,15 +334,11 @@ class EDD_Base_Log_List_Table extends List_Table {
 	 *
 	 * @since 3.0
 	 *
+	 * @param bool $paginate Whether to add pagination arguments
+	 *
 	 * @return array
 	 */
-	protected function get_query_args() {
-
-		// Pagination
-		$paged  = $this->get_paged();
-		$offset = ( $paged > 1 )
-			? ( ( $paged - 1 ) * $this->per_page )
-			: 0;
+	protected function get_query_args( $paginate = true ) {
 
 		// Defaults
 		$retval = array(
@@ -350,8 +346,6 @@ class EDD_Base_Log_List_Table extends List_Table {
 			'customer_id' => $this->get_filtered_customer(),
 			'payment_id'  => $this->get_filtered_payment(),
 			'meta_query'  => $this->get_meta_query(),
-			'offset'      => $offset,
-			'number'      => $this->per_page
 		);
 
 		// Search
@@ -403,7 +397,9 @@ class EDD_Base_Log_List_Table extends List_Table {
 		}
 
 		// Return query arguments
-		return $retval;
+		return ( true === $paginate )
+			? $this->parse_pagination_args( $retval )
+			: $retval;
 	}
 
 	/**

--- a/includes/admin/reporting/class-download-reports-table.php
+++ b/includes/admin/reporting/class-download-reports-table.php
@@ -267,9 +267,9 @@ class EDD_Download_Reports_Table extends List_Table {
 	 * @since 1.5
 	 * @uses EDD_Download_Reports_Table::get_columns()
 	 * @uses EDD_Download_Reports_Table::get_sortable_columns()
-	 * @uses EDD_Download_Reports_Table::reports_data()
-	 * @uses EDD_Download_Reports_Table::get_pagenum()
 	 * @uses EDD_Download_Reports_Table::get_total_downloads()
+	 * @uses EDD_Download_Reports_Table::get_data()
+	 * @uses EDD_Download_Reports_Table::set_pagination_args()
 	 * @return void
 	 */
 	public function prepare_items() {
@@ -283,9 +283,9 @@ class EDD_Download_Reports_Table extends List_Table {
 		$this->items = $this->get_data();
 
 		$this->set_pagination_args( array(
+			'total_pages' => ceil( $total_items / $this->per_page ),
 			'total_items' => $total_items,
 			'per_page'    => $this->per_page,
-			'total_pages' => ceil( $total_items / $this->per_page )
 		) );
 	}
 }

--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -811,10 +811,12 @@ class Query extends Base {
 		 */
 		do_action_ref_array( $this->apply_prefix( "pre_get_{$this->item_name_plural}" ), array( &$this ) );
 
-		// Never limit, never update item/meta caches when counting
+		// When counting, never limit/update/order, and no item/meta caches
 		if ( ! empty( $this->query_vars['count'] ) ) {
 			$this->query_vars['number']            = false;
 			$this->query_vars['offset']            = false;
+			$this->query_vars['order']             = false;
+			$this->query_vars['orderby']           = false;
 			$this->query_vars['no_found_rows']     = true;
 			$this->query_vars['update_item_cache'] = false;
 			$this->query_vars['update_meta_cache'] = false;

--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -814,6 +814,7 @@ class Query extends Base {
 		// Never limit, never update item/meta caches when counting
 		if ( ! empty( $this->query_vars['count'] ) ) {
 			$this->query_vars['number']            = false;
+			$this->query_vars['offset']            = false;
 			$this->query_vars['no_found_rows']     = true;
 			$this->query_vars['update_item_cache'] = false;
 			$this->query_vars['update_meta_cache'] = false;


### PR DESCRIPTION
Fixes #7208.

Proposed Changes:
1. Add `parse_pagination_args()` method to Base List Table class
2. Use `parse_pagination_args()` where necessary
3. A few small tweaks to the main `Query` class

This needs testing across:

- [ ] Orders
- [ ] Discounts
- [ ] Customers
- [ ] Customer Addresses
- [ ] Customer Email Addresses