### PR TITLE
Fix saving product requirements when creating new discount #7263

### DIFF
--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -87,7 +87,7 @@ $minutes      = edd_get_minute_values();
 					</th>
 					<td>
 						<?php echo EDD()->html->product_dropdown( array(
-							'name'        => 'products[]',
+							'name'        => 'product_reqs[]',
 							'id'          => 'products',
 							'selected'    => array(),
 							'multiple'    => true,

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
 function edd_add_discount( $data = array() ) {
 
 	// Juggle requirements and products.
-	$product_requirements = isset( $data['products'] )          ? $data['products']          : null;
+	$product_requirements = isset( $data['product_reqs'] )      ? $data['product_reqs']      : null;
 	$excluded_products    = isset( $data['excluded_products'] ) ? $data['excluded_products'] : null;
 	unset( $data['product_reqs'], $data['excluded_products'] );
 

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -23,8 +23,8 @@ defined( 'ABSPATH' ) || exit;
 function edd_add_discount( $data = array() ) {
 
 	// Juggle requirements and products.
-	$product_requirements = isset( $data['product_reqs']      ) ? wp_parse_id_list( $data['product_reqs']      ) : null;
-	$excluded_products    = isset( $data['excluded_products'] ) ? wp_parse_id_list( $data['excluded_products'] ) : null;
+	$product_requirements = isset( $data['products'] )          ? $data['products']          : null;
+	$excluded_products    = isset( $data['excluded_products'] ) ? $data['excluded_products'] : null;
 	unset( $data['product_reqs'], $data['excluded_products'] );
 
 	// Setup the discounts query.


### PR DESCRIPTION
Fixes #7263

Proposed Changes:
1. Change the add discount product requirements field to follow suite with `product_reqs` as the input name, instead of `products`.
