### PR TITLE
3.0 - Fix "$ is not a function"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,6 +67,10 @@ const config = {
 		$: 'jQuery',
 	},
 	plugins: [
+		new webpack.ProvidePlugin( {
+			$: 'jquery',
+			jQuery: 'jquery'
+		} ),
 		// Copy vendor files to ensure 3rd party plugins relying on a script
 		// handle to exist continue to be enqueued.
 		new CopyWebpackPlugin( [


### PR DESCRIPTION
Closes #7457

Use `webpack.ProvidePlugin` to ensure jQuery and $ point both variables to the external jQuery module.