### PR TITLE
issue/7564 - Separate Orders and Refunds in Customer Details

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -856,7 +856,11 @@ function edd_customers_view( $customer = null ) {
 
 				<?php endforeach;
 			else: ?>
-				<tr><td colspan="5" class="no-items"><?php esc_html_e( 'No Payments Found', 'easy-digital-downloads' ); ?></td></tr>
+				<tr><td colspan="5" class="no-items"><?php esc_html_e( 'No orders found', 'easy-digital-downloads' ); ?></td></tr>
+			<?php endif; ?>
+			</tbody>
+		</table>
+
 		<h3><?php _e( 'Recent Refunds', 'easy-digital-downloads' ); ?></h3>
 		<table class="wp-list-table widefat striped customer-payments">
 			<thead>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -440,10 +440,17 @@ function edd_customers_view( $customer = null ) {
 	$addresses = $customer->get_addresses();
 
 	// Orders
+	// Orders and refunds.
 	$orders = edd_get_orders( array(
 		'customer_id' => $customer->id,
 		'number'      => 10,
 		'type'        => 'sale',
+	) );
+
+	$refunds = edd_get_orders( array(
+		'customer_id' => $customer->id,
+		'number'      => 10,
+		'type'        => 'refund',
 	) );
 
 	// Downloads
@@ -850,6 +857,38 @@ function edd_customers_view( $customer = null ) {
 				<?php endforeach;
 			else: ?>
 				<tr><td colspan="5" class="no-items"><?php esc_html_e( 'No Payments Found', 'easy-digital-downloads' ); ?></td></tr>
+		<h3><?php _e( 'Recent Refunds', 'easy-digital-downloads' ); ?></h3>
+		<table class="wp-list-table widefat striped customer-payments">
+			<thead>
+			<tr>
+				<th class="column-primary"><?php _e( 'Number', 'easy-digital-downloads' ); ?></th>
+				<th><?php _e( 'Gateway', 'easy-digital-downloads' ); ?></th>
+				<th><?php _e( 'Total', 'easy-digital-downloads' ); ?></th>
+				<th><?php _e( 'Date', 'easy-digital-downloads' ); ?></th>
+			</tr>
+			</thead>
+			<tbody>
+			<?php if ( ! empty( $refunds ) ) :
+				foreach ( $refunds as $refund ) :
+					// View URL
+					$view_url = edd_get_admin_url( array(
+						'page' => 'edd-payment-history',
+						'view' => 'view-order-details',
+						'id'   => $refund->id,
+					) );
+
+					$link = '<a class="row-title" href="' . esc_url( $view_url ) . '">' . esc_html( $refund->order_number ) . '</a>'; ?>
+
+					<tr>
+						<td class="column-primary"><strong><?php echo $link; ?></strong></td>
+						<td><?php echo edd_get_gateway_admin_label( $refund->gateway ); ?></td>
+						<td><?php echo edd_currency_filter( edd_format_amount( $refund->total ), $refund->currency ); ?></td>
+						<td><time datetime="<?php echo esc_attr( EDD()->utils->date( $refund->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( EDD()->utils->date( $refund->date_created, null, true )->toDateTimeString(), 'M. d, Y' ) . '<br>' . edd_date_i18n( EDD()->utils->date( $refund->date_created, null, true )->toDateTimeString(), 'H:i' ); ?></time></td>
+					</tr>
+
+				<?php endforeach;
+			else: ?>
+				<tr><td colspan="5" class="no-items"><?php esc_html_e( 'No refunds found', 'easy-digital-downloads' ); ?></td></tr>
 			<?php endif; ?>
 			</tbody>
 		</table>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -824,8 +824,8 @@ function edd_customers_view( $customer = null ) {
 			<tr>
 				<th class="column-primary"><?php _e( 'Number', 'easy-digital-downloads' ); ?></th>
 				<th><?php _e( 'Gateway', 'easy-digital-downloads' ); ?></th>
-				<th><?php _e( 'Amount', 'easy-digital-downloads' ); ?></th>
-				<th><?php _e( 'Completed', 'easy-digital-downloads' ); ?></th>
+				<th><?php _e( 'Total', 'easy-digital-downloads' ); ?></th>
+				<th><?php _e( 'Date', 'easy-digital-downloads' ); ?></th>
 			</tr>
 			</thead>
 			<tbody>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -443,6 +443,7 @@ function edd_customers_view( $customer = null ) {
 	$orders = edd_get_orders( array(
 		'customer_id' => $customer->id,
 		'number'      => 10,
+		'type'        => 'sale',
 	) );
 
 	// Downloads


### PR DESCRIPTION
Fixes #7564 

Proposed Changes:
1. Show separate tables for Orders and Refunds when viewing a Customer record.
2. Adjust table column headers from "Amount" to "Total" and "Completed" to "Date"