### PR TITLE
Add price name to order_items table #7308

### DIFF
--- a/includes/admin/payments/class-order-items-table.php
+++ b/includes/admin/payments/class-order-items-table.php
@@ -260,6 +260,14 @@ class Order_Items_Table extends List_Table {
 				'post'  => $order_item->product_id,
 			), admin_url( 'post.php' )  ) . '">' . $order_item->get_order_item_name() . '</a>' . $state . '</strong>';
 
+		// See what the current name of the product is:
+		$current_product_name = edd_get_download_name( $order_item->product_id, $order_item->price_id );
+		if ( strtolower( htmlentities( $current_product_name ) ) !== strtolower( htmlentities( $order_item->get_order_item_name() ) ) ) {
+			$status_help = '<p>' . sprintf( __( 'This product has been renamed since this purchase. It is now %s.', 'easy-digital-downloads' ), $current_product_name );
+
+			$order_item_title .= ' <span alt="f223" class="edd-help-tip dashicons dashicons-backup" title="' . $status_help . '"></span>';
+		}
+
 		// Return order_item title & row actions
 		return apply_filters( 'edd_order_item_title_and_actions', $order_item_title . $this->row_actions( $row_actions ), $order_item );
 	}

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -636,6 +636,13 @@ class Data_Migrator {
 					? absint( $cart_item['item_number']['options']['price_id'] )
 					: 0;
 
+				if ( ! empty( $product_name ) ) {
+					$option_name = edd_get_price_option_name( $cart_item['id'], $price_id );
+					if ( ! empty( $option_name ) ) {
+						$product_name .= ' — ' . $option_name;
+					}
+				}
+
 				// Get item price.
 				$cart_item['item_price'] = isset( $cart_item['item_price'] )
 					? (float) $cart_item['item_price']

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -171,7 +171,7 @@ function edd_get_download_name( $download_id = 0, $price_id = 0 ) {
 
 		// Product has prices
 		if ( ! empty( $price_name ) ) {
-			$retval .= ' &mdash; ' . $price_name;
+			$retval .= ' — ' . $price_name;
 		}
 	}
 

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -182,6 +182,7 @@ function edd_get_email_body_content( $payment_id = 0, $payment_data = array() ) 
  */
 function edd_get_sale_notification_body_content( $payment_id = 0, $payment_data = array() ) {
 	$payment = edd_get_payment( $payment_id );
+	$order   = edd_get_order( $payment_id );
 
 	if( $payment->user_id > 0 ) {
 		$user_data = get_userdata( $payment->user_id );
@@ -194,16 +195,9 @@ function edd_get_sale_notification_body_content( $payment_id = 0, $payment_data 
 
 	$download_list = '';
 
-	if( is_array( $payment->downloads ) ) {
-		foreach( $payment->downloads as $item ) {
-			$download = new EDD_Download( $item['id'] );
-			$title    = $download->get_name();
-			if( isset( $item['options'] ) ) {
-				if( isset( $item['options']['price_id'] ) ) {
-					$title .= ' - ' . edd_get_price_option_name( $item['id'], $item['options']['price_id'], $payment_id );
-				}
-			}
-			$download_list .= html_entity_decode( $title, ENT_COMPAT, 'UTF-8' ) . "\n";
+	if( ! empty( $order->get_items() ) ) {
+		foreach( $order->get_items() as $item ) {
+			$download_list .= html_entity_decode( $item->product_name, ENT_COMPAT, 'UTF-8' ) . "\n";
 		}
 	}
 

--- a/includes/orders/classes/class-order-item.php
+++ b/includes/orders/classes/class-order-item.php
@@ -240,13 +240,6 @@ class Order_Item extends \EDD\Database\Rows\Order_Item {
 	 * @return string The product name including any price ID name.
 	 */
 	public function get_order_item_name() {
-
-		// Return product name if not a variable price
-		if ( ! edd_has_variable_prices( $this->product_id ) ) {
-			return $this->product_name;
-		}
-
-		// Get the download name, maybe with the price name appended
-		return edd_get_download_name( $this->product_id, $this->price_id );
+		return $this->product_name;
 	}
 }

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -811,10 +811,16 @@ function edd_build_order( $order_data = array() ) {
 				? $item['subtotal']
 				: (float) $item['quantity'] * $item['item_price'];
 
+			$item_name   = $item['name'];
+			$option_name = edd_get_price_option_name( $item['id'], $price_id );
+			if ( ! empty( $option_name ) ) {
+				$item_name .= ' — ' . $option_name;
+			}
+
 			$order_item_args = array(
 				'order_id'     => $order_id,
 				'product_id'   => $item['id'],
-				'product_name' => $item['name'],
+				'product_name' => $item_name,
 				'price_id'     => $price_id,
 				'cart_index'   => $key,
 				'type'         => 'download',


### PR DESCRIPTION
Fixes #7308

Proposed Changes:
1. Adds logic to `edd_build_order` to add the price ID name to an order_item when one exists.
2. Adds logic to the EDD order migrator to add the price ID name to an order_item when one exists.