### PR TITLE
Only delete discount meta if it's explicitly being set to an empty value #7576

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -206,7 +206,7 @@ function edd_update_discount( $discount_id = 0, $data = array() ) {
 		}
 
 		unset( $data['product_reqs'] );
-	} else {
+	} elseif ( isset( $data['product_reqs'] ) ) {
 		edd_delete_adjustment_meta( $discount_id, 'product_requirement' );
 
 		// We don't have product conditions when there are no product requirements.
@@ -229,7 +229,7 @@ function edd_update_discount( $discount_id = 0, $data = array() ) {
 		}
 
 		unset( $data['excluded_products'] );
-	} else {
+	} elseif( isset( $data['excluded_products'] ) ) {
 		edd_delete_adjustment_meta( $discount_id, 'excluded_product' );
 	}
 


### PR DESCRIPTION
Fixes #7576

Proposed Changes:
1.Adjustment meta is now only deleted if it's explicitly passed through to `edd_update_discount()` as an empty value. Previously running this would delete `product_reqs` because the value was omitted: `edd_update_discount( 1, array( 'name' => 'New Name' ) );` . Now to remove `product_reqs` you'd have to explicitly pass through `product_reqs` like this: `edd_update_discount( 1, array( 'name' => 'New Name', 'product_reqs' => '' ) );`