### PR TITLE
prevent PHP Fatal error when deleting EDD plugin

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -20,7 +20,7 @@
  */
 
 // Exit if accessed directly.
-if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) exit;
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) || class_exists( 'Easy_Digital_Downloads' ) ) exit;
 
 // Load EDD file.
 include_once( 'easy-digital-downloads.php' );


### PR DESCRIPTION
Fixes issue where EDD is installed twice, 1 is active, and you attempt to delete the other, inactive, plugin.

It prevents executing the contents of `uninstall.php` when the Easy Digital Download main class exists.

Fixes #7444 