### PR TITLE
Corrected an issue where we sent in strings instead of arrays to the stats class, and account for this in the stats class #7360

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -121,6 +121,7 @@ class Stats {
 				'price_id'          => '',
 			);
 		}
+
 	}
 
 	/** Calculation Methods ***************************************************/
@@ -405,7 +406,11 @@ class Stats {
 			? $query['status']
 			: array( 'complete', 'partially_refunded' );
 
-		$query['type'] = 'refund';
+		if ( ! array( $query['status'] ) ) {
+			$query['status'] = array( $query['status'] );
+		}
+
+		$query['type'] = array( 'refund' );
 
 		return $this->get_order_count( $query );
 	}
@@ -544,7 +549,7 @@ class Stats {
 	 */
 	public function get_order_refund_amount( $query = array() ) {
 		$query['status'] = array( 'complete', 'partially_refunded' );
-		$query['type']   = 'refund';
+		$query['type']   = array( 'refund' );
 
 		// Request raw output so we can run `abs()` on the value.
 		$query['output'] = 'raw';
@@ -2608,6 +2613,12 @@ class Stats {
 		}
 
 		if ( ! empty( $this->query_vars['type'] ) ) {
+
+			// We always want to format this as an array, so account for a possible string.
+			if ( ! is_array( $this->query_vars['type'] ) ) {
+				$this->query_vars['type'] = array( $this->query_vars['type'] );
+			}
+
 			$this->query_vars['type'] = array_map( 'sanitize_text_field', $this->query_vars['type'] );
 
 			$placeholders = implode( ', ', array_fill( 0, count( $this->query_vars['type'] ), '%s' ) );


### PR DESCRIPTION
Fixes #7360 

Proposed Changes:
1. In the stats class we now force the `type` to be an array if it's not.
2. Fixed the calls to the stats class to make the `type` an array.