### PR TITLE
Save country field on edd_edit_user_profile

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -894,6 +894,7 @@ function edd_process_profile_editor_updates( $data ) {
 				'address'     => $address['line1'],
 				'address2'    => $address['line2'],
 				'city'        => $address['city'],
+				'country'     => $address['country'],
 				'region'      => $address['state'],
 				'postal_code' => $address['zip'],
 			) );
@@ -906,6 +907,7 @@ function edd_process_profile_editor_updates( $data ) {
 				'address'     => $address['line1'],
 				'address2'    => $address['line2'],
 				'city'        => $address['city'],
+				'country'     => $address['country'],
 				'region'      => $address['state'],
 				'postal_code' => $address['zip'],
 			) );


### PR DESCRIPTION
Fixes #7378 

The country field was not being saved/updated which is why it was not being populated in the short code.

Proposed Changes:
1. Save the country field on profile edit.
