### PR TITLE
Consistently handle user ID changes on orders and customer

### DIFF
--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -164,15 +164,6 @@ function edd_edit_customer( $args = array() ) {
 			edd_add_customer_address( $address );
 		}
 
-		if ( (int) $customer->user_id !== (int) $previous_user_id ) {
-			// Update some payment meta if we need to
-			$order_ids = edd_get_orders( array( 'customer_id' => $customer->id, 'number' => 9999 ) );
-
-			foreach ( $order_ids as $order_id ) {
-				edd_update_order( $order_id, array( 'user_id' => $customer->user_id ) );
-			}
-		}
-
 		$output['success']       = true;
 		$customer_data           = array_merge( $customer_data, $address );
 		$output['customer_info'] = $customer_data;
@@ -477,11 +468,6 @@ function edd_disconnect_customer_user_id( $args = array() ) {
 	$customer_args = array( 'user_id' => 0 );
 
 	if ( $customer->update( $customer_args ) ) {
-
-		$order_ids = edd_get_orders( array( 'customer_id' => $customer->id, 'number' => 9999 ) );
-		foreach ( $order_ids as $order_id ) {
-			edd_update_order( $order_id, array( 'user_id' => 0 ) );
-		}
 
 		$output['success'] = true;
 

--- a/includes/admin/customers/customer-actions.php
+++ b/includes/admin/customers/customer-actions.php
@@ -164,12 +164,12 @@ function edd_edit_customer( $args = array() ) {
 			edd_add_customer_address( $address );
 		}
 
-		// Update some payment meta if we need to
-		$payments_array = explode( ',', $customer->payment_ids );
-
 		if ( (int) $customer->user_id !== (int) $previous_user_id ) {
-			foreach ( $payments_array as $payment_id ) {
-				edd_update_payment_meta( $payment_id, '_edd_payment_user_id', $customer->user_id );
+			// Update some payment meta if we need to
+			$order_ids = edd_get_orders( array( 'customer_id' => $customer->id, 'number' => 9999 ) );
+
+			foreach ( $order_ids as $order_id ) {
+				edd_update_order( $order_id, array( 'user_id' => $customer->user_id ) );
 			}
 		}
 
@@ -477,10 +477,10 @@ function edd_disconnect_customer_user_id( $args = array() ) {
 	$customer_args = array( 'user_id' => 0 );
 
 	if ( $customer->update( $customer_args ) ) {
-		global $wpdb;
 
-		if ( ! empty( $customer->payment_ids ) ) {
-			$wpdb->query( "UPDATE $wpdb->postmeta SET meta_value = 0 WHERE meta_key = '_edd_payment_user_id' AND post_id IN ( $customer->payment_ids )" );
+		$order_ids = edd_get_orders( array( 'customer_id' => $customer->id, 'number' => 9999 ) );
+		foreach ( $order_ids as $order_id ) {
+			edd_update_order( $order_id, array( 'user_id' => 0 ) );
 		}
 
 		$output['success'] = true;

--- a/tests/customers/tests-customers.php
+++ b/tests/customers/tests-customers.php
@@ -365,4 +365,25 @@ class Tests_Customers extends \EDD_UnitTestCase {
 	public function test_get_customer_pending_payments_should_be_empty() {
 		$this->assertEmpty( self::$customers[0]->get_payments( 'pending' ) );
 	}
+
+	public function test_customer_and_user_order_lookup_success() {
+		self::$customers[0]->attach_payment( self::$order );
+
+		$customers_orders = edd_get_orders( array( 'customer_id' => self::$customers[0]->id, 'number' => 9999 ) );
+		$users_orders     = edd_get_orders( array( 'user_id' => self::$customers[0]->user_id, 'number' => 9999 ) );
+
+		$this->assertEquals( $customers_orders, $users_orders );
+	}
+
+	public function test_customer_and_user_order_lookup_success_after_user_id_change() {
+		self::$customers[0]->attach_payment( self::$order );
+
+		self::$customers[0]->update( array( 'user_id' => 2 ) );
+		$this->assertSame( '2', self::$customers[0]->user_id );
+
+		$customers_orders = edd_get_orders( array( 'customer_id' => self::$customers[0]->id, 'number' => 9999 ) );
+		$users_orders     = edd_get_orders( array( 'user_id' => self::$customers[0]->user_id, 'number' => 9999 ) );
+
+		$this->assertEquals( $customers_orders, $users_orders );
+	}
 }


### PR DESCRIPTION
Fixes #7321

Proposed Changes:
1. Alters the change and remove User ID actions when altering a customer to alter the orders as well.
