### PR TITLE
Issue/7589 - Correct date timezones on Orders, Notes, & Customers pages

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -843,7 +843,7 @@ function edd_customers_view( $customer = null ) {
 						<td class="column-primary"><strong><?php echo $link; ?></strong></td>
 						<td><?php echo edd_get_gateway_admin_label( $order->gateway ); ?></td>
 						<td><?php echo edd_currency_filter( edd_format_amount( $order->total ), $order->currency ); ?></td>
-						<td><time datetime="<?php echo esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString(), 'M. d, Y' ) . '<br>' . edd_date_i18n( strtotime( $order->date_created ), 'H:i' ); ?></time></td>
+						<td><time datetime="<?php echo esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString(), 'M. d, Y' ) . '<br>' . edd_date_i18n( strtotime( $order->date_created ), 'H:i' ) . ' ' . edd_get_timezone_abbr(); ?></time></td>
 					</tr>
 
 				<?php endforeach;

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -610,7 +610,7 @@ function edd_customers_view( $customer = null ) {
 		<p class="customer-terms-agreement-date info-item">
 			<?php
 			if ( ! empty( $agreement_timestamp ) ) {
-				echo esc_html( date_i18n( get_option( 'date_format' ) . ' H:i:s', $agreement_timestamp ) );
+				echo esc_html( edd_date_i18n( $agreement_timestamp, get_option( 'date_format' ) . ' H:i:s' ) . ' ' . edd_get_timezone_abbr() );
 
 				esc_html_e( ' &mdash; Agreed to Terms', 'easy-digital-downloads' );
 
@@ -624,7 +624,7 @@ function edd_customers_view( $customer = null ) {
 				esc_html_e( 'No terms agreement found.', 'easy-digital-downloads' );
 
 			} else {
-				echo esc_html( date_i18n( get_option( 'date_format' ) . ' H:i:s', $last_payment_date ) );
+				echo esc_html( edd_date_i18n( $last_payment_date, get_option( 'date_format' ) . ' H:i:s' ) . ' ' . edd_get_timezone_abbr() );
 
 				esc_html_e( ' &mdash; Agreed to Terms', 'easy-digital-downloads' );
 				?>
@@ -637,7 +637,7 @@ function edd_customers_view( $customer = null ) {
 
 		<p class="customer-privacy-policy-date info-item">
 			<?php if ( ! empty( $privacy_timestamp ) ) {
-				echo esc_html( date_i18n( get_option( 'date_format' ) . ' H:i:s', $privacy_timestamp ) );
+				echo esc_html( edd_date_i18n( $privacy_timestamp, get_option( 'date_format' ) . ' H:i:s' ) . ' ' . edd_get_timezone_abbr() );
 
 				esc_html_e( ' &mdash; Agreed to Privacy Policy', 'easy-digital-downloads' );
 
@@ -651,7 +651,7 @@ function edd_customers_view( $customer = null ) {
 				esc_html_e( 'No privacy policy agreement found.', 'easy-digital-downloads' );
 
 			} else {
-				echo esc_html( date_i18n( get_option( 'date_format' ) . ' H:i:s', $last_payment_date ) );
+				echo esc_html( edd_date_i18n( $last_payment_date, get_option( 'date_format' ) . ' H:i:s' ) . ' ' . edd_get_timezone_abbr() );
 
 				esc_html_e( ' &mdash; Agreed to Privacy Policy', 'easy-digital-downloads' );
 				?>
@@ -729,7 +729,7 @@ function edd_customers_view( $customer = null ) {
 								: '&mdash;';
 							?>
 						</td>
-						<td><time datetime="<?php echo esc_attr( EDD()->utils->date( $address->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( EDD()->utils->date( $address->date_created, null, true )->toDateTimeString(), 'M. d, Y' ) . '<br>' . edd_date_i18n( EDD()->utils->date( $address->date_created, null, true )->toDateTimeString(), 'H:i' ); ?></time></td>
+						<td><time datetime="<?php echo esc_attr( EDD()->utils->date( $address->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( EDD()->utils->date( $address->date_created, null, true )->toDateTimeString(), 'M. d, Y' ) . '<br>' . edd_date_i18n( strtotime( $address->date_created ), 'H:i' ) . ' ' . edd_get_timezone_abbr(); ?></time></td>
 					</tr>
 
 				<?php endforeach; ?>
@@ -843,7 +843,7 @@ function edd_customers_view( $customer = null ) {
 						<td class="column-primary"><strong><?php echo $link; ?></strong></td>
 						<td><?php echo edd_get_gateway_admin_label( $order->gateway ); ?></td>
 						<td><?php echo edd_currency_filter( edd_format_amount( $order->total ), $order->currency ); ?></td>
-						<td><time datetime="<?php echo esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString(), 'M. d, Y' ) . '<br>' . edd_date_i18n( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString(), 'H:i' ); ?></time></td>
+						<td><time datetime="<?php echo esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString(), 'M. d, Y' ) . '<br>' . edd_date_i18n( strtotime( $order->date_created ), 'H:i' ); ?></time></td>
 					</tr>
 
 				<?php endforeach;

--- a/includes/admin/notes/note-functions.php
+++ b/includes/admin/notes/note-functions.php
@@ -87,15 +87,12 @@ function edd_admin_get_note_html( $note_id = 0 ) {
 
 	// Start a buffer
 	ob_start();
-
-	// Apply offset so date and time is displayed correctly.
-	$date = EDD()->utils->date( $note->date_created, null, true )->toDateTimeString();
 	?>
 
 	<div class="edd-note" id="edd-note-<?php echo esc_attr( $note->id ); ?>">
 		<div>
 			<strong class="edd-note-author"><?php echo esc_html( $author ); ?></strong>
-			<time datetime="<?php echo esc_attr( $date ); ?>"><?php echo edd_date_i18n( $date, 'datetime' ); ?></time>
+			<time datetime="<?php echo esc_attr( EDD()->utils->date( $note->date_created, null, true )->toDateTimeString() ); ?>"><?php echo edd_date_i18n( $note->date_created, 'datetime' ); ?></time>
 			<p><?php echo make_clickable( $note->content ); ?></p>
 			<a href="<?php echo esc_url( $delete_note_url ); ?>#edd-notes" class="edd-delete-note" data-note-id="<?php echo esc_attr( $note->id ); ?>" data-object-id="<?php echo esc_attr( $note->object_id ); ?>" data-object-type="<?php echo esc_attr( $note->object_type ); ?>">
 				<?php esc_html_e( 'Delete', 'easy-digital-downloads' ); ?>

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -421,8 +421,7 @@ class EDD_Payment_History_Table extends List_Table {
 				$value = edd_currency_filter( edd_format_amount( $order->total ), $order->currency );
 				break;
 			case 'date':
-				$date  = EDD()->utils->date( $order->date_created, null, true )->toDateTimeString();
-				$value = '<time datetime="' . esc_attr( $date ) . '">' . edd_date_i18n( $date, 'M. d, Y' ) . '<br>' . edd_date_i18n( $date, 'H:i' ) . ' ' . $timezone_abbreviation . '</time>';
+				$value = '<time datetime="' . esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ) . '">' . edd_date_i18n( $order->date_created, 'M. d, Y' ) . '<br>' . edd_date_i18n( $order->date_created, 'H:i' ) . ' ' . $timezone_abbreviation . '</time>';
 				break;
 			case 'gateway':
 				$value = edd_get_gateway_admin_label( $order->gateway );

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -421,7 +421,7 @@ class EDD_Payment_History_Table extends List_Table {
 				$value = edd_currency_filter( edd_format_amount( $order->total ), $order->currency );
 				break;
 			case 'date':
-				$value = '<time datetime="' . esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ) . '">' . edd_date_i18n( $order->date_created, 'M. d, Y' ) . '<br>' . edd_date_i18n( $order->date_created, 'H:i' ) . ' ' . $timezone_abbreviation . '</time>';
+				$value = '<time datetime="' . esc_attr( EDD()->utils->date( $order->date_created, null, true )->toDateTimeString() ) . '">' . edd_date_i18n( $order->date_created, 'M. d, Y' ) . '<br>' . edd_date_i18n( strtotime( $order->date_created ), 'H:i' ) . ' ' . $timezone_abbreviation . '</time>';
 				break;
 			case 'gateway':
 				$value = edd_get_gateway_admin_label( $order->gateway );

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -817,7 +817,7 @@ function edd_order_details_attributes( $order ) {
 					echo EDD()->html->select( array(
 						'name'             => 'edd-payment-time-hour',
 						'options'          => edd_get_hour_values(),
-						'selected'         => $order_date->format( 'G' ),
+						'selected'         => $order_date->format( 'H' ),
 						'chosen'           => true,
 						'class'            => 'edd-time',
 						'show_option_none' => false,

--- a/includes/date-functions.php
+++ b/includes/date-functions.php
@@ -186,7 +186,7 @@ function edd_get_hour_values() {
 	return (array) apply_filters( 'edd_get_hour_values', array(
 		'00' => '00',
 		'01' => '01',
-		'03' => '02',
+		'02' => '02',
 		'03' => '03',
 		'04' => '04',
 		'05' => '05',


### PR DESCRIPTION
Fixes #7589 

Proposed Changes:
1. Show order completed date in site time zone.
2. Show order & customer notes in site time zone.
3. Show customer Agreements dates in site time zone. Also append site time zone abbreviation.
4. Show customer addresses "First Used" date column in site time zone. Also append time zone abbreviation.
5. Show customer recent orders "Completed" date column in site time zone. Also append time zone abbreviation.
6. Correct an array key error in `edd_get_hour_values()` function. There was an incorrect entry for `'03' => '02',` when it should have been `'02' => '02',`.