### PR TITLE
Return backwards compat customer address inside another array #7458

### DIFF
--- a/includes/compat/class-customer.php
+++ b/includes/compat/class-customer.php
@@ -228,7 +228,7 @@ class Customer extends Base {
 			}
 		}
 
-		return $value;
+		return array( $value );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7458

Proposed Changes:
1. Adjust backwards compatibility for `_edd_user_address` user meta so that we return an array containing the array of address data.