### PR TITLE
Use "Order" and "Orders" for `sale` Order Type UI labels

### DIFF
--- a/includes/orders/functions/types.php
+++ b/includes/orders/functions/types.php
@@ -81,8 +81,8 @@ function edd_register_default_order_types( $name = '' ) {
 	// Sales
 	edd_register_order_type( 'sale', array(
 		'labels' => array(
-			'singular' => __( 'Sale',  'easy-digital-downloads' ),
-			'plural'   => __( 'Sales', 'easy-digital-downloads' )
+			'singular' => __( 'Order',  'easy-digital-downloads' ),
+			'plural'   => __( 'Orders', 'easy-digital-downloads' )
 		)
 	) );
 


### PR DESCRIPTION
Fixes #7527 

Proposed Changes:
1. Use "Order" and "Orders" for `sale` Order Type UI labels.