### PR TITLE
Allow order items to inherit the date_craeted in edd_add_order #7085

### DIFF
--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -826,6 +826,7 @@ function edd_build_order( $order_data = array() ) {
 				'tax'          => $item['tax'],
 				'total'        => $item['price'],
 				'item_price'   => $item['item_price'], // Added for backwards compatibility
+				'date_created' => ! empty( $order_data['date_created'] ) ? $order_data['date_created'] : '',
 			);
 
 			/**


### PR DESCRIPTION
Fixes #7085

Proposed Changes:
1. Allows order items to inherit the date_created in edd_add_order