### PR TITLE
add/add-states/province-and-currency-to-mozambique

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -105,6 +105,9 @@ function edd_get_shop_states( $country = null ) {
 		case 'MY' :
 			$states = edd_get_malaysian_states_list();
 			break;
+		case 'MZ' :
+			$states = edd_get_mozambique_states_list();
+			break;
 		case 'NP' :
 			$states = edd_get_nepalese_states_list();
 			break;
@@ -1524,6 +1527,31 @@ function edd_get_mexican_states_list() {
 	);
 
 	return apply_filters( 'edd_mexican_states', $states );
+}
+
+/**
+ * Get Mozambique States
+ *
+ * @since 2.9.13
+ * @return array $states A list of states
+ */
+function edd_get_mozambique_states_list() {
+	$states = array(
+		''       => '',
+		'MZ-MPM' => 'Maputo/city',
+		'MZ-P' 	 => 'Cabo Delgado',
+		'MZ-G'   => 'Gaza',
+		'MZ-I'   => 'Inhambane',
+		'MZ-B'   => 'Manica',
+		'MZ-L'   => 'Maputo',
+		'MZ-N'   => 'Nampula',
+		'MZ-A'   => 'Niassa',
+		'MZ-S'   => 'Sofala',
+		'MZ-T'   => 'Tete',
+		'MZ-Q'   => 'Zambézia',
+	);
+
+	return apply_filters( 'edd_mozambique_states', $states );
 }
 
 /**

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -344,6 +344,7 @@ function edd_get_currencies() {
 		'RIAL' => __( 'Iranian Rial (&#65020;)', 'easy-digital-downloads' ),
 		'RUB'  => __( 'Russian Rubles', 'easy-digital-downloads' ),
 		'AOA'  => __( 'Angolan Kwanza', 'easy-digital-downloads' ),
+		'MZM'  => __( 'Mozambique Metical', 'easy-digital-downloads' ),
 	);
 
 	return apply_filters( 'edd_currencies', $currencies );
@@ -397,6 +398,9 @@ function edd_currency_symbol( $currency = '' ) {
 			break;
 		case "AOA" :
 			$symbol = 'Kz';
+			break;
+		case "MZM" :
+			$symbol = 'MT;';
 			break;
 		default :
 			$symbol = $currency;


### PR DESCRIPTION
Subdivisions
1 city (en) / ville (fr) / cidade (pt)
10 province (en) / province (fr) / província (pt)

https://www.iso.org/obp/ui/fr/#iso:code:3166:MZ

MZM (Mozambique Metical) is the national currency the African nation of the Republic of Mozambique.

https://www.investopedia.com/terms/forex/m/mzm-mozambique-metical.asp
