### PR TITLE
Added hook to import custom data during the download-import process

### DIFF
--- a/includes/admin/import/class-batch-import-downloads.php
+++ b/includes/admin/import/class-batch-import-downloads.php
@@ -238,7 +238,8 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 				}
 
 				// Custom fields
-
+				// Allow for hooking into the import process to import custom data
+				do_action( 'edd_import_download_process_step', $download_id, $row );
 
 				$i++;
 			}


### PR DESCRIPTION
Fixes #5123 

Proposed Changes:
1. Add an action hook that runs after a single CSV row is imported. This hook makes the `$download_id` and `$row` available.

