### PR TITLE
issue/7532 - Enqueue Export Script in Reports > Export

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2529,6 +2529,8 @@ add_action( 'edd_reports_init', 'edd_register_export_report' );
  */
 function display_export_report() {
 	global $wpdb;
+
+	wp_enqueue_script( 'edd-admin-tools-export' );
     ?>
     <div id="edd-dashboard-widgets-wrap">
         <div class="metabox-holder">


### PR DESCRIPTION
Fixes #7532

Proposed Changes:
1. Ensure Reports can be exported.

---

Note: If not previously compiled you may need to run `npm install && npm run build`