### PR TITLE
issue/7387 - Adjust JSON-LD Structured Data for Downloads

### DIFF
--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -152,7 +152,9 @@ class Structured_Data {
 				'@type' => 'Thing',
 				'name'  => get_bloginfo( 'name' ),
 			),
-			'sku'         => $download->get_sku(),
+			'sku'         => '-' === $download->get_sku()
+				? $download->ID
+				: $download->get_sku(),
 		);
 
 		// Add image if it exists.

--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -147,7 +147,6 @@ class Structured_Data {
 		$data = array(
 			'@type'       => 'Product',
 			'name'        => $download->post_title,
-			'description' => $download->post_excerpt,
 			'url'         => get_permalink( $download->ID ),
 			'brand'       => array(
 				'@type' => 'Thing',
@@ -162,6 +161,12 @@ class Structured_Data {
 		if ( false !== $image_url ) {
 			$data['image'] = esc_url( $image_url );
 		}
+
+		// Add description if it is not blank.
+		if ( '' !== $download->post_excerpt ) {
+			$data['description'] = $download->post_excerpt;
+		}
+
 		if ( $download->has_variable_prices() ) {
 			$variable_prices = $download->get_prices();
 

--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -153,10 +153,15 @@ class Structured_Data {
 				'@type' => 'Thing',
 				'name'  => get_bloginfo( 'name' ),
 			),
-			'image'       => wp_get_attachment_image_url( get_post_thumbnail_id( $download->ID ) ),
 			'sku'         => $download->get_sku(),
 		);
 
+		// Add image if it exists.
+		$image_url = wp_get_attachment_image_url( get_post_thumbnail_id( $download->ID ) );
+
+		if ( false !== $image_url ) {
+			$data['image'] = esc_url( $image_url );
+		}
 		if ( $download->has_variable_prices() ) {
 			$variable_prices = $download->get_prices();
 

--- a/includes/class-structured-data.php
+++ b/includes/class-structured-data.php
@@ -179,7 +179,7 @@ class Structured_Data {
 					'@type'           => 'Offer',
 					'price'           => $price['amount'],
 					'priceCurrency'   => edd_get_currency(),
-					'priceValidUntil' => null,
+					'priceValidUntil' => date( 'c', time() + YEAR_IN_SECONDS ),
 					'itemOffered'     => $data['name'] . ' - ' . $price['name'],
 					'url'             => $data['url'],
 					'availability'    => 'http://schema.org/InStock',

--- a/tests/tests-structured-data.php
+++ b/tests/tests-structured-data.php
@@ -38,7 +38,27 @@ class Tests_Structured_Data extends EDD_UnitTestCase {
 
 		$data = EDD()->structured_data->get_data();
 
-		$this->assertEquals( self::$download->post_title, $data[0]['name'] );
+		$product = $data[0];
+
+		// @type
+		$this->assertEquals( 'Product', $product['@type'] );
+
+		// name
+		$this->assertEquals( self::$download->post_title, $product['name'] );
+
+		// url
+		$this->assertArrayHasKey( 'url', $product );
+
+		// image
+		$this->assertArrayNotHasKey( 'image', $product );
+
+		// brand
+		$this->assertArrayHasKey( 'brand', $product );
+		$this->assertEquals( 'Thing', $product['brand']['@type'] );
+		$this->assertEquals( get_bloginfo( 'name' ), $product['brand']['name'] );
+
+		// offers
+		$this->assertArrayHasKey( 'offers', $product );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7387 

Proposed Changes:
1. Only include `image` if one exists.
2. Only include `description` if one exists.
3. Fallback to the Download ID if no unique SKU is set.
4. Set `priceValidUntil` for each offer.