### PR TITLE
issue/7569 - Adjust "Email" Order Details Section UI/UX

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -552,6 +552,15 @@ a.edd-delete:hover {
 	display: none;
 }
 
+.edd-order-resend-email-chooser legend {
+	font-weight: bold;
+	margin-bottom: 4px;
+}
+
+.edd-order-resend-email-chooser p {
+	margin: 4px 0;
+}
+
 /* Note Styles
 -------------------------------------------------------------- */
 

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -278,7 +278,17 @@ function edd_order_details_customer( $order ) {
  * @param object $order
  */
 function edd_order_details_email( $order ) {
-	$customer = edd_get_customer( $order->customer_id ); ?>
+	$customer   = edd_get_customer( $order->customer_id );
+	$all_emails = array( 'primary' => $customer->email );
+
+	foreach ( $customer->emails as $key => $email ) {
+		if ( $customer->email === $email ) {
+			continue;
+		}
+
+		$all_emails[ $key ] = $email;
+	}
+?>
 
 	<div><?php
 		if ( ! empty( $customer->emails ) && count( (array) $customer->emails ) > 1 ) : ?>
@@ -292,6 +302,7 @@ function edd_order_details_email( $order ) {
 					<input autocomplete="off" class="edd-order-resend-receipt-email" name="edd-order-resend-receipt-address" type="radio" value="<?php echo rawurlencode( sanitize_email( $email ) ); ?>" />
 					<?php echo esc_attr( $email ); ?>
 				</label>
+						<input autocomplete="off" id="<?php echo rawurlencode( sanitize_email( $email ) ); ?>" class="edd-order-resend-receipt-email" name="edd-order-resend-receipt-address" type="radio" value="<?php echo rawurlencode( sanitize_email( $email ) ); ?>" <?php checked( true, ( 'primary' === $key ) ); ?> />
 				<?php endforeach; ?>
 			</span>
 

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -292,25 +292,28 @@ function edd_order_details_email( $order ) {
 
 	<div><?php
 		if ( ! empty( $customer->emails ) && count( (array) $customer->emails ) > 1 ) : ?>
-			<span class="edd-order-resend-receipt-header">
-				<?php _e( 'Choose an email address to send the receipt to:', 'easy-digital-downloads' ); ?>
-			</span>
+			<fieldset class="edd-order-resend-email-chooser">
+				<legend>
+					<?php _e( 'Send to', 'easy-digital-downloads' ); ?>
+				</legend>
 
-			<span class="edd-order-resend-receipt-addresses">
-				<?php foreach ( $customer->emails as $key => $email ) : ?>
-				<label>
-					<input autocomplete="off" class="edd-order-resend-receipt-email" name="edd-order-resend-receipt-address" type="radio" value="<?php echo rawurlencode( sanitize_email( $email ) ); ?>" />
-					<?php echo esc_attr( $email ); ?>
-				</label>
+				<?php foreach ( $all_emails as $key => $email ) : ?>
+				<p>
+					<label for="<?php echo rawurlencode( sanitize_email( $email ) ); ?>">
 						<input autocomplete="off" id="<?php echo rawurlencode( sanitize_email( $email ) ); ?>" class="edd-order-resend-receipt-email" name="edd-order-resend-receipt-address" type="radio" value="<?php echo rawurlencode( sanitize_email( $email ) ); ?>" <?php checked( true, ( 'primary' === $key ) ); ?> />
+						<?php echo esc_attr( $email ); ?>
+					</label>
+				</p>
 				<?php endforeach; ?>
-			</span>
+			</fieldset>
 
 		<?php else : ?>
 
 			<input readonly type="email" value="<?php echo esc_attr( $order->email ); ?>" />
 
 		<?php endif; ?>
+
+		<p class="description"><?php esc_html_e( 'Send a new copy of the purchase receipt to the email address used for this order. If download URLs were included in the original receipt, new ones will be included.', 'easy-digital-downloads' ); ?></p>
 
 		<a href="<?php echo esc_url( add_query_arg( array(
 			'edd-action'  => 'email_links',
@@ -320,8 +323,6 @@ function edd_order_details_email( $order ) {
 		} else {
 			echo esc_attr( 'edd-resend-receipt' );
 		} ?>" class="button-secondary"><?php esc_html_e( 'Resend Receipt', 'easy-digital-downloads' ); ?></a>
-
-		<p class="description"><?php esc_html_e( 'Send a new copy of the purchase receipt to the email address used for this order. If download URLs were included in the original receipt, new ones will be included.', 'easy-digital-downloads' ); ?></p>
 
 		<?php do_action( 'edd_view_order_details_resend_receipt_after', $order->id ); ?>
 

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -294,7 +294,7 @@ function edd_order_details_email( $order ) {
 		if ( ! empty( $customer->emails ) && count( (array) $customer->emails ) > 1 ) : ?>
 			<fieldset class="edd-order-resend-email-chooser">
 				<legend>
-					<?php _e( 'Send to', 'easy-digital-downloads' ); ?>
+					<?php _e( 'Send email receipt to', 'easy-digital-downloads' ); ?>
 				</legend>
 
 				<?php foreach ( $all_emails as $key => $email ) : ?>


### PR DESCRIPTION
Fixes #7569 

Proposed Changes:
1. Preselects the Customer's primary email address.
2. Adds setting description directly under the setting.
3. Adds valid markup for a list of radios.

<img width="802" alt="Screen Shot 2020-02-10 at 10 45 22 AM" src="https://user-images.githubusercontent.com/491124/74164978-75475780-4bf2-11ea-890b-3b811ef521f5.png">
