### PR TITLE
issue/7523 - Remove Right-Aligned Labels in Orders

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1407,7 +1407,6 @@ input[class*="edd-price-field"] {
 .edd-edit-purchase-element ul li.price {
 	width: 20%;
 }
-.edd-admin-box .label {
 .edd-admin-box-inside {
 	border-bottom: 1px solid #f1f1f1;
 	clear: both;

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1408,8 +1408,6 @@ input[class*="edd-price-field"] {
 	width: 20%;
 }
 .edd-admin-box .label {
-	font-weight: 600;
-}
 .edd-admin-box-inside {
 	border-bottom: 1px solid #f1f1f1;
 	clear: both;
@@ -1417,11 +1415,32 @@ input[class*="edd-price-field"] {
 	margin: 0;
 	word-wrap: break-word;
 }
+.edd-admin-box-inside--row {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
 .edd-admin-box-inside > p {
 	margin: 8px 3px;
 }
 .edd-admin-box-inside .strong {
 	font-weight: 600;
+}
+.edd-admin-box div:not(.edd-admin-box-inside--row) .label {
+	display: block;
+	margin-bottom: 4px;
+	margin-right: 0;
+}
+.edd-admin-box .label--has-tip {
+	display: flex;
+	align-items: center;
+}
+.edd-admin-box .label--has-tip .edd-help-tip {
+	margin-top: 0;
+	font-size: 20px;
+}
+.edd-admin-box div:not(.edd-admin-box-inside--row) .label--has-checkbox {
+	margin-bottom: 0;
 }
 .edd-payment-fees .fee-label {
 	color: #666;
@@ -1494,9 +1513,6 @@ input[class*="edd-price-field"] {
 	width: 100%;
 }
 .edd-admin-box-inside span.label {
-	display: inline-block;
-	width: 85px;
-	text-align: right;
 	margin-right: 10px;
 }
 #edd-order-resend-receipt .inside {

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -704,10 +704,11 @@ function edd_order_details_extras( $order = false ) {
 
 				<?php if ( edd_is_add_order_page() ) : ?>
 					<div class="edd-send-purchase-receipt edd-admin-box-inside">
-						<span class="label"><?php esc_html_e( 'Receipt', 'easy-digital-downloads' ); ?>:</span>
-						<input type="checkbox" name="edd_order_send_receipt" id="edd-order-send-receipt" value="1" />
-						<label class="description" for="edd-order-send-receipt"><?php esc_html_e( 'Send Receipt', 'easy-digital-downloads' ); ?></label>
-						<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Send Receipt</strong>: checking this box will send the purchase receipt to the selected customer.', 'easy-digital-downloads' ); ?>"></span>
+						<label class="description label label--has-tip label--has-checkbox" for="edd-order-send-receipt">
+							<input type="checkbox" name="edd_order_send_receipt" id="edd-order-send-receipt" value="1" />
+							<?php esc_html_e( 'Send Receipt', 'easy-digital-downloads' ); ?>
+							<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Send Receipt</strong>: checking this box will send the purchase receipt to the selected customer.', 'easy-digital-downloads' ); ?>"></span>
+						</label>
 					</div>
 				<?php endif; ?>
 

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -553,8 +553,8 @@ function edd_order_details_adjustments( $order ) {
 
 				<ul>
 					<li class="credit" style="display: none;">
-						<input type="text" class="edd-add-order-credit-description" value="" placeholder="Description" />
-						<input type="number" class="edd-add-order-credit-amount" value="" min="1" placeholder="Amount" />
+						<input type="text" class="edd-add-order-credit-description" value="" placeholder="<?php echo esc_attr( 'Description', 'easy-digital-downloads' ); ?>" />
+						<input type="text" class="edd-add-order-credit-amount" value="" min="1" placeholder="<?php echo esc_attr( 'Amount', 'easy-digital-downloads' ); ?>" />
 					</li>
 				</ul>
 
@@ -654,25 +654,25 @@ function edd_order_details_extras( $order = false ) {
 
 				<?php if ( ! edd_is_add_order_page() && ! empty( $order->id ) ) : ?>
 					<?php if ( ! empty( $order->gateway ) ) : ?>
-					<div class="edd-order-gateway edd-admin-box-inside">
-						<span class="label"><?php esc_html_e( 'Gateway', 'easy-digital-downloads' ); ?>:</span>
-						<?php echo edd_get_gateway_admin_label( $order->gateway ); ?>
+					<div class="edd-order-gateway edd-admin-box-inside edd-admin-box-inside--row">
+						<span class="label"><?php esc_html_e( 'Gateway', 'easy-digital-downloads' ); ?></span>
+						<span class="value"><?php echo edd_get_gateway_admin_label( $order->gateway ); ?></span>
 					</div>
 					<?php endif; ?>
 				<?php else : ?>
 					<div class="edd-order-gateway edd-admin-box-inside">
-						<span class="label"><?php esc_html_e( 'Gateway', 'easy-digital-downloads' ); ?>:</span>
+						<span class="label"><?php esc_html_e( 'Gateway', 'easy-digital-downloads' ); ?></span>
 						<?php echo $gateway_select; ?>
 					</div>
 				<?php endif; ?>
 
 				<div class="edd-order-payment-key edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Key', 'easy-digital-downloads' ); ?>:</span>
+					<span class="label"><?php esc_html_e( 'Key', 'easy-digital-downloads' ); ?></span>
 					<input type="text" name="payment_key" <?php echo esc_attr( $readonly ); ?> value="<?php echo esc_attr( $order->payment_key ); ?>" />
 				</div>
 
 				<div class="edd-order-ip edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'IP', 'easy-digital-downloads' ); ?>:</span>
+					<span class="label"><?php esc_html_e( 'IP', 'easy-digital-downloads' ); ?></span>
 					<?php if ( edd_is_add_order_page() ) : ?>
 						<input type="text" name="ip" value="<?php echo esc_attr( edd_get_ip() ); ?>" />
 					<?php else : ?>
@@ -682,23 +682,24 @@ function edd_order_details_extras( $order = false ) {
 
 				<?php if ( $transaction_id ) : ?>
 					<div class="edd-order-tx-id edd-admin-box-inside">
-						<span class="label"><?php esc_html_e( 'Transaction ID', 'easy-digital-downloads' ); ?>:</span>
+						<span class="label"><?php esc_html_e( 'Transaction ID', 'easy-digital-downloads' ); ?></span>
 						<span><?php echo $transaction_id; ?></span>
 					</div>
 				<?php endif; ?>
 
 				<?php if ( edd_is_add_order_page() ) : ?>
 					<div class="edd-order-tx-id edd-admin-box-inside">
-						<span class="label"><?php esc_html_e( 'Transaction ID', 'easy-digital-downloads' ); ?>:</span>
+						<span class="label"><?php esc_html_e( 'Transaction ID', 'easy-digital-downloads' ); ?></span>
 						<input type="text" name="transaction_id" value="" />
 					</div>
 				<?php endif; ?>
 
 				<div class="edd-unlimited-downloads edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Downloads', 'easy-digital-downloads' ); ?>:</span>
-					<input type="checkbox" name="edd-unlimited-downloads" id="edd_unlimited_downloads" value="1"<?php checked( true, $unlimited, true ); ?>/>
-					<label class="description" for="edd_unlimited_downloads"><?php esc_html_e( 'Unlimited', 'easy-digital-downloads' ); ?></label>
-					<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Unlimited Downloads</strong>: checking this box will override all other file download limits for this purchase, granting the customer unliimited downloads of all files included on the purchase.', 'easy-digital-downloads' ); ?>"></span>
+					<label for="edd_unlimited_downloads" class="label label--has-tip label--has-checkbox">
+						<input type="checkbox" name="edd-unlimited-downloads" id="edd_unlimited_downloads" value="1"<?php checked( true, $unlimited, true ); ?>/>
+						<?php esc_html_e( 'Unlimited Downloads', 'easy-digital-downloads' ); ?>
+						<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Unlimited Downloads</strong>: checking this box will override all other file download limits for this purchase, granting the customer unliimited downloads of all files included on the purchase.', 'easy-digital-downloads' ); ?>"></span>
+					</span>
 				</div>
 
 				<?php if ( edd_is_add_order_page() ) : ?>
@@ -778,44 +779,56 @@ function edd_order_details_attributes( $order ) {
 		<div class="inside">
 			<div class="edd-order-update-box edd-admin-box">
 				<div class="edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Status:', 'easy-digital-downloads' ); ?></span>
+					<span class="label label--has-tip">
+						<?php
+						esc_html_e( 'Status', 'easy-digital-downloads' );
+
+						$status_help  = '<ul>';
+						$status_help .= '<li>' . __( '<strong>Pending</strong>: order is still processing or was abandoned by customer. Successful orders will be marked as Complete automatically once processing is finalized.', 'easy-digital-downloads' ) . '</li>';
+						$status_help .= '<li>' . __( '<strong>Complete</strong>: all processing is completed for this purchase.', 'easy-digital-downloads' ) . '</li>';
+						$status_help .= '<li>' . __( '<strong>Revoked</strong>: access to purchased items is disabled, perhaps due to policy violation or fraud.', 'easy-digital-downloads' ) . '</li>';
+						$status_help .= '<li>' . __( '<strong>Refunded</strong>: the purchase amount is returned to the customer and access to items is disabled.', 'easy-digital-downloads' ) . '</li>';
+						$status_help .= '<li>' . __( '<strong>Abandoned</strong>: the purchase attempt was not completed by the customer.', 'easy-digital-downloads' ) . '</li>';
+						$status_help .= '<li>' . __( '<strong>Failed</strong>: customer clicked Cancel before completing the purchase.', 'easy-digital-downloads' ) . '</li>';
+						$status_help .= '</ul>';
+						?>
+						<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php echo $status_help; // WPCS: XSS ok. ?>"></span>
+					</span>
 					<select name="edd-payment-status" class="edd-select-chosen <?php echo esc_attr( $rtl_class ); ?>">
 						<?php foreach ( edd_get_payment_statuses() as $key => $status ) : ?>
 							<option value="<?php echo esc_attr( $key ); ?>"<?php selected( $order->status, $key, true ); ?>><?php echo esc_html( $status ); ?></option>
 						<?php endforeach; ?>
 					</select>
-
-					<?php
-					$status_help  = '<ul>';
-					$status_help .= '<li>' . __( '<strong>Pending</strong>: order is still processing or was abandoned by customer. Successful orders will be marked as Complete automatically once processing is finalized.', 'easy-digital-downloads' ) . '</li>';
-					$status_help .= '<li>' . __( '<strong>Complete</strong>: all processing is completed for this purchase.', 'easy-digital-downloads' ) . '</li>';
-					$status_help .= '<li>' . __( '<strong>Revoked</strong>: access to purchased items is disabled, perhaps due to policy violation or fraud.', 'easy-digital-downloads' ) . '</li>';
-					$status_help .= '<li>' . __( '<strong>Refunded</strong>: the purchase amount is returned to the customer and access to items is disabled.', 'easy-digital-downloads' ) . '</li>';
-					$status_help .= '<li>' . __( '<strong>Abandoned</strong>: the purchase attempt was not completed by the customer.', 'easy-digital-downloads' ) . '</li>';
-					$status_help .= '<li>' . __( '<strong>Failed</strong>: customer clicked Cancel before completing the purchase.', 'easy-digital-downloads' ) . '</li>';
-					$status_help .= '</ul>';
-					?>
-					<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php echo $status_help; // WPCS: XSS ok. ?>"></span>
 				</div>
 
 				<?php if ( ! edd_is_add_order_page() && edd_is_order_recoverable( $order->id ) && ! empty( $recovery_url ) ) : ?>
 					<div class="edd-admin-box-inside">
-						<span class="label"><?php esc_html_e( 'Recover', 'easy-digital-downloads' ); ?>:</span>
+						<span class="label label--has-tip">
+							<?php esc_html_e( 'Recover', 'easy-digital-downloads' ); ?>
+							<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php esc_html_e( 'Pending and abandoned payments can be resumed by the customer, using this custom URL. Payments can be resumed only when they do not have a transaction ID from the gateway.', 'easy-digital-downloads' ); ?>"></span>
+						</span>
+
 						<input type="text" readonly="readonly" value="<?php echo esc_url( $recovery_url ); ?>"/>
-						<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php esc_html_e( 'Pending and abandoned payments can be resumed by the customer, using this custom URL. Payments can be resumed only when they do not have a transaction ID from the gateway.', 'easy-digital-downloads' ); ?>"></span>
 					</div>
 				<?php endif; ?>
 
 				<div class="edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Date:', 'easy-digital-downloads' ); ?></span>
-					<input type="text" name="edd-payment-date" value="<?php echo esc_attr( $order_date->format( 'Y-m-d' ) ); ?>" class="medium-text edd_datepicker" placeholder="<?php echo esc_attr( edd_get_date_picker_format() ); ?>"/>
+					<label for="edd-payment-date" class="label">
+						<?php esc_html_e( 'Date', 'easy-digital-downloads' ); ?>
+					</label>
+					<input type="text" id="edd-payment-date" name="edd-payment-date" value="<?php echo esc_attr( $order_date->format( 'Y-m-d' ) ); ?>" class="medium-text edd_datepicker" placeholder="<?php echo esc_attr( edd_get_date_picker_format() ); ?>"/>
+
 				</div>
 
 				<div class="edd-admin-box-inside">
-					<span class="label"><?php echo esc_html( __( 'Time', 'easy-digital-downloads' ) . ' (' . edd_get_timezone_abbr() . ') :' ); ?></span>
+					<label for="edd_payment_time_hour" class="label">
+						<?php echo esc_html( __( 'Time', 'easy-digital-downloads' ) . ' (' . edd_get_timezone_abbr() . ')' ); ?>
+					</label>
+
 					<?php
 					echo EDD()->html->select( array(
 						'name'             => 'edd-payment-time-hour',
+						'id'               => 'edd-payment-time-hour',
 						'options'          => edd_get_hour_values(),
 						'selected'         => $order_date->format( 'G' ),
 						'chosen'           => true,
@@ -889,36 +902,51 @@ function edd_order_details_amounts( $order ) {
 			<div class="edd-order-update-box edd-admin-box">
 				<?php do_action( 'edd_view_order_details_totals_before', $order->id ); ?>
 
-				<div class="edd-order-subtotal edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Subtotal', 'easy-digital-downloads' ); ?>:</span><?php
-					echo esc_html( edd_currency_symbol( $order->currency ) );
-					?><span class="value"><?php echo esc_attr( edd_format_amount( $order->subtotal ) ); ?></span>
+				<div class="edd-order-subtotal edd-admin-box-inside edd-admin-box-inside--row">
+					<strong class="label">
+						<?php esc_html_e( 'Subtotal', 'easy-digital-downloads' ); ?>
+					</strong>
+					<span class="value">
+						<?php echo esc_attr( edd_currency_filter( edd_format_amount( $order->subtotal ) ) ); ?>
+					</span>
 				</div>
 
-				<div class="edd-order-discounts edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Discount', 'easy-digital-downloads' ); ?>:</span><?php
-					echo esc_html( edd_currency_symbol( $order->currency ) );
-					?><span class="value"><?php echo esc_attr( edd_format_amount( $order->discount ) ); ?></span>
+				<div class="edd-order-discounts edd-admin-box-inside edd-admin-box-inside--row">
+					<strong class="label">
+						<?php esc_html_e( 'Discount', 'easy-digital-downloads' ); ?>
+					</strong>
+					<span class="value">
+						<?php echo esc_attr( edd_currency_filter( edd_format_amount( $order->discount ) ) ); ?>
+					</span>
 				</div>
 
-				<div class="edd-order-adjustments edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Adjustments', 'easy-digital-downloads' ); ?>:</span><?php
-					echo esc_html( edd_currency_symbol( $order->currency ) );
-					?><span class="value"><?php echo esc_attr( edd_format_amount( $order->discount ) ); ?></span>
+				<div class="edd-order-adjustments edd-admin-box-inside edd-admin-box-inside--row">
+					<strong class="label">
+						<?php esc_html_e( 'Adjustments', 'easy-digital-downloads' ); ?>
+					</strong>
+					<span class="value">
+						<?php echo esc_attr( edd_currency_filter( edd_format_amount( $order->discount ) ) ); ?>
+					</span>
 				</div>
 
 				<?php if ( edd_use_taxes() ) : ?>
-					<div class="edd-order-taxes edd-admin-box-inside">
-						<span class="label"><?php esc_html_e( 'Tax', 'easy-digital-downloads' ); ?>:</span><?php
-						echo esc_html( edd_currency_symbol( $order->currency ) );
-						?><span class="value"><?php echo esc_attr( edd_format_amount( $order->tax ) ); ?></span>
+					<div class="edd-order-taxes edd-admin-box-inside edd-admin-box-inside--row">
+						<strong class="label">
+							<?php esc_html_e( 'Tax', 'easy-digital-downloads' ); ?>
+						</strong>
+						<span class="value">
+							<?php echo esc_attr( edd_currency_filter( edd_format_amount( $order->tax ) ) ); ?>
+						</span>
 					</div>
 				<?php endif; ?>
 
-				<div class="edd-order-total edd-admin-box-inside">
-					<span class="label"><?php esc_html_e( 'Total', 'easy-digital-downloads' ); ?>:</span><?php
-					echo esc_html( edd_currency_symbol( $order->currency ) );
-					?><span class="value"><?php echo esc_attr( edd_format_amount( $order->total ) ); ?></span>
+				<div class="edd-order-total edd-admin-box-inside edd-admin-box-inside--row">
+					<strong class="label">
+						<?php esc_html_e( 'Total', 'easy-digital-downloads' ); ?>
+					</strong>
+					<span class="value">
+						<?php echo esc_attr( edd_currency_filter( edd_format_amount( $order->total ) ) ); ?>
+					</span>
 				</div>
 
 				<?php do_action( 'edd_view_order_details_totals_after', $order->id ); ?>


### PR DESCRIPTION
Fixes #7523 

Proposed Changes:
1. Create more flexible labels for order details.

<img width="300" alt="Screen Shot 2020-01-23 at 12 13 55 PM" src="https://user-images.githubusercontent.com/491124/73007383-73039180-3dda-11ea-9d9b-4ca35fd35b34.png">
<img width="299" alt="Screen Shot 2020-01-23 at 12 14 02 PM" src="https://user-images.githubusercontent.com/491124/73007384-73039180-3dda-11ea-8409-d74635580acc.png">
