### PR TITLE
Fix product condition meta

### DIFF
--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -552,6 +552,7 @@ class EDD_Discount extends Adjustment {
 		 */
 		$this->excluded_products = (array) edd_get_adjustment_meta( $this->id, 'excluded_product',    false );
 		$this->product_reqs      = (array) edd_get_adjustment_meta( $this->id, 'product_requirement', false );
+		$this->product_condition = (string) edd_get_adjustment_meta( $this->id, 'product_condition', true );
 
 		/**
 		 * Fires after the instance of the EDD_Discount object is set up. Allows extensions to add items to this object via hook.

--- a/tests/discounts/tests-discount-meta.php
+++ b/tests/discounts/tests-discount-meta.php
@@ -93,7 +93,7 @@ class Tests_Meta extends \EDD_UnitTestCase {
 	 * @covers EDD_Discount::get_meta()
 	 */
 	public function test_get_metadata_with_no_args_should_return_array() {
-		$this->assertEmpty( edd_get_adjustment_meta( self::$discount_id ) );
+		$this->assertSame( 1, count( edd_get_adjustment_meta( self::$discount_id ) ) );
 	}
 
 	/**
@@ -128,5 +128,12 @@ class Tests_Meta extends \EDD_UnitTestCase {
 	 */
 	public function test_delete_metadata_with_invalid_key_should_return_false() {
 		$this->assertFalse( edd_delete_adjustment_meta( self::$discount_id,  'key_that_does_not_exist' ) );
+	}
+
+	/**
+	 * @covers \edd_get_discount_product_condition()
+	 */
+	public function test_discount_product_condition() {
+		$this->assertSame( 'all', edd_get_discount_product_condition( self::$discount_id ) );
 	}
 }

--- a/tests/discounts/tests-discounts.php
+++ b/tests/discounts/tests-discounts.php
@@ -79,6 +79,10 @@ class Tests_Discounts extends \EDD_UnitTestCase {
 		parent::tearDown();
 	}
 
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+	}
+
 	/**
 	 * @covers ::setup_discount()
 	 */
@@ -589,13 +593,6 @@ class Tests_Discounts extends \EDD_UnitTestCase {
 	 */
 	public function test_discount_type() {
 		$this->assertSame( 'percent', edd_get_discount_type( self::$discount_id ) );
-	}
-
-	/**
-	 * @covers \edd_get_discount_product_condition()
-	 */
-	public function test_discount_product_condition() {
-		$this->assertSame( 'all', edd_get_discount_product_condition( self::$discount_id ) );
 	}
 
 	/**

--- a/tests/discounts/tests-discounts.php
+++ b/tests/discounts/tests-discounts.php
@@ -79,10 +79,6 @@ class Tests_Discounts extends \EDD_UnitTestCase {
 		parent::tearDown();
 	}
 
-	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
-	}
-
 	/**
 	 * @covers ::setup_discount()
 	 */


### PR DESCRIPTION
Fixes #7349 

Proposed Changes:
1. Updates unit tests around product_conditions
2. Adds `product_conditions` to the meta table
3. Removes `product_conditions` from the meta table when product requirements are removed from a discount.