### PR TITLE
Migrate jQuery to Vanilla JS for the frontend

### DIFF
--- a/assets/js/frontend/checkout/index.js
+++ b/assets/js/frontend/checkout/index.js
@@ -66,7 +66,9 @@ export function recalculate_taxes( state ) {
 				tax_data.response = tax_response;
 				jQuery( 'body' ).trigger( 'edd_taxes_recalculated', [ tax_data ] );
 			}
-			jQuery( '.edd-recalculate-taxes-loading' ).remove();
+			document.querySelectorAll( '.edd-recalculate-taxes-loading' ).forEach( function( el ) {
+				el.parentNode.removeChild( el );
+			} );
 		},
 	} ).fail( function( data ) {
 		if ( window.console && window.console.log ) {

--- a/assets/js/frontend/checkout/index.js
+++ b/assets/js/frontend/checkout/index.js
@@ -157,12 +157,14 @@ window.EDD_Checkout = ( function( $ ) {
 		// When discount link is clicked, hide the link, then show the discount input and set focus.
 		$body.on( 'click', '.edd_discount_link', function( e ) {
 			e.preventDefault();
-			$( '.edd_discount_link' ).parent().hide();
+			document.querySelectorAll( '.edd_discount_link' ).forEach( function( el ) {
+				el.parentNode.style.display = 'none';
+			} );
 			$( '#edd-discount-code-wrap' ).show().find( '#edd-discount' ).focus();
 		} );
 
 		// Hide / show discount fields for browsers without javascript enabled
-		$body.find( '#edd-discount-code-wrap' ).hide();
+		document.body.querySelector( '#edd-discount-code-wrap' ).style.display = 'none';
 		$body.find( '#edd_show_discount' ).show();
 
 		// Update the checkout when item quantities are updated
@@ -228,7 +230,9 @@ window.EDD_Checkout = ( function( $ ) {
 			form: $( '#edd_purchase_form' ).serialize(),
 		};
 
-		$( '#edd-discount-error-wrap' ).html( '' ).hide();
+		document.querySelector( '#edd-discount-error-wrap' ).innerHTML               = '';
+		document.querySelector( '#edd-discount-error-wrap' ).innerHTML.style.display = 'none';
+
 		edd_discount_loader.show();
 
 		$.ajax( {
@@ -281,7 +285,7 @@ window.EDD_Checkout = ( function( $ ) {
 					}
 					$body.trigger( 'edd_discount_failed', [ discount_response ] );
 				}
-				edd_discount_loader.hide();
+				document.querySelector( '#edd-discount-loader' ).style.display = 'none';
 			},
 		} ).fail( function( data ) {
 			if ( window.console && window.console.log ) {
@@ -325,7 +329,9 @@ window.EDD_Checkout = ( function( $ ) {
 				$( '.edd_cart_discount' ).html( discount_response.html );
 
 				if ( ! discount_response.discounts ) {
-					$( '.edd_cart_discount_row' ).hide();
+					document.querySelectorAll( '.edd_cart_discount_row' ).forEach( function( el ) {
+						el.style.display = 'none';
+					} );
 				}
 
 				recalculate_taxes();

--- a/assets/js/frontend/checkout/index.js
+++ b/assets/js/frontend/checkout/index.js
@@ -18,14 +18,14 @@ export function recalculate_taxes( state ) {
 		return;
 	} // Taxes not enabled
 
-	const $edd_cc_address = jQuery( '#edd_cc_address' );
+	const edd_cc_address = document.querySelector( '#edd_cc_address' );
 
-	const billing_country = $edd_cc_address.find( '#billing_country' ).val(),
-		card_address = $edd_cc_address.find( '#card_address' ).val(),
-		card_address_2 = $edd_cc_address.find( '#card_address_2' ).val(),
-		card_city = $edd_cc_address.find( '#card_city' ).val(),
-		card_state = $edd_cc_address.find( '#card_state' ).val(),
-		card_zip = $edd_cc_address.find( '#card_zip' ).val();
+	const billing_country = edd_cc_address.querySelector( '#billing_country' ).value,
+		card_address      = edd_cc_address.querySelector( '#card_address' ).value,
+		card_address_2    = edd_cc_address.querySelector( '#card_address_2' ).value,
+		card_city         = edd_cc_address.querySelector( '#card_city' ).value,
+		card_state        = edd_cc_address.querySelector( '#card_state' ).value,
+		card_zip          = edd_cc_address.querySelector( '#card_zip' ).value;
 
 	if ( ! state ) {
 		state = card_state;

--- a/assets/js/frontend/edd-ajax.js
+++ b/assets/js/frontend/edd-ajax.js
@@ -67,8 +67,10 @@ jQuery( document ).ready( function( $ ) {
 					}
 
 					// Remove the selected cart item
-					$( '.edd-cart' ).each( function() {
-						$( this ).find( "[data-cart-item='" + item + "']" ).parent().remove();
+					document.querySelectorAll( '.edd-cart' ).forEach( function( el ) {
+						el.querySelectorAll( "[data-cart-item='" + item + "']" ).forEach( function( cartEl ) {
+							cartEl.parentNode.parentNode.removeChild( cartEl.parentNode );
+						} );
 					} );
 
 					//Reset the data-cart-item attributes to match their new values in the EDD session cart array
@@ -363,13 +365,16 @@ jQuery( document ).ready( function( $ ) {
 		};
 
 		$.post( edd_global_vars.ajaxurl, data, function( data ) {
+			document.querySelectorAll( '.edd_errors' ).forEach( function( el ) {
+				el.parentNode.removeChild( el );
+			} );
 			if ( $.trim( data ) === 'success' ) {
-				$( '.edd_errors' ).remove();
 				window.location = edd_scripts.checkout_page;
 			} else {
 				$( '#edd_login_fields input[type=submit]' ).val( complete_purchase_val );
-				$( '.edd-loading-ajax' ).remove();
-				$( '.edd_errors' ).remove();
+				document.querySelectorAll( '.edd-loading-ajax' ).forEach( function( el ) {
+					el.parentNode.removeChild( el );
+				} );
 				$( '#edd-user-login-submit' ).before( data );
 			}
 		} );
@@ -435,13 +440,17 @@ jQuery( document ).ready( function( $ ) {
 			document.querySelectorAll( '.edd-error' ).forEach( function( el ) {
 				el.style.display = 'none';
 			} );
+			document.querySelectorAll( '.edd_errors' ).forEach( function( el ) {
+				el.parentNode.removeChild( el );
+			} );
+
 			if ( $.trim( data ) === 'success' ) {
-				$( '.edd_errors' ).remove();
 				$( eddPurchaseform ).submit();
 			} else {
 				$( '#edd-purchase-button' ).val( complete_purchase_val );
-				$( '.edd-loading-ajax' ).remove();
-				$( '.edd_errors' ).remove();
+				document.querySelectorAll( '.edd-loading-ajax' ).forEach( function( el ) {
+					el.parentNode.removeChild( el );
+				} );
 				$( edd_global_vars.checkout_error_anchor ).before( data );
 				$( '#edd-purchase-button' ).prop( 'disabled', false );
 

--- a/assets/js/frontend/edd-ajax.js
+++ b/assets/js/frontend/edd-ajax.js
@@ -5,9 +5,37 @@
  */
 import { recalculate_taxes } from './checkout';
 
+function eddSlideUp( target, duration ) {
+	duration                        = duration || 400;
+	target.style.transitionProperty = 'height, margin, padding';
+	target.style.transitionDuration = duration + 'ms';
+	target.style.boxSizing          = 'border-box';
+	target.style.height             = target.offsetHeight + 'px';
+	target.offsetHeight;
+	target.style.overflow           = 'hidden';
+	target.style.height             = 0;
+	target.style.paddingTop         = 0;
+	target.style.paddingBottom      = 0;
+	target.style.marginTop          = 0;
+	target.style.marginBottom       = 0;
+	window.setTimeout( function() {
+		target.style.display = 'none';
+		target.style.removeProperty( 'height' );
+		target.style.removeProperty( 'padding-top' );
+		target.style.removeProperty( 'padding-bottom' );
+		target.style.removeProperty( 'margin-top' );
+		target.style.removeProperty( 'margin-bottom' );
+		target.style.removeProperty( 'overflow' );
+		target.style.removeProperty( 'transition-duration' );
+		target.style.removeProperty( 'transition-property' );
+	}, duration );
+}
+
 jQuery( document ).ready( function( $ ) {
 	// Hide unneeded elements. These are things that are required in case JS breaks or isn't present
-	$( '.edd-no-js' ).hide();
+	document.querySelectorAll( '.edd-no-js' ).forEach( function( el ) {
+		el.style.display = 'none';
+	} );
 	$( 'a.edd-add-to-cart' ).addClass( 'edd-has-js' );
 
 	// Send Remove from Cart requests
@@ -54,7 +82,9 @@ jQuery( document ).ready( function( $ ) {
 
 					// Check to see if the purchase form(s) for this download is present on this page
 					if ( $( '[id^=edd_purchase_' + id + ']' ).length ) {
-						$( '[id^=edd_purchase_' + id + '] .edd_go_to_checkout' ).hide();
+						document.querySelectorAll( '[id^=edd_purchase_' + id + '] .edd_go_to_checkout' ).forEach( function( el ) {
+							el.style.display = 'none';
+						} );
 						$( '[id^=edd_purchase_' + id + '] a.edd-add-to-cart' ).show().removeAttr( 'data-edd-loading' );
 						if ( edd_scripts.quantities_enabled === '1' ) {
 							$( '[id^=edd_purchase_' + id + '] .edd_download_quantity_wrapper' ).show();
@@ -71,7 +101,9 @@ jQuery( document ).ready( function( $ ) {
 					$( '.cart_item.edd_total span' ).html( response.total );
 
 					if ( response.cart_quantity === 0 ) {
-						$( '.cart_item.edd_subtotal,.edd-cart-number-of-items,.cart_item.edd_checkout,.cart_item.edd_cart_tax,.cart_item.edd_total' ).hide();
+						document.querySelectorAll( '.cart_item.edd_subtotal,.edd-cart-number-of-items,.cart_item.edd_checkout,.cart_item.edd_cart_tax,.cart_item.edd_total' ).forEach( function( el ) {
+							el.style.display = 'none';
+						} );
 						$( '.edd-cart' ).each( function() {
 							const cart_wrapper = $( this ).parent();
 							if ( cart_wrapper ) {
@@ -201,7 +233,9 @@ jQuery( document ).ready( function( $ ) {
 					$( '.cart_item.edd_checkout' ).show();
 
 					if ( $( '.cart_item.empty' ).length ) {
-						$( '.cart_item.empty' ).hide();
+						document.querySelectorAll( '.cart_item.empty' ).forEach( function( el ) {
+							el.style.display = 'none';
+						 } );
 					}
 
 					$( '.widget_edd_cart_widget .edd-cart' ).each( function( cart ) {
@@ -249,12 +283,18 @@ jQuery( document ).ready( function( $ ) {
 
 					// Update all buttons for same download
 					if ( $( '.edd_download_purchase_form' ).length && ( variable_price === 'no' || ! form.find( '.edd_price_option_' + download ).is( 'input:hidden' ) ) ) {
-						const parent_form = $( '.edd_download_purchase_form *[data-download-id="' + download + '"]' ).parents( 'form' );
-						$( 'a.edd-add-to-cart', parent_form ).hide();
-						if ( price_mode !== 'multi' ) {
-							parent_form.find( '.edd_download_quantity_wrapper' ).slideUp();
-						}
-						$( '.edd_go_to_checkout', parent_form ).show().removeAttr( 'data-edd-loading' );
+						document.querySelectorAll( '.edd_download_purchase_form *[data-download-id="' + download + '"]' ).forEach( function( el ) {
+							var parent_form = el.closest( 'form' );
+							parent_form.querySelectorAll( 'a.edd-add-to-cart' ).forEach( function( addToCartEl ) {
+								addToCartEl.style.display = 'none';
+							} );
+							if ( 'multi' !== price_mode ) {
+								parent_form.querySelectorAll( '.edd_download_quantity_wrapper' ).forEach( function( qtyWrapperEl ) {
+									eddSlideUp( qtyWrapperEl );
+								} );
+							}
+							$( '.edd_go_to_checkout', parent_form ).show().removeAttr( 'data-edd-loading' );
+						} );
 					}
 
 					if ( response !== 'incart' ) {
@@ -297,7 +337,9 @@ jQuery( document ).ready( function( $ ) {
 			$( '#edd_checkout_login_register' ).html( edd_scripts.loading );
 			$( '#edd_checkout_login_register' ).html( checkout_response );
 			// Hide the ajax loader
-			$( '.edd-cart-ajax' ).hide();
+			document.querySelectorAll( '.edd-cart-ajax' ).forEach( function( el ) {
+				el.style.display = 'none';
+			} );
 		} );
 		return false;
 	} );
@@ -390,15 +432,16 @@ jQuery( document ).ready( function( $ ) {
 		$( this ).after( '<span class="edd-loading-ajax edd-loading"></span>' );
 
 		$.post( edd_global_vars.ajaxurl, $( '#edd_purchase_form' ).serialize() + '&action=edd_process_checkout&edd_ajax=true', function( data ) {
+			document.querySelectorAll( '.edd-error' ).forEach( function( el ) {
+				el.style.display = 'none';
+			} );
 			if ( $.trim( data ) === 'success' ) {
 				$( '.edd_errors' ).remove();
-				$( '.edd-error' ).hide();
 				$( eddPurchaseform ).submit();
 			} else {
 				$( '#edd-purchase-button' ).val( complete_purchase_val );
 				$( '.edd-loading-ajax' ).remove();
 				$( '.edd_errors' ).remove();
-				$( '.edd-error' ).hide();
 				$( edd_global_vars.checkout_error_anchor ).before( data );
 				$( '#edd-purchase-button' ).prop( 'disabled', false );
 
@@ -504,7 +547,9 @@ function edd_load_gateway( payment_mode ) {
 	jQuery.post( url, { action: 'edd_load_gateway', edd_payment_mode: payment_mode, nonce: nonce },
 		function( response ) {
 			jQuery( '#edd_purchase_form_wrap' ).html( response );
-			jQuery( '.edd-no-js' ).hide();
+			document.querySelectorAll( '.edd-no-js' ).forEach( function( el ) {
+				el.style.display = 'none';
+			} );
 			jQuery( 'body' ).trigger( 'edd_gateway_loaded', [ payment_mode ] );
 		}
 	);


### PR DESCRIPTION
Fixes #7351

Proposed Changes:
* Migrate jQuery to Vanilla JS

WIP, this is a rather large task so I'll be pushing smaller commits here instead of a single large one. It's better that way since I'll be able to divide the task in multiple sessions and should also make reviewing easier.