### PR TITLE
Refactor how edd_get_payment_status finds the status, with unit tests  #7292

### DIFF
--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -711,28 +711,26 @@ function edd_get_payment_status( $payment, $return_label = false ) {
 
 	if( is_numeric( $payment ) ) {
 
-		$payment = new EDD_Payment( $payment );
+		$payment = edd_get_payment( $payment );
 
-		if( ! $payment->ID > 0 ) {
+		if( empty( $payment ) ) {
 			return false;
 		}
 
+	} else if ( $payment instanceof WP_Post ) {
+		$payment = edd_get_payment( $payment->ID );
 	}
 
-	if ( ! is_object( $payment ) || ! isset( $payment->post_status ) ) {
+	if ( ! is_object( $payment ) || ! isset( $payment->status ) ) {
 		return false;
 	}
 
 	if ( true === $return_label ) {
-		return edd_get_payment_status_label( $payment->post_status );
+		$status = edd_get_payment_status_label( $payment->status );
 	} else {
-		$statuses = edd_get_payment_statuses();
-
-		// Account that our 'publish' status is labeled 'Complete'
-		$post_status = 'publish' == $payment->status ? 'Complete' : $payment->post_status;
-
-		// Make sure we're matching cases, since they matter
-		return array_search( strtolower( $post_status ), array_map( 'strtolower', $statuses ) );
+		$keys      = edd_get_payment_status_keys();
+		$found_key = array_search( strtolower( $payment->status ), $keys );
+		$status    = array_key_exists( $found_key, $keys ) ? $keys[ $found_key ] : false;
 	}
 
 	return ! empty( $status ) ? $status : false;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,7 +36,7 @@ wp_update_user( array( 'ID' => 1, 'first_name' => 'Admin', 'last_name' => 'User'
 add_filter( 'edd_log_email_errors', '__return_false' );
 
 function _disable_reqs( $status = false, $args = array(), $url = '') {
-	return new WP_Error( 'no_reqs_in_unit_tests', __( 'HTTP Requests disbaled for unit tests', 'easy-digital-downloads' ) );
+	return new WP_Error( 'no_reqs_in_unit_tests', __( 'HTTP Requests disabled for unit tests', 'easy-digital-downloads' ) );
 }
 add_filter( 'pre_http_request', '_disable_reqs' );
 

--- a/tests/tests-payments.php
+++ b/tests/tests-payments.php
@@ -135,6 +135,21 @@ class Tests_Payments extends EDD_UnitTestCase {
 		$this->assertFalse( edd_get_payment_status( 1212121212121 ) );
 	}
 
+	public function test_get_payment_status_translated() {
+		add_filter( 'locale', function() { return 'fr_FR'; }, 10 );
+		$lang_file = EDD_PLUGIN_DIR . 'languages/easy-digital-downloads-fr_FR.mo';
+		load_textdomain( 'easy-digital-downloads', $lang_file );
+
+		$this->assertEquals( 'pending', edd_get_payment_status( $this->_payment_id ) );
+		$this->assertEquals( 'pending', edd_get_payment_status( get_post( $this->_payment_id ) ) );
+		$payment = new EDD_Payment( $this->_payment_id );
+		$this->assertEquals( 'pending', edd_get_payment_status( $payment ) );
+		$this->assertFalse( edd_get_payment_status( 1212121212121 ) );
+
+		remove_filter( 'locale', function() { return 'fr_FR'; }, 10 );
+		unload_textdomain( 'easy-digital-downloads' );
+	}
+
 	public function test_get_payment_status_label() {
 		$this->assertEquals( 'Pending', edd_get_payment_status( $this->_payment_id, true ) );
 		$this->assertEquals( 'Pending', edd_get_payment_status( get_post( $this->_payment_id ), true ) );


### PR DESCRIPTION
Fixes #7292

Proposed Changes:
1. Changes all references to possibly using post_status and WP_Post objects to using an EDD_Payment object.
2. Swaps use of literal status labels for the keys, which are not translated.
