### PR TITLE
Fix searching payment history #6803

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -761,7 +761,7 @@ class EDD_Payment_History_Table extends List_Table {
 			'gateway'  => $gateway,
 			'mode'     => $mode,
 			'type'     => $type,
-			's'        => $search,
+			'search'   => $search,
 		);
 
 		// Search


### PR DESCRIPTION
Fixes #6803

Proposed Changes:
1. Swaps the `s` argument to `search` which is what the query class is expecting.