### PR TITLE
3.0 - Override get_data() Methods in Customer Report List Tables

### DIFF
--- a/includes/reports/data/customers/class-most-valuable-customers-list-table.php
+++ b/includes/reports/data/customers/class-most-valuable-customers-list-table.php
@@ -34,7 +34,7 @@ class Most_Valuable_Customers_List_Table extends \EDD_Customer_Reports_Table {
 	 *
 	 * @return array $data Customers.
 	 */
-	public function reports_data() {
+	public function get_data() {
 		global $wpdb;
 
 		$data = array();

--- a/includes/reports/data/customers/class-top-five-customers-list-table.php
+++ b/includes/reports/data/customers/class-top-five-customers-list-table.php
@@ -32,7 +32,7 @@ class Top_Five_Customers_List_Table extends \EDD_Customer_Reports_Table {
 	 *
 	 * @return array $data Customers.
 	 */
-	public function reports_data() {
+	public function get_data() {
 		$data = array();
 
 		$args = array(


### PR DESCRIPTION
Fixes #7331

Proposed Changes:
1. Allow "Most Valuable Customers" and "Top 5 Customers" Report List Tables to properly set the report data by overriding the `get_data()` method, instead of the deprecated (and uncalled) `reports_data()` method.