### PR TITLE
Default tax rate tracked through adjustments DB

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -786,7 +786,7 @@ function edd_get_registered_settings() {
 						'type'          => 'number',
 						'size'          => 'small',
 						'step'          => '0.0001',
-						'std'						=> (float) edd_get_default_tax_rate(),
+						'std'		=> (float) edd_get_default_tax_rate(),
 						'min'           => '0',
 						'max'           => '99',
 						'tooltip_title' => __( 'Default Rate', 'easy-digital-downloads' ),

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -25,7 +25,7 @@ function edd_get_option( $key = '', $default = false ) {
 	global $edd_options;
 
 	// Special case for tax_rate
-	if ( $key === 'tax_rate' ) {
+	if ( 'tax_rate' === $key ) {
 		$value = (float) edd_get_default_tax_rate();
 	} else {
 		$value = ! empty( $edd_options[ $key ] )

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1403,7 +1403,7 @@ function edd_settings_sanitize_tax_rate( $input ) {
 	$tax_rate = $_POST['edd_settings']['tax_rate'];
 
 	$adjustment_data = array(
-		'name'        => __( 'GLOBAL', 'easy-digital-dowloads' ),
+		'name'        => __( 'Global Rate', 'easy-digital-dowloads' ),
 		'type'        => 'tax_rate',
 		'scope'       => 'global',
 		'amount_type' => 'percent',

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -23,15 +23,10 @@ defined( 'ABSPATH' ) || exit;
  */
 function edd_get_option( $key = '', $default = false ) {
 	global $edd_options;
-
-	// Special case for tax_rate
-	if ( 'tax_rate' === $key ) {
-		$value = (float) edd_get_default_tax_rate();
-	} else {
-		$value = ! empty( $edd_options[ $key ] )
-			? $edd_options[ $key ]
-			: $default;
-	}
+	
+	$value = ! empty( $edd_options[ $key ] )
+		? $edd_options[ $key ]
+		: $default;
 
 	$value = apply_filters( 'edd_get_option', $value, $key, $default );
 
@@ -791,6 +786,7 @@ function edd_get_registered_settings() {
 						'type'          => 'number',
 						'size'          => 'small',
 						'step'          => '0.0001',
+						'std'						=> (float) edd_get_default_tax_rate(),
 						'min'           => '0',
 						'max'           => '99',
 						'tooltip_title' => __( 'Default Rate', 'easy-digital-downloads' ),

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1400,7 +1400,7 @@ function edd_settings_sanitize_tax_rate( $input ) {
 		return $input;
 	}
 
-	$tax_rate = $_POST['edd_settings']['tax_rate'];
+	$tax_rate = sanitize_text_field( $_POST['edd_settings']['tax_rate'] );
 
 	$adjustment_data = array(
 		'name'        => __( 'Global Rate', 'easy-digital-dowloads' ),
@@ -1463,12 +1463,14 @@ function edd_settings_sanitize_taxes( $input ) {
 			? sanitize_text_field( $tax_rate['state'] )
 			: '';
 
+		$rate = sanitize_text_field( $tax_rate['rate'] );
+		
 		$adjustment_data = array(
 			'name'        => sanitize_text_field( $tax_rate['country'] ),
 			'type'        => 'tax_rate',
 			'scope'       => $scope,
 			'amount_type' => 'percent',
-			'amount'      => floatval( $tax_rate['rate'] ),
+			'amount'      => floatval( $rate ),
 			'description' => $region,
 		);
 

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1040,7 +1040,7 @@ class Data_Migrator {
 
 		$scope;
 
-		if ( $data['country'] === __( 'Global Rate', 'easy-digital-dowloads' ) ) {
+		if ( isset( $data['is_global_rate'] ) ) {
 			$scope = 'global';
 		} else {
 			$scope = isset( $data['global'] )
@@ -1062,7 +1062,7 @@ class Data_Migrator {
 			'description' => $region,
 		);
 
-		if ($scope === 'global') {
+		if ( isset( $data['is_global_rate'] ) ) {
 			// Change the global settings
 			$id = edd_add_adjustment( $adjustment_data );
 			edd_update_option( 'edd_default_tax_rate_id', $id );

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1038,9 +1038,15 @@ class Data_Migrator {
 			return;
 		}
 
-		$scope = isset( $data['global'] )
+		$scope;
+
+		if ( $data['country'] === 'GLOBAL' ) {
+			$scope = 'global';
+		} else {
+			$scope = isset( $data['global'] )
 			? 'country'
 			: 'region';
+		}
 
 		$region = isset( $data['state'] )
 			? sanitize_text_field( $data['state'] )
@@ -1056,7 +1062,15 @@ class Data_Migrator {
 			'description' => $region,
 		);
 
-		edd_add_adjustment( $adjustment_data );
+		if ($scope === 'global') {
+			// Change the global settings
+			$id = edd_add_adjustment( $adjustment_data );
+			edd_update_option( 'edd_default_tax_rate_id', $id );
+			edd_delete_option( 'tax_rate' );
+		} else {
+			edd_add_adjustment( $adjustment_data );
+		}
+
 	}
 
 	/**

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1040,7 +1040,7 @@ class Data_Migrator {
 
 		$scope;
 
-		if ( $data['country'] === 'GLOBAL' ) {
+		if ( $data['country'] === __( 'Global Rate', 'easy-digital-dowloads' ) ) {
 			$scope = 'global';
 		} else {
 			$scope = isset( $data['global'] )

--- a/includes/admin/upgrades/v3/class-tax-rates.php
+++ b/includes/admin/upgrades/v3/class-tax-rates.php
@@ -48,7 +48,7 @@ class Tax_Rates extends Base {
 
 		if ( isset ($edd_options['tax_rate']) ) {
 			$data = [
-				'country' => __( 'GLOBAL', 'easy-digital-downloads' ),
+				'country' => __( 'Global Rate', 'easy-digital-downloads' ),
 				'rate' => $edd_options['tax_rate'],
 			];
 

--- a/includes/admin/upgrades/v3/class-tax-rates.php
+++ b/includes/admin/upgrades/v3/class-tax-rates.php
@@ -48,8 +48,9 @@ class Tax_Rates extends Base {
 
 		if ( isset ($edd_options['tax_rate']) ) {
 			$data = [
-				'country' => __( 'Global Rate', 'easy-digital-downloads' ),
-				'rate' => $edd_options['tax_rate'],
+				'country'        => __( 'Global Rate', 'easy-digital-downloads' ),
+				'rate'           => $edd_options['tax_rate'],
+				'is_global_rate' => true,
 			];
 
 			$results[] = $data;

--- a/includes/admin/upgrades/v3/class-tax-rates.php
+++ b/includes/admin/upgrades/v3/class-tax-rates.php
@@ -42,6 +42,19 @@ class Tax_Rates extends Base {
 		$offset = ( $this->step - 1 ) * $this->per_step;
 
 		$results = get_option( 'edd_tax_rates', array() );
+
+		// Migrate edd_options[tax_rate], it will be tracked through DB from now on
+		global $edd_options;
+
+		if ( isset ($edd_options['tax_rate']) ) {
+			$data = [
+				'country' => __( 'GLOBAL', 'easy-digital-downloads' ),
+				'rate' => $edd_options['tax_rate'],
+			];
+
+			$results[] = $data;
+		}
+
 		$results = array_slice( $results, $offset, $this->per_step, true );
 
 		if ( ! empty( $results ) ) {

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1303,8 +1303,9 @@ class EDD_CLI extends WP_CLI_Command {
 
 		if ( isset ($edd_options['tax_rate']) ) {
 			$data = [
-				'country' => __( 'Global Rate', 'easy-digital-downloads' ),
-				'rate' => $edd_options['tax_rate'],
+				'country'        => __( 'Global Rate', 'easy-digital-downloads' ),
+				'rate'           => $edd_options['tax_rate'],
+				'is_global_rate' => true,
 			];
 
 			$tax_rates[] = $data;

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -973,7 +973,7 @@ class EDD_CLI extends WP_CLI_Command {
 			LEFT JOIN {$wpdb->term_relationships} AS tr ON (p.ID = tr.object_id)
 			LEFT JOIN {$wpdb->term_taxonomy} AS tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id)
 			LEFT JOIN {$wpdb->terms} AS t ON (tt.term_id = t.term_id)
-			WHERE p.post_type = 'edd_log' AND t.slug != 'sale' 
+			WHERE p.post_type = 'edd_log' AND t.slug != 'sale'
 		";
 
 		$results = $wpdb->get_results( $sql );
@@ -1303,10 +1303,10 @@ class EDD_CLI extends WP_CLI_Command {
 
 		if ( isset ($edd_options['tax_rate']) ) {
 			$data = [
-				'country' => __( 'GLOBAL', 'easy-digital-downloads' ),
+				'country' => __( 'Global Rate', 'easy-digital-downloads' ),
 				'rate' => $edd_options['tax_rate'],
 			];
-			
+
 			$tax_rates[] = $data;
 		}
 

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1298,6 +1298,18 @@ class EDD_CLI extends WP_CLI_Command {
 		// Migrate user addresses first.
 		$tax_rates = get_option( 'edd_tax_rates', array() );
 
+		// Migrate edd_options[tax_rate], it will be tracked through DB from now on
+		global $edd_options;
+
+		if ( isset ($edd_options['tax_rate']) ) {
+			$data = [
+				'country' => __( 'GLOBAL', 'easy-digital-downloads' ),
+				'rate' => $edd_options['tax_rate'],
+			];
+			
+			$tax_rates[] = $data;
+		}
+
 		if ( ! empty( $tax_rates ) ) {
 			$progress = new \cli\progress\Bar( 'Migrating Tax Rates', count( $tax_rates ) );
 

--- a/includes/reports/data/taxes/class-tax-collected-by-location-list-table.php
+++ b/includes/reports/data/taxes/class-tax-collected-by-location-list-table.php
@@ -145,12 +145,24 @@ class Tax_Collected_By_Location extends List_Table {
 				? $wpdb->prepare( ' AND region = %s', esc_sql( $tax_rate->description ) )
 				: '';
 
-			$results = $wpdb->get_results( $wpdb->prepare( "
-				SELECT SUM(tax) as tax, SUM(total) as total, country, region
-				FROM {$wpdb->edd_orders}
-				INNER JOIN {$wpdb->edd_order_addresses} ON {$wpdb->edd_order_addresses}.order_id = {$wpdb->edd_orders}.id
-				WHERE {$wpdb->edd_order_addresses}.country = %s {$region} {$date_query}
-			", esc_sql( $tax_rate->name ) ), ARRAY_A );
+			$results;
+
+			if ( $location !== __( 'Global Rate', 'easy-digital-downloads' ) ) {
+				$results = $wpdb->get_results( $wpdb->prepare( "
+					SELECT SUM(tax) as tax, SUM(total) as total, country, region
+					FROM {$wpdb->edd_orders}
+					INNER JOIN {$wpdb->edd_order_addresses} ON {$wpdb->edd_order_addresses}.order_id = {$wpdb->edd_orders}.id
+					WHERE {$wpdb->edd_order_addresses}.country = %s {$region} {$date_query}
+				", esc_sql( $tax_rate->name ) ), ARRAY_A );
+			} else {
+				$results = $wpdb->get_results( "
+					SELECT SUM(tax) as tax, SUM(total) as total, country, region
+					FROM {$wpdb->edd_orders}
+					INNER JOIN {$wpdb->edd_order_addresses} ON {$wpdb->edd_order_addresses}.order_id = {$wpdb->edd_orders}.id
+					WHERE {$wpdb->edd_order_addresses}.country NOT IN ( SELECT name FROM {$wpdb->edd_adjustments}
+					WHERE scope != 'global' AND type = 'tax_rate') {$date_query}
+				", ARRAY_A );
+			}
 
 			$all_orders[0]['tax']   -= $results[0]['tax'];
 			$all_orders[0]['total'] -= $results[0]['total'];
@@ -163,19 +175,6 @@ class Tax_Collected_By_Location extends List_Table {
 				'tax'      => edd_currency_filter( edd_format_amount( floatval( $results[0]['tax'] ) ) ),
 				'net'      => edd_currency_filter( edd_format_amount( floatval( $results[0]['total'] - $results[0]['tax'] ) ) ),
 			);
-		}
-
-		if( $all_orders[0]['total'] > 0 && $all_orders[0]['tax'] > 0 ) {
-
-			$data[ 'global' ] = array(
-				'country'  => __( 'Global Rate', 'easy-digital-downloads' ),
-				'from'     => $from,
-				'to'       => $to,
-				'gross'    => edd_currency_filter( edd_format_amount( floatval( max( 0, $all_orders[0]['total'] ) ) ) ),
-				'tax'      => edd_currency_filter( edd_format_amount( floatval( max( 0, $all_orders[0]['tax'] ) ) ) ),
-				'net'      => edd_currency_filter( edd_format_amount( floatval( max( 0, $all_orders[0]['total'] - $all_orders[0]['tax'] ) ) ) ),
-			);
-
 		}
 
 		return $data;

--- a/includes/reports/data/taxes/class-tax-collected-by-location-list-table.php
+++ b/includes/reports/data/taxes/class-tax-collected-by-location-list-table.php
@@ -147,7 +147,7 @@ class Tax_Collected_By_Location extends List_Table {
 
 			$results;
 
-			if ( $location !== __( 'Global Rate', 'easy-digital-downloads' ) ) {
+			if ( 'global' !== $tax_rate->scope ) {
 				$results = $wpdb->get_results( $wpdb->prepare( "
 					SELECT SUM(tax) as tax, SUM(total) as total, country, region
 					FROM {$wpdb->edd_orders}

--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -31,6 +31,21 @@ function edd_use_taxes() {
 }
 
 /**
+ * Returns the default tax_rate stored in adjustments
+ *
+ * @since 3.0
+ *
+ * @return array|\EDD\Adjustments\Adjustment Tax rate.
+ */
+function edd_get_default_tax_rate() {
+	// Default rate
+	$id      = edd_get_option( 'edd_default_tax_rate_id' );
+	$default = edd_get_tax_rates( array( 'id' => $id ), OBJECT );
+
+	return $default[0]->amount;
+}
+
+/**
  * Retrieve tax rates
  *
  * @since 1.6
@@ -156,7 +171,7 @@ function edd_active_tax_rates_query_clauses( $clauses ) {
 function edd_get_tax_rate( $country = '', $region = '' ) {
 
 	// Default rate
-	$rate = (float) edd_get_option( 'tax_rate', 0 );
+	$rate = (float) edd_get_default_tax_rate();
 
 	// Get the address, to try to get the tax rate
 	$user_address = edd_get_customer_address();


### PR DESCRIPTION
Fixes #6840 

Proposed Changes:
1. Migrate tax_rate from settings to edd_adjustments
2. Track using edd_settings[edd_default_tax_rate_id]
3. Hide from tax rates table by including this id in wp query.

_Please do not submit PRs with minified CSS or JS files. This is managed at the time of release by the Core Team_
