### PR TITLE
Don't add a general log entry for refunds for now #7286

### DIFF
--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -276,16 +276,6 @@ function edd_refund_order( $order_id = 0, $status = 'complete', $order_items = a
 		) );
 	}
 
-	// Log the refund.
-	edd_add_log( array(
-		'object_id'   => $order_id,
-		'object_type' => 'order',
-		'user_id'     => get_current_user_id(),
-		'type'        => 'refund',
-		'title'       => __( 'Refund Issued', 'easy-digital-downloads' ),
-		'content'     => __( 'A refund for the entire order was issued.', 'easy-digital-downloads' ),
-	) );
-
 	// Update order status to `refunded` once refund is complete and if all items are marked as refunded.
 	$all_refunded = true;
 	$order_items = edd_get_order_items( array(


### PR DESCRIPTION
Fixes #7286

Proposed Changes:
1. Removes the logging of the refund in the general log

We may bring this back but currently this is the only type of order action logged in the general logging, and we do make a log on the order itself. Removing it for now.