### PR TITLE
issue/7542 - Ensure Adding/Editing Discounts Allow Product Requirement Conditions

### DIFF
--- a/assets/js/admin/discounts/index.js
+++ b/assets/js/admin/discounts/index.js
@@ -7,7 +7,7 @@ import { jQueryReady } from 'utils/jquery.js';
  * DOM ready.
  */
 jQueryReady( () => {
-	const products = $( '#products' );
+	const products = $( '#edd_products' );
 
 	if ( ! products ) {
 		return;

--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -83,12 +83,12 @@ $minutes      = edd_get_minute_values();
 
 				<tr>
 					<th scope="row" valign="top">
-						<label for="edd-products"><?php printf( esc_html__( '%s Requirements', 'easy-digital-downloads' ), edd_get_label_singular() ); ?></label>
+						<label for="edd_products"><?php printf( esc_html__( '%s Requirements', 'easy-digital-downloads' ), edd_get_label_singular() ); ?></label>
 					</th>
 					<td>
 						<?php echo EDD()->html->product_dropdown( array(
 							'name'        => 'product_reqs[]',
-							'id'          => 'products',
+							'id'          => 'edd_products',
 							'selected'    => array(),
 							'multiple'    => true,
 							'chosen'      => true,

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -116,12 +116,12 @@ $minutes              = edd_get_minute_values();
 
                 <tr>
                     <th scope="row" valign="top">
-                        <label for="edd-products"><?php printf( __( '%s Requirements', 'easy-digital-downloads' ), edd_get_label_singular() ); ?></label>
+                        <label for="edd_products"><?php printf( __( '%s Requirements', 'easy-digital-downloads' ), edd_get_label_singular() ); ?></label>
                     </th>
                     <td>
 						<?php echo EDD()->html->product_dropdown( array(
 							'name'        => 'product_reqs[]',
-							'id'          => 'edd-products',
+							'id'          => 'edd_products',
 							'selected'    => $product_requirements,
 							'multiple'    => true,
 							'chosen'      => true,


### PR DESCRIPTION
Fixes #7542 

Proposed Changes:
1. Ensure adding or editing a discount shows product requirement conditions when applicable.

---

Note: Run `npm install && npm run dev`
