### PR TITLE
Convert DB table version numbers to 9 digits. #7579

### DIFF
--- a/includes/database/engine/class-table.php
+++ b/includes/database/engine/class-table.php
@@ -728,6 +728,25 @@ abstract class Table extends Base {
 		$this->db_version = $this->is_global()
 			? get_network_option( get_main_network_id(), $this->db_version_key, false )
 			:         get_option(                        $this->db_version_key, false );
+
+		/**
+		 * If the DB version is higher than the stated version and is 12 digits long, we need to update it to our
+		 * new, shorter format of 9 digits.
+		 *
+		 * This is only for 3.0 beta testers, and can be removed in 3.0.1 or above.
+		 *
+		 * @link https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7579
+		 */
+		if ( version_compare( $this->db_version, $this->version, '<=' ) || 12 !== strlen( $this->db_version ) ) {
+			return;
+		}
+
+		// Parse the new version number from the existing. Converting from {YYYY}{mm}{dd}{xxxx} to {YYYY}{mm}{dd}{x}
+		$date             = substr( $this->db_version, 0, 8 );
+		$increment        = substr( $this->db_version, 8, 4 );
+		$this->db_version = intval( $date . intval( $increment ) ); // Trims off the three prefixed zeros.
+
+		$this->set_db_version( $this->db_version );
 	}
 
 	/**
@@ -737,8 +756,8 @@ abstract class Table extends Base {
 	 */
 	private function delete_db_version() {
 		$this->db_version = $this->is_global()
-			? delete_network_option( get_main_network_id(), $this->db_version_key, false )
-			:         delete_option(                        $this->db_version_key, false );
+			? delete_network_option( get_main_network_id(), $this->db_version_key )
+			:         delete_option(                        $this->db_version_key );
 	}
 
 	/**

--- a/includes/database/tables/class-adjustment-meta.php
+++ b/includes/database/tables/class-adjustment-meta.php
@@ -38,7 +38,7 @@ final class Adjustment_Meta extends Table {
      * @since 3.0
      * @var int
      */
-    protected $version = 201806140002;
+    protected $version = 201806142;
 
     /**
      * Array of upgrade versions and methods.
@@ -48,7 +48,7 @@ final class Adjustment_Meta extends Table {
      * @var array
      */
     protected $upgrades = array(
-        '201806140002' => 201806140002
+        '201806142' => 201806142
     );
 
 	/**
@@ -69,7 +69,7 @@ final class Adjustment_Meta extends Table {
 	}
 
     /**
-     * Upgrade to version 201806140002
+     * Upgrade to version 201806142
      * - Migrate data from `edd_discounts` to `edd_adjustments`.
      *
 	 * This is only for 3.0 beta testers, and can be removed in 3.0.1 or above.
@@ -78,7 +78,7 @@ final class Adjustment_Meta extends Table {
      *
      * @return boolean True if upgrade was successful, false otherwise.
      */
-    protected function __201806140002() {
+    protected function __201806142() {
 
         // Old discounts table
         $table_name = $this->get_db()->get_blog_prefix( null ) . 'edd_discountmeta';

--- a/includes/database/tables/class-adjustments.php
+++ b/includes/database/tables/class-adjustments.php
@@ -38,7 +38,7 @@ final class Adjustments extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201906030001;
+	protected $version = 201906031;
 
 	/**
 	 * Array of upgrade versions and methods.
@@ -48,9 +48,9 @@ final class Adjustments extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201806140002' => 201806140002,
-		'201807270003' => 201807270003,
-		'201906030001' => 201906030001,
+		'201806142' => 201806142,
+		'201807273' => 201807273,
+		'201906031' => 201906031,
 	);
 
 	/**
@@ -113,7 +113,7 @@ final class Adjustments extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201806140002
+	 * Upgrade to version 201806142
 	 * - Migrate data from `edd_discounts` to `edd_adjustments`.
 	 *
 	 * This is only for 3.0 beta testers, and can be removed in 3.0.1 or above.
@@ -123,7 +123,7 @@ final class Adjustments extends Table {
 	 *
 	 * @return boolean True if upgrade was successful, false otherwise.
 	 */
-	protected function __201806140002() {
+	protected function __201806142() {
 
 		// Old discounts table
 		$table_name = $this->get_db()->get_blog_prefix( null ) . 'edd_discounts';
@@ -180,7 +180,7 @@ final class Adjustments extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807110001
+	 * Upgrade to version 201807111
 	 * - Rename `min_cart_price` to `min_charge_amount`.
 	 *
 	 * This is only for 3.0 beta testers, and can be removed in 3.0.1 or above.
@@ -190,7 +190,7 @@ final class Adjustments extends Table {
 	 *
 	 * @return boolean True if upgrade was successful, false otherwise.
 	 */
-	protected function __201807110001() {
+	protected function __201807111() {
 		$retval = $this->get_db()->query( "
 			ALTER TABLE {$this->table_name} CHANGE `min_cart_price` `min_charge_amount` decimal(18,9) NOT NULL default '0';
 		" );
@@ -200,14 +200,14 @@ final class Adjustments extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column.
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean True if upgrade was successful, false otherwise.
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );
@@ -224,14 +224,14 @@ final class Adjustments extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201906030001
+	 * Upgrade to version 201906031
 	 * - Drop the `product_condition` column.
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean True if upgrade was successful, false otherwise.
 	 */
-	protected function __201906030001() {
+	protected function __201906031() {
 
 		// Look for column
 		$result = $this->column_exists( 'product_condition' );

--- a/includes/database/tables/class-customer-addresses.php
+++ b/includes/database/tables/class-customer-addresses.php
@@ -38,7 +38,7 @@ final class Customer_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201906250001;
+	protected $version = 201906251;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,8 +48,8 @@ final class Customer_Addresses extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807270003' => 201807270003,
-		'201906250001' => 201906250001,
+		'201807273' => 201807273,
+		'201906251' => 201906251,
 	);
 
 	/**
@@ -82,14 +82,14 @@ final class Customer_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );
@@ -106,14 +106,14 @@ final class Customer_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201906250001
+	 * Upgrade to version 201906251
 	 * - Add the `name` mediumtext column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201906250001() {
+	protected function __201906251() {
 
 		$result = $this->column_exists( 'name' );
 

--- a/includes/database/tables/class-customer-email-addresses.php
+++ b/includes/database/tables/class-customer-email-addresses.php
@@ -38,7 +38,7 @@ final class Customer_Email_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201808170001;
+	protected $version = 201808171;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,8 +48,8 @@ final class Customer_Email_Addresses extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201808140001' => 201808140001,
-		'201808170001' => 201808170001,
+		'201808141' => 201808141,
+		'201808171' => 201808171,
 	);
 
 	/**
@@ -77,14 +77,14 @@ final class Customer_Email_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201808140001
+	 * Upgrade to version 201808141
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201808140001() {
+	protected function __201808141() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );
@@ -101,14 +101,14 @@ final class Customer_Email_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201808170001
+	 * Upgrade to version 201808171
 	 * - Add the `email` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201808170001() {
+	protected function __201808171() {
 
 		$result = $this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY COLUMN `email` varchar(100) NOT NULL default ''" );
 		$result = $this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX email (email)" );

--- a/includes/database/tables/class-customer-meta.php
+++ b/includes/database/tables/class-customer-meta.php
@@ -38,7 +38,7 @@ final class Customer_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807110001;
+	protected $version = 201807111;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,7 +48,7 @@ final class Customer_Meta extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807110001' => 201807110001
+		'201807111' => 201807111
 	);
 
 	/**
@@ -96,7 +96,7 @@ final class Customer_Meta extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807110001
+	 * Upgrade to version 201807111
 	 * - Rename  `customer_id` column to `edd_customer_id`
 	 * - Add `status` column.
 	 *
@@ -104,7 +104,7 @@ final class Customer_Meta extends Table {
 	 *
 	 * @return bool
 	 */
-	protected function __201807110001() {
+	protected function __201807111() {
 
 		// Alter the database with separate queries so indexes succeed
 		if ( $this->column_exists( 'customer_id' ) && ! $this->column_exists( 'edd_customer_id' ) ) {

--- a/includes/database/tables/class-customers.php
+++ b/includes/database/tables/class-customers.php
@@ -38,7 +38,7 @@ final class Customers extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201810090001;
+	protected $version = 201810091;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,11 +48,11 @@ final class Customers extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807110001' => 201807110001,
-		'201807130001' => 201807130001,
-		'201807130002' => 201807130002,
-		'201807270003' => 201807270003,
-		'201810090001' => 201810090001,
+		'201807111' => 201807111,
+		'201807131' => 201807131,
+		'201807132' => 201807132,
+		'201807273' => 201807273,
+		'201810091' => 201810091,
 	);
 
 	/**
@@ -123,7 +123,7 @@ final class Customers extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201806070001
+	 * Upgrade to version 201806071
 	 * - Change `purchase_value` from mediumtext to decimal(18,9).
 	 * - Add the `status` column.
 	 *
@@ -131,7 +131,7 @@ final class Customers extends Table {
 	 *
 	 * @return bool
 	 */
-	protected function __201807110001() {
+	protected function __201807111() {
 
 		// Alter the database
 		$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `purchase_value` decimal(18,9) NOT NULL default '0'" );
@@ -146,14 +146,14 @@ final class Customers extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807130001
+	 * Upgrade to version 201807131
 	 * - Add `date_modified` column.
 	 *
 	 * @since 3.0
 	 *
 	 * @return bool
 	 */
-	protected function __201807130001() {
+	protected function __201807131() {
 
 		if ( ! $this->column_exists( 'date_modified' ) ) {
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN date_modified datetime NOT NULL default '0000-00-00 00:00:00' AFTER `date_created`" );
@@ -164,14 +164,14 @@ final class Customers extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807130002
+	 * Upgrade to version 201807132
 	 * - Set values of `date_modified` to `date_created` (no empties)
 	 *
 	 * @since 3.0
 	 *
 	 * @return bool
 	 */
-	protected function __201807130002() {
+	protected function __201807132() {
 
 		// Update modified row values
 		$this->get_db()->query( "UPDATE {$this->table_name} SET `date_modified` = `date_created`" );
@@ -181,14 +181,14 @@ final class Customers extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );
@@ -205,14 +205,14 @@ final class Customers extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201810090001
+	 * Upgrade to version 201810091
 	 * - Modify the `name` column from mediumtext to varchar(255)
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201810090001() {
+	protected function __201810091() {
 
 		$result = $this->get_db()->query( "
 			ALTER TABLE {$this->table_name} MODIFY `name` varchar(255) NOT NULL default '';

--- a/includes/database/tables/class-log-meta.php
+++ b/includes/database/tables/class-log-meta.php
@@ -38,7 +38,7 @@ final class Log_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201805220001;
+	protected $version = 201805221;
 
 	/**
 	 * Setup the database schema

--- a/includes/database/tables/class-logs-api-request-meta.php
+++ b/includes/database/tables/class-logs-api-request-meta.php
@@ -38,7 +38,7 @@ final class Logs_Api_Request_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201907290001;
+	protected $version = 201907291;
 
 	/**
 	 * Setup the database schema

--- a/includes/database/tables/class-logs-api-requests.php
+++ b/includes/database/tables/class-logs-api-requests.php
@@ -38,7 +38,7 @@ final class Logs_Api_Requests extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201807273;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,8 +48,8 @@ final class Logs_Api_Requests extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807270002' => 201807270002,
-		'201807270003' => 201807270003,
+		'201807272' => 201807272,
+		'201807273' => 201807273,
 	);
 
 	/**
@@ -78,14 +78,14 @@ final class Logs_Api_Requests extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `date_modified` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270002() {
+	protected function __201807272() {
 
 		// Look for column
 		$result = $this->column_exists( 'date_modified' );
@@ -102,14 +102,14 @@ final class Logs_Api_Requests extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270002
+	 * Upgrade to version 201807272
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );

--- a/includes/database/tables/class-logs-file-download-meta.php
+++ b/includes/database/tables/class-logs-file-download-meta.php
@@ -38,7 +38,7 @@ final class Logs_File_Download_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201907290001;
+	protected $version = 201907291;
 
 	/**
 	 * Setup the database schema

--- a/includes/database/tables/class-logs-file-downloads.php
+++ b/includes/database/tables/class-logs-file-downloads.php
@@ -38,7 +38,7 @@ final class Logs_File_Downloads extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201806280001;
+	protected $version = 201806281;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,8 +48,8 @@ final class Logs_File_Downloads extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201806280001' => 201806280001,
-		'201807270003' => 201807270003
+		'201806281' => 201806281,
+		'201807273' => 201807273
 	);
 
 	/**
@@ -78,14 +78,14 @@ final class Logs_File_Downloads extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201806280001
+	 * Upgrade to version 201806281
 	 * - Rename  `download_id` column to `product_id`
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201806280001() {
+	protected function __201806281() {
 
 		// Alter the database with separate queries so indexes succeed
 		$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE COLUMN download_id product_id bigint(20) unsigned NOT NULL default 0" );
@@ -99,14 +99,14 @@ final class Logs_File_Downloads extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );

--- a/includes/database/tables/class-logs.php
+++ b/includes/database/tables/class-logs.php
@@ -38,7 +38,7 @@ final class Logs extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201807273;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,9 +48,9 @@ final class Logs extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807240001' => 201807240001,
-		'201807270002' => 201807270002,
-		'201807270003' => 201807270003,
+		'201807241' => 201807241,
+		'201807272' => 201807272,
+		'201807273' => 201807273,
 	);
 
 	/**
@@ -79,14 +79,14 @@ final class Logs extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807230001
+	 * Upgrade to version 201807231
 	 * - Add `user_id` column.
 	 *
 	 * @since 3.0
 	 *
 	 * @return bool
 	 */
-	protected function __201807240001() {
+	protected function __201807241() {
 
 		// Alter the database
 		if ( ! $this->column_exists( 'user_id' ) ) {
@@ -99,14 +99,14 @@ final class Logs extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270002
+	 * Upgrade to version 201807272
 	 * - Add the `date_modified` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270002() {
+	protected function __201807272() {
 
 		// Look for column
 		$result = $this->column_exists( 'date_modified' );
@@ -123,14 +123,14 @@ final class Logs extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );

--- a/includes/database/tables/class-note-meta.php
+++ b/includes/database/tables/class-note-meta.php
@@ -38,7 +38,7 @@ final class Note_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201805220001;
+	protected $version = 201805221;
 
 	/**
 	 * Setup the database schema

--- a/includes/database/tables/class-notes.php
+++ b/includes/database/tables/class-notes.php
@@ -38,7 +38,7 @@ final class Notes extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201807273;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,8 +48,8 @@ final class Notes extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807270002' => 201807270002,
-		'201807270003' => 201807270003,
+		'201807272' => 201807272,
+		'201807273' => 201807273,
 	);
 
 	/**
@@ -75,14 +75,14 @@ final class Notes extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270002
+	 * Upgrade to version 201807272
 	 * - Add the `date_modified` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270002() {
+	protected function __201807272() {
 
 		// Look for column
 		$result = $this->column_exists( 'date_modified' );
@@ -99,14 +99,14 @@ final class Notes extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );

--- a/includes/database/tables/class-order-addresses.php
+++ b/includes/database/tables/class-order-addresses.php
@@ -38,7 +38,7 @@ final class Order_Addresses extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201906280001;
+	protected $version = 201906281;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,9 +48,9 @@ final class Order_Addresses extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807270003' => 201807270003,
-		'201906250001' => 201906250001,
-		'201906280001' => 201906280001,
+		'201807273' => 201807273,
+		'201906251' => 201906251,
+		'201906281' => 201906281,
 	);
 
 	/**
@@ -85,14 +85,14 @@ final class Order_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );
@@ -109,7 +109,7 @@ final class Order_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201906250001
+	 * Upgrade to version 201906251
 	 * - Adds the 'name' column
 	 * - Combines the `first_name` and `last_name` columns to the `name` column.
 	 * - Removes the `first_name` and `last_name` columns.
@@ -118,7 +118,7 @@ final class Order_Addresses extends Table {
 	 *
 	 * @return boolean
 	 */
-	protected function __201906250001() {
+	protected function __201906251() {
 
 		$success = true;
 
@@ -149,14 +149,14 @@ final class Order_Addresses extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201906280001
+	 * Upgrade to version 201906281
 	 * - Add the `type` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201906280001() {
+	protected function __201906281() {
 
 		// Look for column.
 		$result = $this->column_exists( 'type' );

--- a/includes/database/tables/class-order-adjustment-meta.php
+++ b/includes/database/tables/class-order-adjustment-meta.php
@@ -38,7 +38,7 @@ final class Order_Adjustment_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201805220001;
+	protected $version = 201805221;
 
 	/**
 	 * Setup the database schema

--- a/includes/database/tables/class-order-adjustments.php
+++ b/includes/database/tables/class-order-adjustments.php
@@ -38,7 +38,7 @@ final class Order_Adjustments extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201807273;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,8 +48,8 @@ final class Order_Adjustments extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807070001' => 201807070001,
-		'201807270003' => 201807270003
+		'201807071' => 201807071,
+		'201807273' => 201807273
 	);
 
 	/**
@@ -78,7 +78,7 @@ final class Order_Adjustments extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807070001
+	 * Upgrade to version 201807071
 	 * - Add subtotal and tax columns.
 	 * - Rename amount column to total.
 	 *
@@ -86,7 +86,7 @@ final class Order_Adjustments extends Table {
 	 *
 	 * @return bool
 	 */
-	protected function __201807070001() {
+	protected function __201807071() {
 
 		// Alter the database.
 		$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE `amount` `total` decimal(18,9) NOT NULL default '0'" );
@@ -98,14 +98,14 @@ final class Order_Adjustments extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );

--- a/includes/database/tables/class-order-item-meta.php
+++ b/includes/database/tables/class-order-item-meta.php
@@ -38,7 +38,7 @@ final class Order_Item_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201805220001;
+	protected $version = 201805221;
 
 	/**
 	 * Setup the database schema

--- a/includes/database/tables/class-order-items.php
+++ b/includes/database/tables/class-order-items.php
@@ -38,7 +38,7 @@ final class Order_Items extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201906240001;
+	protected $version = 201906241;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,9 +48,9 @@ final class Order_Items extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807270002' => 201807270002,
-		'201807270003' => 201807270003,
-		'201906240001' => 201906240001,
+		'201807272' => 201807272,
+		'201807273' => 201807273,
+		'201906241' => 201906241,
 	);
 
 	/**
@@ -84,14 +84,14 @@ final class Order_Items extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270002
+	 * Upgrade to version 201807272
 	 * - Add the `date_modified` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270002() {
+	protected function __201807272() {
 
 		// Look for column
 		$result = $this->column_exists( 'date_created' );
@@ -118,14 +118,14 @@ final class Order_Items extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );
@@ -142,7 +142,7 @@ final class Order_Items extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201906240001
+	 * Upgrade to version 201906241
 	 * - Make the quantity column signed so it can contain negative numbers.
 	 * - Switch the quantity column from bigint to int for storage optimization.
 	 *
@@ -150,7 +150,7 @@ final class Order_Items extends Table {
 	 *
 	 * @return bool
 	 */
-	protected function __201906240001() {
+	protected function __201906241() {
 		$result = $this->get_db()->query( "
 			ALTER TABLE {$this->table_name} MODIFY `quantity` int signed NOT NULL default '0';
 		" );

--- a/includes/database/tables/class-order-meta.php
+++ b/includes/database/tables/class-order-meta.php
@@ -38,7 +38,7 @@ final class Order_Meta extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201805220001;
+	protected $version = 201805221;
 
 	/**
 	 * Setup the database schema

--- a/includes/database/tables/class-order-transactions.php
+++ b/includes/database/tables/class-order-transactions.php
@@ -38,7 +38,7 @@ final class Order_Transactions extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 201807270003;
+	protected $version = 201807273;
 
 	/**
 	 * Array of upgrade versions and methods
@@ -48,7 +48,7 @@ final class Order_Transactions extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807270003' => 201807270003,
+		'201807273' => 201807273,
 	);
 
 	/**
@@ -77,14 +77,14 @@ final class Order_Transactions extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270003
+	 * Upgrade to version 201807273
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );

--- a/includes/database/tables/class-orders.php
+++ b/includes/database/tables/class-orders.php
@@ -38,7 +38,7 @@ final class Orders extends Table {
 	 * @since  3.0
 	 * @var    int
 	 */
-	protected $version = 201901110001;
+	protected $version = 201901111;
 
 	/**
 	 * Array of upgrade versions and methods.
@@ -48,11 +48,11 @@ final class Orders extends Table {
 	 * @var    array
 	 */
 	protected $upgrades = array(
-		'201806110001' => 201806110001,
-		'201807270003' => 201807270003,
-		'201808140001' => 201808140001,
-		'201808150001' => 201808150001,
-		'201901110001' => 201901110001,
+		'201806111' => 201806111,
+		'201807273' => 201807273,
+		'201808141' => 201808141,
+		'201808151' => 201808151,
+		'201901111' => 201901111,
 	);
 
 	/**
@@ -123,14 +123,14 @@ final class Orders extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201806110001
+	 * Upgrade to version 201806111
 	 * - Add the `date_refundable` datetime column.
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201806110001() {
+	protected function __201806111() {
 
 		// Look for column
 		$result = $this->get_db()->query( "SHOW COLUMNS FROM {$this->table_name} LIKE 'date_refundable'" );
@@ -147,14 +147,14 @@ final class Orders extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201807270001
+	 * Upgrade to version 201807271
 	 * - Add the `uuid` varchar column
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201807270003() {
+	protected function __201807273() {
 
 		// Look for column
 		$result = $this->column_exists( 'uuid' );
@@ -171,14 +171,14 @@ final class Orders extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201808140001
+	 * Upgrade to version 201808141
 	 * - Add the `type` column.
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201808140001() {
+	protected function __201808141() {
 
 		// Look for column
 		$result = $this->column_exists( 'type' );
@@ -195,14 +195,14 @@ final class Orders extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201808150001
+	 * Upgrade to version 201808151
 	 * - Change the default value of the `type` column to `sale`.
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201808150001() {
+	protected function __201808151() {
 
 		// Alter the database
 		$this->get_db()->query( "
@@ -218,14 +218,14 @@ final class Orders extends Table {
 	}
 
 	/**
-	 * Upgrade to version 201901110001
+	 * Upgrade to version 201901111
 	 * - Set any 'publish' status items to 'complete'.
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __201901110001() {
+	protected function __201901111() {
 		$this->get_db()->query( "
 			UPDATE {$this->table_name} set `status` = 'complete' WHERE `status` = 'publish';
 		" );


### PR DESCRIPTION
Fixes #7579

Proposed Changes:
1. Updates all database table version numbers to new 9 digit format: from `{YYYY}{mm}{dd}{xxxx}` to `{YYYY}{mm}{dd}{x}`.
2. Hooks into `EDD\Database\Table::get_db_version()` to detect if the stored version is 12 digits instead of the new 9. If so, converts to the new length (essentially just strips off the 3 prefixed zeros) and updates the version number in the database. This ensures all upgrades will still continue to be processed in order.
3. Removed unnecessary third parameter in `EDD\Database\Table::delete_db_version()` `delete_option()` calls. (Those functions only take 2 parameters but 3 were being passed.)