### PR TITLE
Fix edd_order_item table to accept negative integers for quantity #7307

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -709,7 +709,7 @@ class Data_Migrator {
 					$refund_item_args['status']   = 'refunded';
 
 					// Negate the amounts
-					$refund_item_args['quantity'] = edd_negate_amount( $cart_item['quantity'] );
+					$refund_item_args['quantity'] = edd_negate_int( $cart_item['quantity'] );
 					$refund_item_args['amount']   = edd_negate_amount( (float) $cart_item['item_price'] );
 					$refund_item_args['subtotal'] = edd_negate_amount( $cart_item['subtotal'] );
 					$refund_item_args['discount'] = edd_negate_amount( $cart_item['discount'] );
@@ -838,7 +838,7 @@ class Data_Migrator {
 					$refund_item_args = $order_item_args;
 
 					$refund_item_args['order_id'] = $refund_id;
-					$refund_item_args['quantity'] = edd_negate_amount( 1 );
+					$refund_item_args['quantity'] = edd_negate_int( 1 );
 					$refund_item_args['amount']   = edd_negate_amount( (float) $payment_meta['amount'] );
 					$refund_item_args['subtotal'] = edd_negate_amount( (float) $payment_meta['amount'] );
 					$refund_item_args['total']    = edd_negate_amount( (float) $payment_meta['amount'] );

--- a/includes/database/tables/class-order-items.php
+++ b/includes/database/tables/class-order-items.php
@@ -38,7 +38,7 @@ final class Order_Items extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201906240001;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -50,6 +50,7 @@ final class Order_Items extends Table {
 	protected $upgrades = array(
 		'201807270002' => 201807270002,
 		'201807270003' => 201807270003,
+		'201906240001' => 201906240001,
 	);
 
 	/**
@@ -68,7 +69,7 @@ final class Order_Items extends Table {
 			cart_index bigint(20) unsigned NOT NULL default '0',
 			type varchar(20) NOT NULL default 'download',
 			status varchar(20) NOT NULL default '',
-			quantity bigint(20) unsigned NOT NULL default '0',
+			quantity int signed NOT NULL default '0',
 			amount decimal(18,9) NOT NULL default '0',
 			subtotal decimal(18,9) NOT NULL default '0',
 			discount decimal(18,9) NOT NULL default '0',
@@ -135,6 +136,24 @@ final class Order_Items extends Table {
 				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
 			" );
 		}
+
+		// Return success/fail
+		return $this->is_success( $result );
+	}
+
+	/**
+	 * Upgrade to version 201906240001
+	 * - Make the quantity column signed so it can contain negative numbers.
+	 * - Switch the quantity column from bigint to int for storage optimization.
+	 *
+	 * @since 3.0
+	 *
+	 * @return bool
+	 */
+	protected function __201906240001() {
+		$result = $this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY `quantity` int signed NOT NULL default '0';
+		" );
 
 		// Return success/fail
 		return $this->is_success( $result );

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1483,11 +1483,23 @@ function edd_admin_filter_bar( $context = '', $item = null ) {
  *
  * @since 3.0
  *
- * @param int|float $value Amount to negate.
+ * @param float $value Amount to negate.
  * @return float Negated amount.
  */
-function edd_negate_amount( $value = 0 ) {
+function edd_negate_amount( $value = 0.00 ) {
 	return abs( floatval( $value ) ) * -1;
+}
+
+/**
+ * Negate an integer
+ *
+ * @since 3.0
+ *
+ * @param int $value
+ * @return int
+ */
+function edd_negate_int( $value = 0 ) {
+	return intval( $value ) * -1;
 }
 
 /**

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -205,7 +205,7 @@ function edd_refund_order( $order_id = 0, $status = 'complete' ) {
 			'cart_index'   => $item->cart_index,
 			'type'         => $item->type,
 			'status'       => 'refunded',
-			'quantity'     => edd_negate_amount( $item->quantity ),
+			'quantity'     => edd_negate_int( $item->quantity ),
 			'amount'       => edd_negate_amount( $item->amount ),
 			'subtotal'     => edd_negate_amount( $item->subtotal ),
 			'discount'     => edd_negate_amount( $item->discount ),

--- a/tests/orders/tests-refunds.php
+++ b/tests/orders/tests-refunds.php
@@ -126,6 +126,10 @@ class Refunds_Tests extends \EDD_UnitTestCase {
 
 		// Verify total.
 		$this->assertSame( -120.0, floatval( $o->total ) );
+
+		$refunded_items = edd_Get_order_items( $refunded_order );
+
+		$this->assertEquals( edd_negate_int( $order_items[0]->quantity ), $refunded_items[0]->quantity );
 	}
 
 	/**

--- a/tests/orders/tests-refunds.php
+++ b/tests/orders/tests-refunds.php
@@ -127,7 +127,7 @@ class Refunds_Tests extends \EDD_UnitTestCase {
 		// Verify total.
 		$this->assertSame( -120.0, floatval( $o->total ) );
 
-		$refunded_items = edd_Get_order_items( $refunded_order );
+		$refunded_items = edd_get_order_items( $refunded_order );
 
 		$this->assertEquals( edd_negate_int( $order_items[0]->quantity ), $refunded_items[0]->quantity );
 	}

--- a/tests/phpunit/factories/class-edd-factory-for-orders.php
+++ b/tests/phpunit/factories/class-edd-factory-for-orders.php
@@ -51,6 +51,7 @@ class Order extends \WP_UnitTest_Factory_For_Thing {
 			'discount'     => 5,
 			'tax'          => 25,
 			'total'        => 120,
+			'quantity'     => 1,
 		) );
 
 		edd_add_order_adjustment( array(


### PR DESCRIPTION
Fixes #7307

Proposed Changes:
1. Updates `edd_order_items` table to use `signed int` for the `quantity` column.
2. Adds new `edd_negate_int` function and implements for negating integers instead of assuming floats.
3. Unit tests to verify negative values for refunded quantity