### PR TITLE
If no gateways are active, do not show the purchase button by default (filter still runs)

### DIFF
--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -972,15 +972,21 @@ function edd_checkout_button_next() {
  * @return string
  */
 function edd_checkout_button_purchase() {
-	$color = edd_get_option( 'checkout_color', 'blue' );
-	$color = ( $color == 'inherit' ) ? '' : $color;
-	$style = edd_get_option( 'button_style', 'button' );
-	$label = edd_get_checkout_button_purchase_label();
+	$enabled_gateways = edd_get_enabled_payment_gateways();
 
 	ob_start();
-?>
-	<input type="submit" class="edd-submit <?php echo $color; ?> <?php echo $style; ?>" id="edd-purchase-button" name="edd-purchase" value="<?php echo $label; ?>"/>
-<?php
+
+	if ( ! empty( $enabled_gateways ) ) {
+		$color = edd_get_option( 'checkout_color', 'blue' );
+		$color = ( $color == 'inherit' ) ? '' : $color;
+		$style = edd_get_option( 'button_style', 'button' );
+		$label = edd_get_checkout_button_purchase_label();
+
+		?>
+		<input type="submit" class="edd-submit <?php echo $color; ?> <?php echo $style; ?>" id="edd-purchase-button" name="edd-purchase" value="<?php echo $label; ?>"/>
+		<?php
+	}
+
 	return apply_filters( 'edd_checkout_button_purchase', ob_get_clean() );
 }
 

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -976,7 +976,7 @@ function edd_checkout_button_purchase() {
 
 	ob_start();
 
-	if ( ! empty( $enabled_gateways ) ) {
+	if ( ! empty( $enabled_gateways ) || empty( edd_get_cart_total() ) ) {
 		$color = edd_get_option( 'checkout_color', 'blue' );
 		$color = ( $color == 'inherit' ) ? '' : $color;
 		$style = edd_get_option( 'button_style', 'button' );

--- a/includes/checkout/template.php
+++ b/includes/checkout/template.php
@@ -972,11 +972,13 @@ function edd_checkout_button_next() {
  * @return string
  */
 function edd_checkout_button_purchase() {
-	$enabled_gateways = edd_get_enabled_payment_gateways();
 
 	ob_start();
 
-	if ( ! empty( $enabled_gateways ) || empty( edd_get_cart_total() ) ) {
+	$enabled_gateways = edd_get_enabled_payment_gateways();
+	$cart_total       = edd_get_cart_total();
+
+	if ( ! empty( $enabled_gateways ) || empty( $cart_total ) ) {
 		$color = edd_get_option( 'checkout_color', 'blue' );
 		$color = ( $color == 'inherit' ) ? '' : $color;
 		$style = edd_get_option( 'button_style', 'button' );


### PR DESCRIPTION
Fixes #7247

Proposed Changes:
1. Wraps the default purchase link button in `edd_checkout_button_purchase` to verify that we have active gateways, to prevent a whitescreen when there are no gateways selected.