### PR TITLE
issue/7524 - Move "Logs" to "Order Details" Section

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2700,7 +2700,7 @@ body.download_page_edd-reports {
 .edd-sections-wrap .section-wrap .customer-section table {
 	margin-bottom: 20px;
 }
-.edd-sections-wrap .section-wrap .section-content {
+.edd-sections-wrap .section-wrap {
 	border-left: 1px solid #e5e5e5;
 }
 .edd-sections-wrap .section-wrap .section-content > div {
@@ -2755,10 +2755,6 @@ body.download_page_edd-reports {
 	margin-top: -3px;
 	margin-right: 50px;
 	width: 202px;
-}
-.edd-sections-wrap .section-wrap .customer-info {
-	margin-bottom: 10px;
-	min-height: 185px;
 }
 .edd-sections-wrap .section-wrap .info-wrapper {
 	min-height: 125px;
@@ -3359,11 +3355,6 @@ div:not(#edd-item-tab-wrapper) + #edd-item-card-wrapper .item-section { /** [1] 
 	.edd-vertical-sections .section-wrap {
 		width: calc( 100% - 48px );
 	}
-}
-
-.section-content {
-	border-left: 1px solid #e5e5e5;
-	min-height: 155px;
 }
 
 #edd-debug-log .edd-inline-button {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1484,7 +1484,7 @@ input[class*="edd-price-field"] {
 #edd-refund-order-dialog .edd-refund-submit-line-total td:first-child {
 	text-align: right;
 }
-#edd-order-logs ul {
+#edd_general_logs p {
 	margin: 0;
 	padding: 0;
 }

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -76,6 +76,12 @@ function edd_get_order_details_sections( $order ) {
 			'icon'     => 'admin-comments',
 			'callback' => 'edd_order_details_notes',
 		),
+		array(
+			'id'       => 'logs',
+			'label'    => __( 'Logs', 'easy-digital-downloads' ),
+			'icon'     => 'admin-tools',
+			'callback' => 'edd_order_details_logs',
+		),
 	);
 
 	// Override sections if adding a new order.
@@ -394,6 +400,47 @@ function edd_order_details_notes( $order ) {
 	</div>
 
 	<?php
+}
+
+/**
+ * Outputs the Order Details logs section.
+ *
+ * @since 3.0
+ *
+ * @param \EDD\Orders\Order $order
+ */
+function edd_order_details_logs( $order ) {
+?>
+
+	<div>
+		<?php
+		/**
+		 * Allows output before the list of logs.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int $order_id ID of the current order.
+		 */
+		do_action( 'edd_view_order_details_logs_before', $order->id );
+		?>
+
+		<p><a href="<?php echo admin_url( 'edit.php?post_type=download&page=edd-tools&tab=logs&payment=' . $order->id ); ?>"><?php esc_html_e( 'File Download Log for Order', 'easy-digital-downloads' ); ?></a></p>
+		<p><a href="<?php echo admin_url( 'edit.php?post_type=download&page=edd-tools&tab=logs&customer=' . $order->customer_id ); ?>"><?php esc_html_e( 'Customer Download Log', 'easy-digital-downloads' ); ?></a></p>
+		<p><a href="<?php echo admin_url( 'edit.php?post_type=download&page=edd-payment-history&user=' . esc_attr( edd_get_payment_user_email( $order->id ) ) ); ?>"><?php esc_html_e( 'Customer Orders', 'easy-digital-downloads' ); ?></a></p>
+
+		<?php
+		/**
+		 * Allows further output after the list of logs.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int $order_id ID of the current order.
+		 */
+		do_action( 'edd_view_order_details_logs_after', $order->id );
+		?>
+	</div>
+
+<?php
 }
 
 /** Main **********************************************************************/
@@ -716,37 +763,6 @@ function edd_order_details_extras( $order = false ) {
 	</div>
 
 <?php
-}
-
-/**
- * Output the order details logs box
- *
- * @since 3.0
- *
- * @param object $order
- */
-function edd_order_details_logs( $order ) {
-	?>
-
-	<div id="edd-order-logs" class="postbox edd-order-logs">
-		<h3 class="hndle"><span><?php esc_html_e( 'Logs', 'easy-digital-downloads' ); ?></span></h3>
-
-		<div class="inside">
-			<div class="edd-admin-box">
-				<div class="edd-admin-box-inside">
-					<ul>
-						<li><a href="<?php echo admin_url( 'edit.php?post_type=download&page=edd-tools&tab=logs&payment=' . $order->id ); ?>"><?php esc_html_e( 'File Download Log for Order', 'easy-digital-downloads' ); ?></a></li>
-						<li><a href="<?php echo admin_url( 'edit.php?post_type=download&page=edd-tools&tab=logs&customer=' . $order->customer_id ); ?>"><?php esc_html_e( 'Customer Download Log', 'easy-digital-downloads' ); ?></a></li>
-						<li><a href="<?php echo admin_url( 'edit.php?post_type=download&page=edd-payment-history&user=' . esc_attr( edd_get_payment_user_email( $order->id ) ) ); ?>"><?php esc_html_e( 'Customer Orders', 'easy-digital-downloads' ); ?></a></li>
-					</ul>
-				</div>
-
-				<?php do_action( 'edd_view_order_details_logs_inner', $order->id ); ?>
-			</div><!-- /.column-container -->
-		</div><!-- /.inside -->
-	</div><!-- /#edd-order-logs -->
-
-	<?php
 }
 
 /**

--- a/includes/admin/payments/view-order-details.php
+++ b/includes/admin/payments/view-order-details.php
@@ -80,9 +80,6 @@ if ( empty( $order ) ) {
 							// Extras
 							edd_order_details_extras( $order );
 
-							// Logs
-							edd_order_details_logs( $order );
-
 							// After sidebar
 							do_action( 'edd_view_order_details_sidebar_after', $order->id );
 


### PR DESCRIPTION
Closes #7524

Proposed Changes:
1. Convert separate "Logs" box to section in the "Order Details" box.

<img width="595" alt="Screen Shot 2020-02-04 at 8 31 34 AM" src="https://user-images.githubusercontent.com/491124/73749218-ec7b7800-4728-11ea-8ee4-143809ef76ff.png">

