### PR TITLE
Remove no downloadable files message when product is service #7486

### DIFF
--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -71,7 +71,7 @@ if ( $purchases ) :
 										endforeach;
 
 									else :
-										_e( 'No downloadable files found.', 'easy-digital-downloads' );
+										apply_filters('edd_receipt_no_files_found_text', __( 'No downloadable files found.', 'easy-digital-downloads' ), $download['id']);
 									endif; // End if payment complete
 
 								else : ?>
@@ -94,7 +94,7 @@ if ( $purchases ) :
 		?>
 	</table>
 	<?php
-		echo edd_pagination( 
+		echo edd_pagination(
 			array(
 				'type'  => 'download_history',
 				'total' => ceil( edd_count_purchases_of_customer() / 20 ) // 20 items per page

--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -195,7 +195,7 @@ $status    = edd_get_payment_status( $payment, true );
 													do_action( 'edd_receipt_bundle_files', $filekey, $file, $item['id'], $bundle_item, $payment->ID, $meta );
 												endforeach;
 											else :
-												echo '<li>' . __( 'No downloadable files found for this bundled item.', 'easy-digital-downloads' ) . '</li>';
+												echo '<li>' . apply_filters('edd_receipt_no_files_found_text', __( 'No downloadable files found for this bundled item.', 'easy-digital-downloads' ), $item['id']) . '</li>';
 											endif;
 											?>
 										</ul>


### PR DESCRIPTION
Fixes #7486 

Used the `edd_receipt_no_files_found_text` function to wrap the `No downloadable files` text.
Fix works locally, text no longer shows up for products that are services.

<img width="933" alt="screenshot" src="https://user-images.githubusercontent.com/51405444/72665833-7549a280-3a0c-11ea-8af9-d42259eeb76d.png">


