### PR TITLE
issue/7525 - Adjust Note Markup and Styles

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -467,9 +467,9 @@ a.edd-delete:hover {
 -------------------------------------------------------------- */
 
 .edd-notes .edd-note {
+	padding: 10px;
 	background-color: #ffffee;
-	border-left: 5px solid #cccc00;
-	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.1 );
+	border: 1px solid #cccc00;
 	width: 100%;
 	position: relative;
 	margin-bottom: 10px;
@@ -481,39 +481,20 @@ a.edd-delete:hover {
 	opacity: 0.5;
 }
 
+.edd-notes .edd-note__header {
+	display: flex;
+	align-items: center;
+}
+
 .edd-add-note .spinner {
 	float: none;
 	display: inline-block;
 	margin: 0;
 }
 
-.edd-notes .edd-note div {
-	padding: 5px 10px;
-	margin: 0;
-}
-
-.edd-notes .edd-note .edd-note-author {
-	padding: 2px 2px 2px 0;
-	float: left;
-}
-
 .edd-notes .edd-note time {
-	float: left;
 	font-size: 11px;
-	line-height: 11px;
 	color: #aaa;
-	padding: 5px 0;
-	vertical-align: middle;
-}
-
-.edd-notes .edd-note p {
-	clear: both;
-	padding: 5px 0;
-	margin: 0;
-}
-
-.edd-notes .edd-note p a {
-	color: #000;
 }
 
 .edd-notes .edd-note .edd-note-author {
@@ -521,19 +502,18 @@ a.edd-delete:hover {
 }
 
 .edd-notes .edd-note .edd-delete-note {
-	position: absolute;
-	right: 0;
-	top: 0;
-	margin: 10px;
-	font-size: 10px;
-	line-height: 10px;
+	color: #a00;
+	font-weight: bold;
 	text-decoration: none;
-	color: #aaa;
-	z-index: 1;
+	margin-left: auto;
 }
 
 .edd-notes .edd-note .edd-delete-note:hover {
 	color: #888;
+}
+
+.edd-notes .edd-note p:last-child {
+	margin-bottom: 0;
 }
 
 .edd-notes .edd-no-notes {

--- a/includes/admin/notes/note-functions.php
+++ b/includes/admin/notes/note-functions.php
@@ -93,14 +93,16 @@ function edd_admin_get_note_html( $note_id = 0 ) {
 	?>
 
 	<div class="edd-note" id="edd-note-<?php echo esc_attr( $note->id ); ?>">
-		<div>
+		<div class="edd-note__header">
 			<strong class="edd-note-author"><?php echo esc_html( $author ); ?></strong>
 			<time datetime="<?php echo esc_attr( $date ); ?>"><?php echo edd_date_i18n( $date, 'datetime' ); ?></time>
-			<p><?php echo make_clickable( $note->content ); ?></p>
+
 			<a href="<?php echo esc_url( $delete_note_url ); ?>#edd-notes" class="edd-delete-note" data-note-id="<?php echo esc_attr( $note->id ); ?>" data-object-id="<?php echo esc_attr( $note->object_id ); ?>" data-object-type="<?php echo esc_attr( $note->object_type ); ?>">
-				<?php esc_html_e( 'Delete', 'easy-digital-downloads' ); ?>
+				<?php echo esc_html_x( '&times;', 'Delete note', 'easy-digital-downloads' ); ?>
 			</a>
 		</div>
+
+		<?php echo wpautop( make_clickable( $note->content ) ); ?>
 	</div>
 
 	<?php


### PR DESCRIPTION
Fixes #7525 

Proposed Changes:
1. Adjust "Notes" markup and styles.

<img width="800" alt="Screen Shot 2020-02-04 at 1 03 21 PM" src="https://user-images.githubusercontent.com/491124/73772727-b81ab280-474e-11ea-924e-e7fb75e46bc2.png">
