### PR TITLE
Add namespace root for DateTime & DateInterval

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -413,9 +413,9 @@ class Data_Migrator {
 		$date_created_gmt = $data->post_date_gmt;
 		if ( '0000-00-00 00:00:00' === $date_created_gmt ) {
 
-			$date_created_gmt  = new DateTime( $data->post_date );
-			$modified_time     = new DateTime( $data->post_modified );
-			$modified_time_gmt = new DateTime( $data->post_modified_gmt );
+			$date_created_gmt  = new \DateTime( $data->post_date );
+			$modified_time     = new \DateTime( $data->post_modified );
+			$modified_time_gmt = new \DateTime( $data->post_modified_gmt );
 
 			$diff = $modified_time_gmt->diff( $modified_time );
 
@@ -433,9 +433,9 @@ class Data_Migrator {
 
 			// Account for -/+ GMT offsets.
 			if ( 1 === $diff->invert ) {
-				$date_created_gmt->add( new DateInterval( $time_diff ) );
+				$date_created_gmt->add( new \DateInterval( $time_diff ) );
 			} else {
-				$date_created_gmt->sub( new DateInterval( $time_diff ) );
+				$date_created_gmt->sub( new \DateInterval( $time_diff ) );
 			}
 
 			$date_created_gmt = $date_created_gmt->format('Y-m-d H:i:s');


### PR DESCRIPTION
This fixes fatal PHP errors when running the v3 Step 1 Order migration.

Fixes #7620

Proposed Changes:
1. Adds proper root namespace prefix to DateTime & DateInterval class usages.
