### PR TITLE
Introduce 'Trash' and 'Restore' for orders and bulk actions.

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -475,6 +475,12 @@ class EDD_Notices {
 		// Shop reports errors
 		if ( current_user_can( 'view_shop_reports' ) ) {
 			switch( $notice ) {
+				case 'order_trashed' :
+					$this->add_notice( array(
+						'id'      => 'edd-order-trashed',
+						'message' => __( 'The order has been moved to the trash.', 'easy-digital-downloads' )
+					) );
+					break;
 				case 'payment_deleted' :
 					$this->add_notice( array(
 						'id'      => 'edd-payment-deleted',

--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -481,6 +481,12 @@ class EDD_Notices {
 						'message' => __( 'The order has been moved to the trash.', 'easy-digital-downloads' )
 					) );
 					break;
+				case 'order_restored' :
+					$this->add_notice( array(
+						'id'      => 'edd-order-restored',
+						'message' => __( 'The order has been restored.', 'easy-digital-downloads' )
+					) );
+					break;
 				case 'payment_deleted' :
 					$this->add_notice( array(
 						'id'      => 'edd-payment-deleted',

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -412,6 +412,29 @@ function edd_trigger_purchase_delete( $data ) {
 add_action( 'edd_delete_payment', 'edd_trigger_purchase_delete' );
 
 /**
+ * New in 3.0, destroys an order, and all it's data, and related data.
+ *
+ * @since 3.0
+ *
+ * @param $data
+ */
+function edd_trigger_destroy_order( $data ) {
+	if ( wp_verify_nonce( $data['_wpnonce'], 'edd_payment_nonce' ) ) {
+
+		$payment_id = absint( $data['purchase_id'] );
+
+		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
+			wp_die( __( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+		}
+
+		edd_destroy_order( $payment_id );
+
+		edd_redirect( admin_url( '/edit.php?post_type=download&page=edd-payment-history&edd-message=payment_deleted' ) );
+	}
+}
+add_action( 'edd_delete_order', 'edd_trigger_destroy_order' );
+
+/**
  * Trigger the action of moving an order to the 'trash' status
  *
  * @since 3.0
@@ -434,6 +457,30 @@ function edd_trigger_trash_order( $data ) {
 	}
 }
 add_action( 'edd_trash_order', 'edd_trigger_trash_order' );
+
+/**
+ * Trigger the action of restoring an order from the 'trash' status
+ *
+ * @since 3.0
+ *
+ * @param $data
+ * @return void
+ */
+function edd_trigger_restore_order( $data ) {
+	if ( wp_verify_nonce( $data['_wpnonce'], 'edd_payment_nonce' ) ) {
+
+		$payment_id = absint( $data['purchase_id'] );
+
+		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
+			wp_die( __( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+		}
+
+		edd_restore_order( $payment_id );
+
+		edd_redirect( admin_url( '/edit.php?post_type=download&page=edd-payment-history&edd-message=order_restored' ) );
+	}
+}
+add_action( 'edd_restore_order', 'edd_trigger_restore_order' );
 
 /**
  * Retrieves a new download link for a purchased file

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -412,6 +412,30 @@ function edd_trigger_purchase_delete( $data ) {
 add_action( 'edd_delete_payment', 'edd_trigger_purchase_delete' );
 
 /**
+ * Trigger the action of moving an order to the 'trash' status
+ *
+ * @since 3.0
+ *
+ * @param $data
+ * @return void
+ */
+function edd_trigger_trash_order( $data ) {
+	if ( wp_verify_nonce( $data['_wpnonce'], 'edd_payment_nonce' ) ) {
+
+		$payment_id = absint( $data['purchase_id'] );
+
+		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
+			wp_die( __( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+		}
+
+		edd_trash_order( $payment_id );
+
+		edd_redirect( admin_url( '/edit.php?post_type=download&page=edd-payment-history&edd-message=order_trashed' ) );
+	}
+}
+add_action( 'edd_trash_order', 'edd_trigger_trash_order' );
+
+/**
  * Retrieves a new download link for a purchased file
  *
  * @since 2.0

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -552,7 +552,7 @@ function edd_orders_list_table_process_bulk_actions() {
 		: '';
 
 	// Bail if we aren't processing bulk actions.
-	if ( 'action' !== $action ) {
+	if ( '-1' === $action ) {
 		return;
 	}
 
@@ -572,10 +572,12 @@ function edd_orders_list_table_process_bulk_actions() {
 
 	foreach ( $ids as $id ) {
 		switch ( $action ) {
-			case 'delete':
-				edd_delete_purchase( $id );
+			case 'trash':
+				edd_trash_order( $id );
 				break;
-
+			case 'restore':
+				edd_restore_order( $id );
+				break;
 			case 'set-status-complete':
 				edd_update_payment_status( $id, 'complete' );
 				break;

--- a/includes/admin/payments/class-order-items-table.php
+++ b/includes/admin/payments/class-order-items-table.php
@@ -216,7 +216,6 @@ class Order_Items_Table extends List_Table {
 		// No state
 		$state = '';
 
-		// Active, so add "deactivate" action
 		if ( empty( $status ) ) {
 			$row_actions['complete'] = '<a href="' . esc_url( wp_nonce_url( add_query_arg( array(
 					'edd-action' => 'handle_order_item_change',
@@ -238,7 +237,6 @@ class Order_Items_Table extends List_Table {
 					'order_item' => $order_item->id,
 				), $base ), 'edd_order_item_nonce' ) ) . '">' . __( 'Refund', 'easy-digital-downloads' ) . '</a>';
 
-			// Inactive, so add "activate" action
 		} elseif ( 'refunded' === $status ) {
 			$state                   = __( 'Refunded', 'easy-digital-downloads' );
 			$row_actions['activate'] = '<a href="' . esc_url( wp_nonce_url( add_query_arg( array(

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -544,17 +544,23 @@ class EDD_Payment_History_Table extends List_Table {
 
 		// Keep Delete at the end
 		if ( edd_is_order_trashable( $order->id ) ) {
-			$delete_url = wp_nonce_url( add_query_arg( array(
+			$trash_url = wp_nonce_url( add_query_arg( array(
 				'edd-action'  => 'trash_order',
 				'purchase_id' => $order->id,
 			), $this->base_url ), 'edd_payment_nonce' );
-			$row_actions['trash'] = '<a href="' . esc_url( $delete_url ) . '">' . esc_html__( 'Trash', 'easy-digital-downloads' ) . '</a>';
+			$row_actions['trash'] = '<a href="' . esc_url( $trash_url ) . '">' . esc_html__( 'Trash', 'easy-digital-downloads' ) . '</a>';
 		} elseif ( edd_is_order_restorable( $order->id ) ) {
-			$delete_url = wp_nonce_url( add_query_arg( array(
+			$restore_url = wp_nonce_url( add_query_arg( array(
 				'edd-action'  => 'restore_order',
 				'purchase_id' => $order->id,
 			), $this->base_url ), 'edd_payment_nonce' );
-			$row_actions['restore'] = '<a href="' . esc_url( $delete_url ) . '">' . esc_html__( 'Restore', 'easy-digital-downloads' ) . '</a>';
+			$row_actions['restore'] = '<a href="' . esc_url( $restore_url ) . '">' . esc_html__( 'Restore', 'easy-digital-downloads' ) . '</a>';
+
+			$delete_url = wp_nonce_url( add_query_arg( array(
+				'edd-action'  => 'delete_order',
+				'purchase_id' => $order->id,
+			), $this->base_url ), 'edd_payment_nonce' );
+			$row_actions['delete'] = '<a href="' . esc_url( $delete_url ) . '">' . esc_html__( 'Delete', 'easy-digital-downloads' ) . '</a>';
 		}
 
 

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -619,7 +619,7 @@ class EDD_Payment_History_Table extends List_Table {
 	 * @return array $actions Bulk actions.
 	 */
 	public function get_bulk_actions() {
-		return apply_filters( 'edd_payments_table_bulk_actions', array(
+		$action = array(
 			'set-status-complete'     => __( 'Mark Completed',   'easy-digital-downloads' ),
 			'set-status-pending'     => __( 'Mark Pending',     'easy-digital-downloads' ),
 			'set-status-processing'  => __( 'Mark Processing',  'easy-digital-downloads' ),
@@ -629,9 +629,16 @@ class EDD_Payment_History_Table extends List_Table {
 			'set-status-abandoned'   => __( 'Mark Abandoned',   'easy-digital-downloads' ),
 			'set-status-preapproval' => __( 'Mark Preapproved', 'easy-digital-downloads' ),
 			'set-status-cancelled'   => __( 'Mark Cancelled',   'easy-digital-downloads' ),
-			'resend-receipt'         => __( 'Resend  Receipts', 'easy-digital-downloads' ),
-			'delete'                 => __( 'Delete',           'easy-digital-downloads' )
-		) );
+			'resend-receipt'         => __( 'Resend Receipts', 'easy-digital-downloads' ),
+		);
+
+		if ( 'trash' === $this->get_status() ) {
+			$action['restore'] = __( 'Restore', 'easy-digital-downloads' );
+		} else {
+			$action['trash'] = __( 'Trash', 'easy-digital-downloads' );
+		}
+
+		return apply_filters( 'edd_payments_table_bulk_actions', $action );
 	}
 
 	/**

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -650,6 +650,8 @@ class EDD_Payment_History_Table extends List_Table {
 		// Get the args (without pagination)
 		$args = $this->parse_args( false );
 
+		unset( $args['status'], $args['status__not_in'], $args['status__in'] );
+
 		// Get order counts by type
 		$this->counts = edd_get_order_counts( $args );
 	}

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -691,7 +691,7 @@ class EDD_Payment_History_Table extends List_Table {
 		// Force EDD\Orders\Order objects to be returned
 		$this->args['output'] = 'orders';
 
-		if ( empty( $this->args['status'] ) || 'trash' !== $this->args['status'] ) {
+		if ( empty( $this->args['status'] ) ) {
 			$this->args['status__not_in'] = array( 'trash' );
 		}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1559,10 +1559,13 @@ function edd_format_counts( $counts = array(), $groupby = '' ) {
 		// Loop through statuses
 		foreach ( $counts->items as $count ) {
 			$c[ $count[ $groupby ] ] = absint( $count['count'] );
+
+			// We don't want to include trashed orders in the counts.
+			if ( 'trash' !== $count['status'] ) {
+				$c['total'] += $count['count'];
+			}
 		}
 
-		// Total
-		$c['total'] = array_sum( $c );
 	}
 
 	// Return array of counts

--- a/tests/orders/tests-trash.php
+++ b/tests/orders/tests-trash.php
@@ -61,4 +61,72 @@ class Trash_Tests extends \EDD_UnitTestCase {
 		self::$order_queries->update_item( self::$orders[1], array( 'status' => 'complete' ) );
 	}
 
+	/**
+	 * @covers ::edd_trash_order
+	 */
+	public function test_trash_order_should_return_true() {
+		$order = edd_get_order( self::$orders[0] );
+		$previous_status = $order->status;
+
+		$this->assertTrue( edd_trash_order( self::$orders[0] ) );
+
+		$order = edd_get_order( self::$orders[0] );
+		$this->assertSame( 'trash', $order->status );
+
+		// Update the status of any order to 'trashed'.
+		$order_items = edd_get_order_items( array(
+			'order_id'      => self::$orders[0],
+			'no_found_rows' => true,
+		) );
+
+		foreach ( $order_items as $order_item ) {
+			$this->assertSame( 'trash', $order_item->status );
+		}
+
+		$this->assertSame( $previous_status, edd_get_order_meta( self::$orders[0], '_pre_trash_status', true ) );
+	}
+
+	public function test_is_order_restorable_should_return_false() {
+		$this->assertFalse( edd_is_order_restorable( self::$orders[0] ) );
+	}
+
+	public function test_is_order_restorable_should_return_true() {
+		edd_trash_order( self::$orders[0] );
+		$this->assertTrue( edd_is_order_restorable( self::$orders[0] ) );
+	}
+
+	public function test_restore_order() {
+		$order = edd_get_order( self::$orders[0] );
+		$previous_status = $order->status;
+
+		edd_trash_order( self::$orders[0] );
+
+		$this->assertTrue( edd_is_order_restorable( self::$orders[0] ) );
+
+		$this->assertTrue( edd_restore_order( self::$orders[0] ) );
+		$order = edd_get_order( self::$orders[0] );
+		$this->assertSame( $previous_status, $order->status );
+		$this->assertEmpty( edd_get_order_meta( self::$orders[0], '_pre_trash_status', true ) );
+	}
+
+	public function test_trash_order_with_refunds() {
+		edd_refund_order( self::$orders[0] );
+		$refunds = edd_get_orders( array( 'parent' => self::$orders[0] ) );
+
+		$this->assertTrue( edd_is_order_trashable( self::$orders[0] ) );
+		$this->assertTrue( edd_is_order_trashable( self::$orders[0] ) );
+
+		edd_trash_order( self::$orders[0] );
+		$order   = edd_get_order( self::$orders[0] );
+		$refunds = edd_get_orders( array( 'parent' => self::$orders[0] ) );
+		$this->assertSame( 'trash', $order->status );
+
+		$this->assertFalse( edd_is_order_trashable( $refunds[0]->id ) );
+		$this->assertSame( 'trash', $refunds[0]->status );
+	}
+
+	public function test_restore_order_with_refunds() {
+
+	}
+
 }

--- a/tests/orders/tests-trash.php
+++ b/tests/orders/tests-trash.php
@@ -1,0 +1,64 @@
+<?php
+namespace EDD\Orders;
+
+use Carbon\Carbon;
+
+/**
+ * Trash Tests.
+ *
+ * @group edd_orders
+ * @group edd_trash
+ * @group database
+ *
+ * @coversDefaultClass \EDD\Orders\Order
+ */
+class Trash_Tests extends \EDD_UnitTestCase {
+
+	/**
+	 * Orders fixture.
+	 *
+	 * @var array
+	 * @static
+	 */
+	protected static $orders = array();
+
+	protected static $order_queries = null;
+
+	/**
+	 * Set up fixtures once.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$order_queries = new \EDD\Database\Queries\Order();
+		self::$orders = parent::edd()->order->create_many( 5 );
+
+		foreach ( self::$orders as $order ) {
+			edd_add_order_adjustment( array(
+				'object_type' => 'order',
+				'object_id'   => $order,
+				'type'        => 'discount',
+				'description' => '5OFF',
+				'subtotal'    => 0,
+				'total'       => 5,
+			) );
+		}
+	}
+
+	/**
+	 * @covers ::edd_is_order_trashable
+	 */
+	public function test_is_order_trashable_should_return_true() {
+		$this->assertTrue( edd_is_order_trashable( self::$orders[0] ) );
+	}
+
+	/**
+	 * @covers ::edd_is_order_trashable
+	 */
+	public function test_is_order_trashable_should_return_false() {
+		self::$order_queries->update_item( self::$orders[1], array( 'status' => 'trash' ) );
+		$this->assertFalse( edd_is_order_trashable( self::$orders[1] ) );
+
+		// Reset this order ID's status
+		self::$order_queries->update_item( self::$orders[1], array( 'status' => 'complete' ) );
+	}
+
+}


### PR DESCRIPTION
Fixes #7245 
Fixes #7224 

Proposed Changes:
1. Adds functions for trashing, and restoring.
2. Adds functions for checking something is trashable or restorable.
3. Extends the list table to be able to work with the statuses.
4. Fixes the bulk actions not working
5. Adds Trash and Restore to the bulk actions (conditionally)
