### PR TITLE
Move to using single 'name' column for customer/order addresses

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -55,6 +55,7 @@ class Data_Migrator {
 			edd_add_customer_address( array(
 				'customer_id' => $customer->id,
 				'type'        => 'primary',
+				'name'        => $customer->name,
 				'address'     => $address['line1'],
 				'address2'    => $address['line2'],
 				'city'        => $address['city'],
@@ -540,8 +541,7 @@ class Data_Migrator {
 
 		$order_address_data = array(
 			'order_id'    => $order_id,
-			'first_name'  => isset( $user_info['first_name'] )         ? $user_info['first_name']         : '',
-			'last_name'   => isset( $user_info['last_name'] )          ? $user_info['last_name']          : '',
+			'name'        => trim( $user_info['first_name'] . ' ' . $user_info['last_name'] ),
 			'address'     => isset( $user_info['address']['line1'] )   ? $user_info['address']['line1']   : '',
 			'address2'    => isset( $user_info['address']['line2'] )   ? $user_info['address']['line2']   : '',
 			'city'        => isset( $user_info['address']['city'] )    ? $user_info['address']['city']    : '',

--- a/includes/database/tables/class-customer-addresses.php
+++ b/includes/database/tables/class-customer-addresses.php
@@ -38,7 +38,7 @@ final class Customer_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201906250001;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -49,6 +49,7 @@ final class Customer_Addresses extends Table {
 	 */
 	protected $upgrades = array(
 		'201807270003' => 201807270003,
+		'201906250001' => 201906250001,
 	);
 
 	/**
@@ -63,6 +64,7 @@ final class Customer_Addresses extends Table {
 			customer_id bigint(20) unsigned NOT NULL default '0',
 			type varchar(20) NOT NULL default 'billing',
 			status varchar(20) NOT NULL default 'active',
+			name mediumtext NOT NULL,
 			address mediumtext NOT NULL,
 			address2 mediumtext NOT NULL,
 			city mediumtext NOT NULL,
@@ -100,6 +102,27 @@ final class Customer_Addresses extends Table {
 		}
 
 		// Return success/fail
+		return $this->is_success( $result );
+	}
+
+	/**
+	 * Upgrade to version 201906250001
+	 * - Add the `name` mediumtext column
+	 *
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	protected function __201906250001() {
+
+		$result = $this->column_exists( 'name' );
+
+		if ( false === $result ) {
+			$result = $this->get_db()->query( "
+				ALTER TABLE {$this->table_name} ADD COLUMN `name` mediumtext AFTER `status`;
+			" );
+		}
+
 		return $this->is_success( $result );
 	}
 }

--- a/includes/database/tables/class-order-addresses.php
+++ b/includes/database/tables/class-order-addresses.php
@@ -38,7 +38,7 @@ final class Order_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201906250001;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -49,6 +49,7 @@ final class Order_Addresses extends Table {
 	 */
 	protected $upgrades = array(
 		'201807270003' => 201807270003,
+		'201906250001' => 201906250001,
 	);
 
 	/**
@@ -62,8 +63,7 @@ final class Order_Addresses extends Table {
 		$max_index_length = 191;
 		$this->schema     = "id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 			order_id bigint(20) unsigned NOT NULL default '0',
-			first_name mediumtext NOT NULL,
-			last_name mediumtext NOT NULL,
+			name mediumtext NOT NULL,
 			address mediumtext NOT NULL,
 			address2 mediumtext NOT NULL,
 			city mediumtext NOT NULL,
@@ -105,4 +105,45 @@ final class Order_Addresses extends Table {
 		// Return success/fail
 		return $this->is_success( $result );
 	}
+
+	/**
+	 * Upgrade to version 201906250001
+	 * - Adds the 'name' column
+	 * - Combines the `first_name` and `last_name` columns to the `name` column.
+	 * - Removes the `first_name` and `last_name` columns.
+	 *
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	protected function __201906250001() {
+
+		$success = true;
+
+		$column_exists = $this->column_exists( 'name' );
+
+		// Don't take any action if the column already exists.
+		if ( false === $column_exists ) {
+			$column_exists = $this->get_db()->query( "
+				ALTER TABLE {$this->table_name} ADD COLUMN `name` mediumtext NOT NULL AFTER `last_name`;
+			" );
+
+		}
+
+		$deprecated_columns_exist = ( $this->column_exists( 'first_name' ) && $this->column_exists( 'last_name' ) );
+		if ( $column_exists && $deprecated_columns_exist ) {
+			$data_merged = $this->get_db()->query( "
+					UPDATE {$this->table_name} SET name = CONCAT(first_name, ' ', last_name);
+				" );
+
+			if ( $data_merged ) {
+				$success = $this->get_db()->query( "
+					ALTER TABLE {$this->table_name} DROP first_name, DROP last_name;
+				" );
+				}
+		}
+
+		return $this->is_success( $success );
+	}
+
 }


### PR DESCRIPTION
Fixes #7302 

Proposed Changes:
1. Converts the `first_name` and `last_name` columns in the `edd_order_addresses` table to a single `name` column, including upgrade routine to add the column, concat the strings to the new column, and removing the old column.
2. Adds the `name` column to the `edd_customer_addresses` table, including upgrade routine.
3. Updates the data migrator to use the new columns.
