### PR TITLE
issue/7626 - Use box-shadow for Vertical Tab Active State

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -3230,54 +3230,54 @@ body.download_page_edd-reports {
 
 /* Fresh */
 .admin-color-fresh .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #0073aa;
+	box-shadow: inset 5px 0 #0073aa;
 }
 
 /* Blue */
 .admin-color-blue .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #096484;
+	box-shadow: inset 5px 0 #096484;
 }
 
 /* Coffee */
 .admin-color-coffee .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #096484;
+	box-shadow: inset 5px 0 #096484;
 }
 
 /* Ectoplasm */
 .admin-color-ectoplasm .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #a3b745;
+	box-shadow: inset 5px 0 #a3b745;
 }
 
 /* Midnight */
 .admin-color-midnight .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #26292c;
+	box-shadow: inset 5px 0 #26292c;
 }
 
 /* Ocean */
 .admin-color-ocean .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #627c83;
+	box-shadow: inset 5px 0 #627c83;
 }
 
 /* Sunrise */
 .admin-color-sunrise .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #be3631;
+	box-shadow: inset 5px 0 #be3631;
 }
 
 /* Light */
 .admin-color-light .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #888;
+	box-shadow: inset 5px 0 #888;
 }
 
 /* bbPress Color Schemes */
 
 /* Evergreen */
 .admin-color-evergreen .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #36533f;
+	box-shadow: inset 5px 0 #36533f;
 }
 
 /* Mint */
 .admin-color-mint .edd-vertical-sections .section-nav li[aria-selected="true"] a {
-	border-left: 5px solid #4f6d59;
+	box-shadow: inset 5px 0 #4f6d59;
 }
 
 .edd-vertical-sections .section-nav li[aria-selected="true"] .dashicons {


### PR DESCRIPTION
Fixes #7526 

Proposed Changes:
1. Use `box-shadow` for Vertical Tab Active State (creates a straight line).