### PR TITLE
Fix orders entering 0 for transaction amounts #6798

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2611,6 +2611,7 @@ class EDD_Payment {
 						'transaction_id' => $meta_value,
 						'gateway'        => $this->gateway,
 						'status'         => 'complete',
+						'total'          => $this->total,
 					) );
 				}
 		}


### PR DESCRIPTION
Fixes #6798 

Proposed Changes:
1. Adds the `total` to the call to `edd_add_order_transaction` in the `EDD_Payment` class.