### PR TITLE
issue/7581 - Ensure Discount Start/End Dates Can Be Blank

### DIFF
--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -214,6 +214,8 @@ function edd_admin_edit_discount( $data = array() ) {
 		// The start date is entered in the user's WP timezone. We need to convert it to UTC prior to saving now.
 		$date                 = edd_get_utc_equivalent_date( EDD()->utils->date( $start_date . ' ' . $start_date_hour . ':' . $start_date_minute . ':00', edd_get_timezone_id(), false ) );
 		$to_update['start_date'] = $date->format( 'Y-m-d H:i:s' );
+	} else {
+		$to_update['start_date'] = '0000-00-00 00:00:00';
 	}
 
 	// End date.
@@ -229,6 +231,8 @@ function edd_admin_edit_discount( $data = array() ) {
 		// The end date is entered in the user's WP timezone. We need to convert it to UTC prior to saving now.
 		$date               = edd_get_utc_equivalent_date( EDD()->utils->date( $end_date . ' ' . $end_date_hour . ':' . $end_date_minute . ':00', edd_get_timezone_id(), false ) );
 		$to_update['end_date'] = $date->format( 'Y-m-d H:i:s' );
+	} else {
+		$to_update['end_date'] = '0000-00-00 00:00:00';
 	}
 
 	// Known & accepted core discount meta

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -175,12 +175,12 @@ $minutes              = edd_get_minute_values();
                         <label for="edd-start"><?php _e( 'Start date', 'easy-digital-downloads' ); ?></label>
                     </th>
                     <td>
-                        <input name="start_date" id="edd-start" type="text" value="<?php echo esc_attr( $start_date ); ?>" class="edd_datepicker" data-format="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" placeholder="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" />
+                        <input name="start_date" id="edd-start" type="text" value="<?php echo esc_attr( false !== $discount->start_date ? $start_date : '' ); ?>" class="edd_datepicker" data-format="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" placeholder="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" />
 						<?php
 						echo EDD()->html->select( array(
 							'name'             => 'start_date_hour',
 							'options'          => $hours,
-							'selected'         => $start_hour,
+							'selected'         => false !== $discount->start_date ? $start_hour : '0',
 							'chosen'           => true,
 							'class'            => 'edd-time',
 							'show_option_none' => false,
@@ -192,7 +192,7 @@ $minutes              = edd_get_minute_values();
 						echo EDD()->html->select( array(
 							'name'             => 'start_date_minute',
 							'options'          => $minutes,
-							'selected'         => $start_minute,
+							'selected'         => false !== $discount->start_date ? $start_minute : '0',
 							'chosen'           => true,
 							'class'            => 'edd-time',
 							'show_option_none' => false,
@@ -212,12 +212,12 @@ $minutes              = edd_get_minute_values();
                         <label for="edd-expiration"><?php _e( 'Expiration date', 'easy-digital-downloads' ); ?></label>
                     </th>
                     <td>
-                        <input name="end_date" id="edd-expiration" type="text" value="<?php echo esc_attr( $end_date ); ?>"  class="edd_datepicker" data-format="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" placeholder="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" />
+                        <input name="end_date" id="edd-expiration" type="text" value="<?php echo esc_attr( false !== $discount->end_date ? $end_date : '' ); ?>"  class="edd_datepicker" data-format="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" placeholder="<?php echo esc_attr( edd_get_date_picker_format() ); ?>" />
 						<?php
 						echo EDD()->html->select( array(
 							'name'             => 'end_date_hour',
 							'options'          => $hours,
-							'selected'         => $end_hour,
+							'selected'         => false !== $discount->end_date ? $end_hour : '23',
 							'chosen'           => true,
 							'class'            => 'edd-time',
 							'show_option_none' => false,
@@ -229,7 +229,7 @@ $minutes              = edd_get_minute_values();
 						echo EDD()->html->select( array(
 							'name'             => 'end_date_minute',
 							'options'          => $minutes,
-							'selected'         => $end_minute,
+							'selected'         => false !== $discount->end_date ? $end_minute : '59',
 							'chosen'           => true,
 							'class'            => 'edd-time',
 							'show_option_none' => false,


### PR DESCRIPTION
Fixes #7581 

Proposed Changes:
1. Ensure Discount start and end dates can be left blank.
