### PR TITLE
Release/2.9.21

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -5,7 +5,7 @@
  * Description: The easiest way to sell digital products with WordPress.
  * Author: Easy Digital Downloads
  * Author URI: https://easydigitaldownloads.com
- * Version: 2.9.20
+ * Version: 2.9.21-020320200001
  * Text Domain: easy-digital-downloads
  * Domain Path: languages
  *
@@ -206,7 +206,7 @@ final class Easy_Digital_Downloads {
 
 		// Plugin version.
 		if ( ! defined( 'EDD_VERSION' ) ) {
-			define( 'EDD_VERSION', '2.9.20' );
+			define( 'EDD_VERSION', '2.9.21-020320200001' );
 		}
 
 		// Plugin Folder Path.

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -5,7 +5,7 @@
  * Description: The easiest way to sell digital products with WordPress.
  * Author: Easy Digital Downloads
  * Author URI: https://easydigitaldownloads.com
- * Version: 2.9.21-020320200001
+ * Version: 2.9.21
  * Text Domain: easy-digital-downloads
  * Domain Path: languages
  *
@@ -206,7 +206,7 @@ final class Easy_Digital_Downloads {
 
 		// Plugin version.
 		if ( ! defined( 'EDD_VERSION' ) ) {
-			define( 'EDD_VERSION', '2.9.21-020320200001' );
+			define( 'EDD_VERSION', '2.9.21' );
 		}
 
 		// Plugin Folder Path.

--- a/languages/easy-digital-downloads.pot
+++ b/languages/easy-digital-downloads.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Easy Digital Downloads package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Digital Downloads 2.9.21-020320200001\n"
+"Project-Id-Version: Easy Digital Downloads 2.9.21\n"
 "Report-Msgid-Bugs-To: https://easydigitaldownloads.com/\n"
-"POT-Creation-Date: 2020-02-03 23:51:08+00:00\n"
+"POT-Creation-Date: 2020-02-24 21:18:20+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/languages/easy-digital-downloads.pot
+++ b/languages/easy-digital-downloads.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Easy Digital Downloads package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Digital Downloads 2.9.20\n"
+"Project-Id-Version: Easy Digital Downloads 2.9.21-020320200001\n"
 "Report-Msgid-Bugs-To: https://easydigitaldownloads.com/\n"
-"POT-Creation-Date: 2020-02-03 23:48:31+00:00\n"
+"POT-Creation-Date: 2020-02-03 23:51:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-digital-downloads",
-  "version": "2.9.20",
+  "version": "2.9.21",
   "private": true,
   "devDependencies": {
     "grunt": "^1.0.4",

--- a/readme.txt
+++ b/readme.txt
@@ -189,7 +189,7 @@ Yes. Easy Digital Downloads also includes default support for Amazon Payments an
 9. Checkout screen
 
 == Changelog ==
-= 2.9.21, February 24, 2020 =
+= 2.9.21, March 2, 2020 =
 * Fix: Corrected a reporting issue with earnings when using negative fees, such as Discounts Pro.
 * Fix: Only count the number of downloads for a purchase when download counts are not unlimited.
 * Fix: Fixed a typo in the settings text.

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: ecommerce, e-commerce, sell, downloads, store, paypal, checkout, shop
 Requires at least: 4.4
 Tested up to: 5.3
 Requires PHP: 5.3
-Stable Tag: 2.9.20
+Stable Tag: 2.9.21
 License: GNU Version 2 or Any Later Version
 
 The easiest way to sell digital products with WordPress.
@@ -189,6 +189,13 @@ Yes. Easy Digital Downloads also includes default support for Amazon Payments an
 9. Checkout screen
 
 == Changelog ==
+= 2.9.21, February 24, 2020 =
+* Fix: Corrected a reporting issue with earnings when using negative fees, such as Discounts Pro.
+* Fix: Only count the number of downloads for a purchase when download counts are not unlimited.
+* Fix: Fixed a typo in the settings text.
+* Dev: Added a supported PHP Version to the plugin headers.
+* New: Added information about the Jilt integration into the email settings.
+
 = 2.9.20, November 14, 2019 =
 * Fix: CSV download import issues with file to price assignments and AmazonS3 files.
 * Fix: The edd_after_payment_actions action fired via cron was missing attributes.

--- a/tests/tests-payments.php
+++ b/tests/tests-payments.php
@@ -136,7 +136,7 @@ class Tests_Payments extends EDD_UnitTestCase {
 	}
 
 	public function test_get_payment_status_translated() {
-		add_filter( 'locale', function() { return 'fr_FR'; }, 10 );
+		add_filter( 'locale', array( $this, 'alter_lang_to_fr' ), 10 );
 		$lang_file = EDD_PLUGIN_DIR . 'languages/easy-digital-downloads-fr_FR.mo';
 		load_textdomain( 'easy-digital-downloads', $lang_file );
 
@@ -147,7 +147,7 @@ class Tests_Payments extends EDD_UnitTestCase {
 		$this->assertEquals( 'pending', edd_get_payment_status( $payment ) );
 		$this->assertFalse( edd_get_payment_status( 1212121212121 ) );
 
-		remove_filter( 'locale', function() { return 'fr_FR'; }, 10 );
+		remove_filter( 'locale', array( $this, 'alter_lang_to_fr' ), 10 );
 		unload_textdomain( 'easy-digital-downloads' );
 	}
 
@@ -543,5 +543,7 @@ class Tests_Payments extends EDD_UnitTestCase {
 
 		$this->assertSame( $payment_customer->id, $recovery_customer->id );
 	}
+
+	public function alter_lang_to_fr() { return 'fr_FR'; }
 
 }

--- a/tests/tests-payments.php
+++ b/tests/tests-payments.php
@@ -138,7 +138,7 @@ class Tests_Payments extends EDD_UnitTestCase {
 	public function test_get_payment_status_translated() {
 		add_filter( 'locale', array( $this, 'alter_lang_to_fr' ), 10 );
 		$lang_file = EDD_PLUGIN_DIR . 'languages/easy-digital-downloads-fr_FR.mo';
-		load_textdomain( 'easy-digital-downloads', $lang_file );
+		@load_textdomain( 'easy-digital-downloads', $lang_file );
 
 		$this->assertEquals( 'pending', edd_get_payment_status( $this->_payment_id ) );
 		$this->assertEquals( 'pending', edd_get_payment_status( get_post( $this->_payment_id ) ) );

--- a/tests/tests-template.php
+++ b/tests/tests-template.php
@@ -34,16 +34,16 @@ class Test_Template extends EDD_UnitTestCase {
 		edd_pagination( $args );
 		$output = ob_get_clean();
 		// Verify it has the current page as 1
-		$this->assertContains( " class='page-numbers current'>1</span>", $output );
+		$this->assertSame( 1, preg_match( '/class=(\"|\')page-numbers current(\"|\')>1<\/span>/', $output ) );
 
 		// Verify that it contains page 2
-		$this->assertContains( "<a class='page-numbers' href='http://example.org/?paged=2'>2</a>", $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=2(\"|\')>2<\/a>/', $output ) );
 
 		// Verify that the 'next' button appears.
-		$this->assertContains( '<a class="next page-numbers" href="http://example.org/?paged=2">Next &raquo;</a>', $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')next page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=2(\"|\')>Next &raquo;<\/a>/', $output ) );
 
 		// Verify that the 'previous' button does not appear.
-		$this->assertNotContains( 'class="prev ', $output );
+		$this->assertEmpty( preg_match( '/class=(\"|\')prev /', $output ) );
 	}
 
 	public function test_pagination_threepages_page2() {
@@ -57,15 +57,15 @@ class Test_Template extends EDD_UnitTestCase {
 		edd_pagination( $args );
 		$output = ob_get_clean();
 		// Verify it has the current page as 2
-		$this->assertContains( " class='page-numbers current'>2</span>", $output );
+		$this->assertSame( 1, preg_match( '/class=(\"|\')page-numbers current(\"|\')>2<\/span>/', $output ) );
 
 		// Verify that it contains pages 1 and 3
-		$this->assertContains( "<a class='page-numbers' href='http://example.org/?paged=1'>1</a>", $output );
-		$this->assertContains( "<a class='page-numbers' href='http://example.org/?paged=3'>3</a>", $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=1(\"|\')>1<\/a>/', $output ) );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=3(\"|\')>3<\/a>/', $output ) );
 
 		// Verify that the 'next' and 'previous' buttons appear.
-		$this->assertContains( '<a class="next page-numbers" href="http://example.org/?paged=3">Next &raquo;</a>', $output );
-		$this->assertContains( '<a class="prev page-numbers" href="http://example.org/?paged=1">&laquo; Previous</a>', $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')prev page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=1(\"|\')>&laquo; Previous<\/a>/', $output ) );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')next page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=3(\"|\')>Next &raquo;<\/a>/', $output ) );
 	}
 
 	public function test_pagination_threepages_page3() {
@@ -78,18 +78,18 @@ class Test_Template extends EDD_UnitTestCase {
 
 		edd_pagination( $args );
 		$output = ob_get_clean();
-		// Verify it has the current page as 2
-		$this->assertContains( " class='page-numbers current'>3</span>", $output );
+		// Verify it has the current page as 3
+		$this->assertSame( 1, preg_match( '/class=(\"|\')page-numbers current(\"|\')>3<\/span>/', $output ) );
 
-		// Verify that it contains pages 1 and 3
-		$this->assertContains( "<a class='page-numbers' href='http://example.org/?paged=1'>1</a>", $output );
-		$this->assertContains( "<a class='page-numbers' href='http://example.org/?paged=2'>2</a>", $output );
+		// Verify that it contains pages 1 and 2
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=1(\"|\')>1<\/a>/', $output ) );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=2(\"|\')>2<\/a>/', $output ) );
 
 		// Verify that the 'previous' button appears for the correct page.
-		$this->assertContains( '<a class="prev page-numbers" href="http://example.org/?paged=2">&laquo; Previous</a>', $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')prev page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=2(\"|\')>&laquo; Previous<\/a>/', $output ) );
 
 		// Verify that the 'next' button does not appear.
-		$this->assertNotContains( 'class="next ', $output );
+		$this->assertEmpty( preg_match( '/class=(\"|\')next /', $output ) );
 	}
 
 	public function test_pagination_has_elipses() {
@@ -102,23 +102,24 @@ class Test_Template extends EDD_UnitTestCase {
 
 		edd_pagination( $args );
 		$output = ob_get_clean();
-		// Verify it has the current page as 2
-		$this->assertContains( "class='page-numbers current'>5</span>", $output );
+		// Verify it has the current page as 5
+		$this->assertSame( 1, preg_match( '/class=(\"|\')page-numbers current(\"|\')>5<\/span>/', $output ) );
 
 		// Verify that it contains page 1
-		$this->assertContains( "<a class='page-numbers' href='http://example.org/?paged=1'>1</a>", $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=1(\"|\')>1<\/a>/', $output ) );
 
 		// Verify that it does not contain page 2 (replaced by elipses)
-		$this->assertNotContains( "<a class='page-numbers' href='http://example.org/?paged=2'>2</a>", $output );
+		$this->assertEmpty( preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=2(\"|\')>2<\/a>/', $output ) );
 
 		// Verify that two elipses items are present.
-		$this->assertSame( 2, substr_count( $output, '<span class="page-numbers dots">&hellip;</span>' ) );
+		preg_match_all( '/<span class=(\'|\")page-numbers dots(\'|\")>&hellip;<\/span>/', $output, $matches );
+		$this->assertSame( 2, count( $matches[0] ) );
 
 		// Verify the last item shows.
-		$this->assertContains( "<a class='page-numbers' href='http://example.org/?paged=100'>100</a>", $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=100(\"|\')>100<\/a>/', $output ) );
 
 		// Verify that the 'previous' button appears.
-		$this->assertContains( '<a class="prev page-numbers" href="http://example.org/?paged=4">&laquo; Previous</a>', $output );
-		$this->assertContains( '<a class="next page-numbers" href="http://example.org/?paged=6">Next &raquo;</a>', $output );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')next page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=6(\"|\')>Next &raquo;<\/a>/', $output ) );
+		$this->assertSame( 1, preg_match( '/<a class=(\"|\')prev page-numbers(\"|\') href=(\"|\')http\:\/\/example\.org\/\?paged=4(\"|\')>&laquo; Previous<\/a>/', $output ) );
 	}
 }


### PR DESCRIPTION
Release 2.9.21 - Maintenance

| Issue | PR | Description                                                                    |
|-------| ---|--------------------------------------------------------------------------------|
| #7546   | #7547 | Prevent file download count check when product/payment has unlimited downloads |
| #7514   | #7515 | Include minimum PHP version required in readme.txt                             |
| #7507   | #7508 | Download Product Earnings report incorrect when item-specific fees are present |
| #7483   | #7484 | Typo in admin promotional area                                                 |
| #7467   | #7468 | Adding Jilt section to Emails page                                             |
| #7281   | #7508 | Wrong earning stats when used with Discounts Pro                               |