### PR TITLE
Fix fees not being applied to orders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,12 @@ env:
 
 matrix:
   include:
-    - php: 7.1
-      env: WP_VERSION=latest WP_MULTISITE=0
-    - php: 7.1
-      env: WP_VERSION=4.7.12 WP_MULTISITE=0
     - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 5.3
-      env: WP_VERSION=4.7.12 WP_MULTISITE=0
+      env: WP_VERSION=4.7.13 WP_MULTISITE=0
       dist: precise
   exclude:
-    - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=0
     - php: 5.4
       env: WP_VERSION=latest WP_MULTISITE=0
     - php: 5.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,20 @@ sudo: false
 dist: trusty
 
 php:
-- 5.4
-- 5.5
-- 5.6
-- 7.0
-- 7.1
-- 7.2
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 env:
-- WP_VERSION=latest WP_MULTISITE=0
-- WP_VERSION=4.9.9 WP_MULTISITE=0
-- WP_VERSION=4.8.8 WP_MULTISITE=0
-- WP_VERSION=4.7.12 WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=5.1.1 WP_MULTISITE=0
+  - WP_VERSION=5.0.4 WP_MULTISITE=0
+  - WP_VERSION=4.9.10 WP_MULTISITE=0
+  - WP_VERSION=4.8.9 WP_MULTISITE=0
+  - WP_VERSION=4.7.13 WP_MULTISITE=0
 
 matrix:
   include:
@@ -26,11 +28,15 @@ matrix:
     - php: 5.6
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=0
-      dist: precise
-    - php: 5.3
       env: WP_VERSION=4.7.12 WP_MULTISITE=0
       dist: precise
+  exclude:
+    - php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.4
+      env: WP_VERSION=latest WP_MULTISITE=0
+    - php: 5.5
+      env: WP_VERSION=latest WP_MULTISITE=0
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
@@ -38,14 +44,13 @@ before_script:
   - composer install
 
 script:
-- phpenv config-rm xdebug.ini
-- vendor/bin/phpunit
+  - phpenv config-rm xdebug.ini
+  - vendor/bin/phpunit
 
 branches:
   only:
     - master
     - /^release\/.*$/
-    - issue/6236
 
 notifications:
   slack:

--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -164,15 +164,6 @@ function edd_edit_customer( $args = array() ) {
 			edd_add_customer_address( $address );
 		}
 
-		// Update some payment meta if we need to
-		$payments_array = explode( ',', $customer->payment_ids );
-
-		if ( (int) $customer->user_id !== (int) $previous_user_id ) {
-			foreach ( $payments_array as $payment_id ) {
-				edd_update_payment_meta( $payment_id, '_edd_payment_user_id', $customer->user_id );
-			}
-		}
-
 		$output['success']       = true;
 		$customer_data           = array_merge( $customer_data, $address );
 		$output['customer_info'] = $customer_data;
@@ -477,11 +468,6 @@ function edd_disconnect_customer_user_id( $args = array() ) {
 	$customer_args = array( 'user_id' => 0 );
 
 	if ( $customer->update( $customer_args ) ) {
-		global $wpdb;
-
-		if ( ! empty( $customer->payment_ids ) ) {
-			$wpdb->query( "UPDATE $wpdb->postmeta SET meta_value = 0 WHERE meta_key = '_edd_payment_user_id' AND post_id IN ( $customer->payment_ids )" );
-		}
 
 		$output['success'] = true;
 

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -552,6 +552,7 @@ class EDD_Discount extends Adjustment {
 		 */
 		$this->excluded_products = (array) edd_get_adjustment_meta( $this->id, 'excluded_product',    false );
 		$this->product_reqs      = (array) edd_get_adjustment_meta( $this->id, 'product_requirement', false );
+		$this->product_condition = (string) edd_get_adjustment_meta( $this->id, 'product_condition', true );
 
 		/**
 		 * Fires after the instance of the EDD_Discount object is set up. Allows extensions to add items to this object via hook.

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -376,11 +376,9 @@ class Utilities {
 				 * of the string timezone since DateTimeZone doesn't support instantiation from a GMT offset in these versions of PHP.
 				 *
 				 * timezone_name_from_abbr allows us to look up a TimeZone string like "America/Chicago" from the offset, which
-				 * will stop DateTimeZone from causing a fatal error in these circumstances. We need to account for opposite of DST here
-				 * in order to properly determine expected dates.
+				 * will stop DateTimeZone from causing a fatal error in these circumstances.
 				 */
 				$is_dst = date( 'I' );
-				$is_dst = empty( $is_dst ) ? 1 : 0;
 				$retval = timezone_name_from_abbr('', $gmt_offset, $is_dst );
 
 			} else {

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -376,10 +376,11 @@ class Utilities {
 				 * of the string timezone since DateTimeZone doesn't support instantiation from a GMT offset in these versions of PHP.
 				 *
 				 * timezone_name_from_abbr allows us to look up a TimeZone string like "America/Chicago" from the offset, which
-				 * will stop DateTimeZone from causing a fatal error in these circumstances. We are not accounting for DST here
-				 * since the user has picked a numeric offset, and thus shouldn't expect the DST to take affect.
+				 * will stop DateTimeZone from causing a fatal error in these circumstances. We need to account for opposite of DST here
+				 * in order to properly determine expected dates.
 				 */
-				$retval = timezone_name_from_abbr('', $gmt_offset, date( 'I' ) );
+				$is_dst = empty( date( 'I' ) ) ? 1 : 0;
+				$retval = timezone_name_from_abbr('', $gmt_offset, $is_dst );
 
 			} else {
 

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -379,7 +379,7 @@ class Utilities {
 				 * will stop DateTimeZone from causing a fatal error in these circumstances. We are not accounting for DST here
 				 * since the user has picked a numeric offset, and thus shouldn't expect the DST to take affect.
 				 */
-				$retval = timezone_name_from_abbr('', $gmt_offset, 0 );
+				$retval = timezone_name_from_abbr('', $gmt_offset, date( 'I' ) );
 
 			} else {
 

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -379,7 +379,8 @@ class Utilities {
 				 * will stop DateTimeZone from causing a fatal error in these circumstances. We need to account for opposite of DST here
 				 * in order to properly determine expected dates.
 				 */
-				$is_dst = empty( date( 'I' ) ) ? 1 : 0;
+				$is_dst = date( 'I' );
+				$is_dst = empty( $is_dst ) ? 1 : 0;
 				$retval = timezone_name_from_abbr('', $gmt_offset, $is_dst );
 
 			} else {

--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -1404,7 +1404,7 @@ class Query extends Base {
 
 		// Bail if malformed
 		if ( empty( $order ) || ! is_string( $order ) ) {
-			return `DESC`;
+			return 'DESC';
 		}
 
 		// Ascending or Descending

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -195,8 +195,9 @@ function edd_get_sale_notification_body_content( $payment_id = 0, $payment_data 
 
 	$download_list = '';
 
-	if( ! empty( $order->get_items() ) ) {
-		foreach( $order->get_items() as $item ) {
+	$order_items = $order->get_items();
+	if( ! empty( $order_items ) ) {
+		foreach( $order_items as $item ) {
 			$download_list .= html_entity_decode( $item->product_name, ENT_COMPAT, 'UTF-8' ) . "\n";
 		}
 	}

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -1000,11 +1000,6 @@ function edd_build_order( $order_data = array() ) {
 	if ( ! empty( $fees ) ) {
 		foreach ( $fees as $key => $fee ) {
 
-			// Skip adding fee if it was specific to a download in the cart.
-			if ( isset( $fee['download_id'] ) && ! empty( $fee['download_id'] ) ) {
-				continue;
-			}
-
 			add_filter( 'edd_prices_include_tax', '__return_false' );
 
 			$tax = ( isset( $fee['no_tax'] ) && false === $fee['no_tax'] ) || $fee['amount'] < 0

--- a/tests/customers/tests-customers.php
+++ b/tests/customers/tests-customers.php
@@ -365,4 +365,25 @@ class Tests_Customers extends \EDD_UnitTestCase {
 	public function test_get_customer_pending_payments_should_be_empty() {
 		$this->assertEmpty( self::$customers[0]->get_payments( 'pending' ) );
 	}
+
+	public function test_customer_and_user_order_lookup_success() {
+		self::$customers[0]->attach_payment( self::$order );
+
+		$customers_orders = edd_get_orders( array( 'customer_id' => self::$customers[0]->id, 'number' => 9999 ) );
+		$users_orders     = edd_get_orders( array( 'user_id' => self::$customers[0]->user_id, 'number' => 9999 ) );
+
+		$this->assertEquals( $customers_orders, $users_orders );
+	}
+
+	public function test_customer_and_user_order_lookup_success_after_user_id_change() {
+		self::$customers[0]->attach_payment( self::$order );
+
+		self::$customers[0]->update( array( 'user_id' => 2 ) );
+		$this->assertSame( '2', self::$customers[0]->user_id );
+
+		$customers_orders = edd_get_orders( array( 'customer_id' => self::$customers[0]->id, 'number' => 9999 ) );
+		$users_orders     = edd_get_orders( array( 'user_id' => self::$customers[0]->user_id, 'number' => 9999 ) );
+
+		$this->assertEquals( $customers_orders, $users_orders );
+	}
 }

--- a/tests/discounts/tests-discount-meta.php
+++ b/tests/discounts/tests-discount-meta.php
@@ -93,7 +93,7 @@ class Tests_Meta extends \EDD_UnitTestCase {
 	 * @covers EDD_Discount::get_meta()
 	 */
 	public function test_get_metadata_with_no_args_should_return_array() {
-		$this->assertEmpty( edd_get_adjustment_meta( self::$discount_id ) );
+		$this->assertSame( 1, count( edd_get_adjustment_meta( self::$discount_id ) ) );
 	}
 
 	/**
@@ -128,5 +128,12 @@ class Tests_Meta extends \EDD_UnitTestCase {
 	 */
 	public function test_delete_metadata_with_invalid_key_should_return_false() {
 		$this->assertFalse( edd_delete_adjustment_meta( self::$discount_id,  'key_that_does_not_exist' ) );
+	}
+
+	/**
+	 * @covers \edd_get_discount_product_condition()
+	 */
+	public function test_discount_product_condition() {
+		$this->assertSame( 'all', edd_get_discount_product_condition( self::$discount_id ) );
 	}
 }

--- a/tests/discounts/tests-discounts.php
+++ b/tests/discounts/tests-discounts.php
@@ -592,13 +592,6 @@ class Tests_Discounts extends \EDD_UnitTestCase {
 	}
 
 	/**
-	 * @covers \edd_get_discount_product_condition()
-	 */
-	public function test_discount_product_condition() {
-		$this->assertSame( 'all', edd_get_discount_product_condition( self::$discount_id ) );
-	}
-
-	/**
 	 * @covers \edd_is_discount_not_global()
 	 */
 	public function test_discount_is_not_global() {

--- a/tests/reports/tests-reports-functions.php
+++ b/tests/reports/tests-reports-functions.php
@@ -425,8 +425,8 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 	 */
 	public function test_parse_dates_for_range_with_today_range_should_return_those_dates() {
 		$expected = array(
-			'start' => self::$date->copy()->startOfDay()->toDateTimeString(),
-			'end'   => self::$date->copy()->endOfDay()->toDateTimeString(),
+			'start' => self::$date->copy()->setTimezone( edd_get_timezone_id() )->startOfDay()->setTimezone( 'UTC' ),
+			'end'   => self::$date->copy()->setTimezone( edd_get_timezone_id() )->endOfDay()->setTimezone( 'UTC' ),
 			'range' => 'today',
 		);
 
@@ -445,8 +445,8 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 	 */
 	public function test_parse_dates_for_range_with_yesterday_range_should_return_those_dates() {
 		$expected = array(
-			'start' => self::$date->copy()->subDay( 1 )->startOfDay()->toDateTimeString(),
-			'end'   => self::$date->copy()->subDay( 1 )->endOfDay()->toDateTimeString(),
+			'start' => self::$date->copy()->setTimezone( edd_get_timezone_id() )->subDay( 1 )->startOfDay()->setTimezone( 'UTC' ),
+			'end'   => self::$date->copy()->setTimezone( edd_get_timezone_id() )->subDay( 1 )->endOfDay()->setTimezone( 'UTC' ),
 			'range' => 'yesterday',
 		);
 

--- a/tests/tests-date-functions.php
+++ b/tests/tests-date-functions.php
@@ -67,7 +67,8 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 		if ( version_compare( phpversion(), '5.5', '<' ) ) {
 
 			// Tests our logic around a shortcoming in PHP 5.3 and 5.4 with DateTimeZone
-			$expected = timezone_name_from_abbr('', get_option( 'gmt_offset', 0 ) * HOUR_IN_SECONDS, 0 );
+			$is_dst   = date( 'I' );
+			$expected = timezone_name_from_abbr('', get_option( 'gmt_offset', 0 ) * HOUR_IN_SECONDS, $is_dst );
 			$this->assertSame( $expected, edd_get_timezone_id() );
 
 		} else {

--- a/tests/tests-misc.php
+++ b/tests/tests-misc.php
@@ -699,7 +699,6 @@ class Test_Misc extends EDD_UnitTestCase {
 
 	public function test_array_convert() {
 		$customer1_id = edd_add_customer( array( 'email' => 'test10@example.com' ) );
-		$customer2_id = edd_add_customer( array( 'email' => 'test11@example.com' ) );
 
 		// Test sending a single object in
 		$customer_object = new EDD_Customer( $customer1_id );


### PR DESCRIPTION
Fixes #7243 

I am not sure why this was being prevented. The furthest back I was able to trace it was here:

https://github.com/easydigitaldownloads/easy-digital-downloads/blame/release/3.0/includes/orders/functions/orders.php#L1003

Any ideas why that line might have been added @JJJ? Do you think it is safe to remove it?

Additionally, this issue uncovered an issue with the flow to the gateway. The gateways were recording this properly, while EDD was not (and thus the customer's receipt was for the wrong amount). 

That is because [send_to_gateway](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/issue/7243/includes/process-purchase.php#L195) is passed data from the session, as opposed to data from the custom tables.

To ensure that the same data is used for everything (and to help avoid these types of data-sync issues), I wonder if `edd_process_purchase_form` should call `edd_build_order`. Then, in `edd_build_order` we can call `send_to_gateway` and pass the data directly from the tables.

This would prevent the customer ever being charged something their receipt does not show. That might be a separate issue to tackle though. I just noticed it here and thought it was important to make a note of.
