### PR TITLE
Introduce convert_file_string_to_array() for product import that ignores / for delimiters. #7199

### DIFF
--- a/includes/admin/import/class-batch-import-downloads.php
+++ b/includes/admin/import/class-batch-import-downloads.php
@@ -192,7 +192,7 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 				// setup files
 				if( ! empty( $this->field_mapping['files'] ) && ! empty( $row[ $this->field_mapping['files'] ] ) ) {
 
-					$files = $this->str_to_array( $row[ $this->field_mapping['files'] ] );
+					$files = $this->convert_file_string_to_array( $row[ $this->field_mapping['files'] ] );
 
 					$this->set_files( $download_id, $files );
 
@@ -307,6 +307,49 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 			}
 
 		}
+
+	}
+
+	/**
+	 * Convert a files string containing delimiters to an array
+	 *
+	 * @since 2.9.20
+	 * @param $str Input string to convert to an array
+	 * @return array
+	 */
+	public function convert_file_string_to_array( $str = '' ) {
+
+		$array = array();
+
+		if( is_array( $str ) ) {
+			return array_map( 'trim', $str );
+		}
+
+		// Look for standard delimiters
+		if( false !== strpos( $str, '|' ) ) {
+
+			$delimiter = '|';
+
+		} elseif( false !== strpos( $str, ',' ) ) {
+
+			$delimiter = ',';
+
+		} elseif( false !== strpos( $str, ';' ) ) {
+
+			$delimiter = ';';
+
+		}
+
+		if( ! empty( $delimiter ) ) {
+
+			$array = (array) explode( $delimiter, $str );
+
+		} else {
+
+			$array[] = $str;
+		}
+
+		return array_map( 'trim', $array );
 
 	}
 

--- a/includes/admin/import/class-batch-import-downloads.php
+++ b/includes/admin/import/class-batch-import-downloads.php
@@ -311,49 +311,6 @@ class EDD_Batch_Downloads_Import extends EDD_Batch_Import {
 	}
 
 	/**
-	 * Convert a files string containing delimiters to an array
-	 *
-	 * @since 2.9.20
-	 * @param $str Input string to convert to an array
-	 * @return array
-	 */
-	public function convert_file_string_to_array( $str = '' ) {
-
-		$array = array();
-
-		if( is_array( $str ) ) {
-			return array_map( 'trim', $str );
-		}
-
-		// Look for standard delimiters
-		if( false !== strpos( $str, '|' ) ) {
-
-			$delimiter = '|';
-
-		} elseif( false !== strpos( $str, ',' ) ) {
-
-			$delimiter = ',';
-
-		} elseif( false !== strpos( $str, ';' ) ) {
-
-			$delimiter = ';';
-
-		}
-
-		if( ! empty( $delimiter ) ) {
-
-			$array = (array) explode( $delimiter, $str );
-
-		} else {
-
-			$array[] = $str;
-		}
-
-		return array_map( 'trim', $array );
-
-	}
-
-	/**
 	 * Set up and store the file downloads
 	 *
 	 * @since 2.6

--- a/includes/admin/import/class-batch-import.php
+++ b/includes/admin/import/class-batch-import.php
@@ -246,6 +246,51 @@ class EDD_Batch_Import {
 	}
 
 	/**
+	 * Convert a files string containing delimiters to an array.
+	 *
+	 * This is identical to str_to_array() except it ignores all / characters.
+	 *
+	 * @since 2.9.20
+	 * @param $str Input string to convert to an array
+	 * @return array
+	 */
+	public function convert_file_string_to_array( $str = '' ) {
+
+		$array = array();
+
+		if( is_array( $str ) ) {
+			return array_map( 'trim', $str );
+		}
+
+		// Look for standard delimiters
+		if( false !== strpos( $str, '|' ) ) {
+
+			$delimiter = '|';
+
+		} elseif( false !== strpos( $str, ',' ) ) {
+
+			$delimiter = ',';
+
+		} elseif( false !== strpos( $str, ';' ) ) {
+
+			$delimiter = ';';
+
+		}
+
+		if( ! empty( $delimiter ) ) {
+
+			$array = (array) explode( $delimiter, $str );
+
+		} else {
+
+			$array[] = $str;
+		}
+
+		return array_map( 'trim', $array );
+
+	}
+
+	/**
 	 * Trims a column value for preview
 	 *
 	 * @since 2.6


### PR DESCRIPTION
Fixes #7199

Proposed Changes:
1. Introduce a `convert_file_string_to_array()` method that ignores `/`s in the file value

This resolves the issue completely without introducing significant complications nor extension-specific compatibility.