### PR TITLE
Issue/7637 Correct refund report queries

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -1079,6 +1079,7 @@ function edd_register_refunds_report( $reports ) {
 						return apply_filters( 'edd_reports_refunds_refund_rate', $stats->get_refund_rate( array(
 							'range'  => $filter['range'],
 							'output' => 'formatted',
+							'status' => array( 'complete', 'revoked', 'refunded', 'partially_refunded' )
 						) ) );
 					},
 					'display_args'  => array(

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -160,6 +160,13 @@ class Stats {
 		$this->query_vars['column']            = 'total';
 		$this->query_vars['date_query_column'] = 'date_created';
 
+		/*
+		 * By default we're checking sales only and excluding refunds. This gives us gross order earnings.
+		 * This may be overridden in $query parameters that get passed through.
+		 */
+		$this->query_vars['type']   = 'sale';
+		$this->query_vars['status'] = array( 'complete', 'revoked', 'refunded', 'partially_refunded' );
+
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );
 
@@ -251,6 +258,13 @@ class Stats {
 		$this->query_vars['table']             = $this->get_db()->edd_orders;
 		$this->query_vars['column']            = 'id';
 		$this->query_vars['date_query_column'] = 'date_created';
+
+		/*
+		 * By default we're checking sales only and excluding refunds. This gives us gross order counts.
+		 * This may be overridden in $query parameters that get passed through.
+		 */
+		$this->query_vars['type']   = 'sale';
+		$this->query_vars['status'] = array( 'complete', 'revoked', 'refunded', 'partially_refunded' );
 
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -418,7 +418,7 @@ class Stats {
 	public function get_order_refund_count( $query = array() ) {
 		$query['status'] = isset( $query['status'] )
 			? $query['status']
-			: array( 'complete', 'partially_refunded' );
+			: array( 'complete' );
 
 		if ( ! array( $query['status'] ) ) {
 			$query['status'] = array( $query['status'] );
@@ -466,7 +466,7 @@ class Stats {
 		// Base value for status.
 		$query['status'] = isset( $query['status'] )
 			? $query['status']
-			: array( 'refunded', 'partially_refunded' );
+			: array( 'refunded' );
 
 		// Ensure we only pick up records from refund objects and not the original sale.
 		$this->query_vars['where_sql'] .= " AND {$this->get_db()->edd_orders}.type = 'refund' ";
@@ -568,7 +568,7 @@ class Stats {
 	 * @return string Formatted amount from refunded orders.
 	 */
 	public function get_order_refund_amount( $query = array() ) {
-		$query['status'] = array( 'complete', 'partially_refunded' );
+		$query['status'] = array( 'complete' );
 		$query['type']   = array( 'refund' );
 
 		/*

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -726,14 +726,14 @@ class Stats {
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );
 
-		$status_sql = $this->get_db()->prepare( "AND status IN(%s, %s) AND type = '%s'", esc_sql( 'complete' ), esc_sql( 'partially_refunded' ), esc_sql( 'refund' ) );
+		$status_sql = $this->get_db()->prepare( "AND status = %s AND type = '%s'", esc_sql( 'complete' ), esc_sql( 'refund' ) );
 
 		$ignore_free = $this->get_db()->prepare( "AND {$this->query_vars['table']}.total > %d", 0 );
 
-		$sql = "SELECT SUM(ABS({$this->query_vars['table']}.total)) / o.total * 100 AS `refund_rate`
+		$sql = "SELECT COUNT(id ) / o.number_orders * 100 AS `refund_rate`
 				FROM {$this->query_vars['table']}
 				CROSS JOIN (
-					SELECT SUM(id) AS total
+					SELECT COUNT(id) AS number_orders
 					FROM {$this->query_vars['table']}
 					WHERE 1=1 {$this->query_vars['status_sql']} {$ignore_free} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}
 				) o

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -571,13 +571,20 @@ class Stats {
 		$query['status'] = array( 'complete', 'partially_refunded' );
 		$query['type']   = array( 'refund' );
 
-		// Request raw output so we can run `abs()` on the value.
+		/*
+		 * Request raw output so we can run `abs()` on the value.
+		 * But save the original value so we can restore it later.
+		 */
+		$original_output = isset( $query['output'] ) ? $query['output'] : 'raw';
 		$query['output'] = 'raw';
 
 		$retval = $this->get_order_earnings( $query );
 
+		// Restore original format.
+		$this->query_vars['output'] = $original_output;
+
 		// Format & return.
-		return edd_currency_filter( edd_format_amount( abs( $retval ) ) );
+		return $this->maybe_format( abs( $retval ) );
 	}
 
 	/**

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -178,13 +178,13 @@ class Stats {
 					CROSS JOIN (
 						SELECT IFNULL({$function}, 0) AS relative
 						FROM {$this->query_vars['table']}
-						WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$relative_date_query_sql}
+						WHERE 1=1 {$this->query_vars['type_sql']} {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$relative_date_query_sql}
 					) o
-					WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
+					WHERE 1=1 {$this->query_vars['type_sql']} {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		} else {
 			$sql = "SELECT {$function} AS total
 					FROM {$this->query_vars['table']}
-					WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['date_query_sql']}";
+					WHERE 1=1 {$this->query_vars['type_sql']} {$this->query_vars['status_sql']} {$this->query_vars['date_query_sql']}";
 		}
 
 		$result = $this->get_db()->get_row( $sql );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -270,13 +270,13 @@ class Stats {
 					CROSS JOIN (
 						SELECT IFNULL(COUNT(id), 0) AS relative
 						FROM {$this->query_vars['table']}
-						WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$relative_date_query_sql}
+						WHERE 1=1 {$this->query_vars['type_sql']} {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$relative_date_query_sql}
 					) o
-					WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
+					WHERE 1=1 {$this->query_vars['type_sql']} {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		} else {
 			$sql = "SELECT {$function} AS total
 					FROM {$this->query_vars['table']}
-					WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
+					WHERE 1=1 {$this->query_vars['type_sql']} {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		}
 
 		$result = $this->get_db()->get_row( $sql );

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -1,6 +1,8 @@
 <?php
 namespace EDD;
 
+use EDD\Orders\Order;
+
 /**
  * Stats Tests.
  *
@@ -21,9 +23,16 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	/**
 	 * Orders test fixture.
 	 *
-	 * @var array
+	 * @var Order[]
 	 */
 	protected static $orders;
+
+	/**
+	 * Refunds test fixture.
+	 *
+	 * @var array
+	 */
+	protected static $refunds;
 
 	/**
 	 * Set up fixtures once.
@@ -31,6 +40,11 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	public static function wpSetUpBeforeClass() {
 		self::$stats  = new Stats();
 		self::$orders = parent::edd()->order->create_many( 5 );
+
+		// Refund two of those orders.
+		for ( $i = 0; $i < 2; $i++ ) {
+			self::$refunds[] = edd_refund_order( self::$orders[ $i ] );
+		}
 	}
 
 	/**
@@ -115,5 +129,27 @@ class Stats_Tests extends \EDD_UnitTestCase {
 		) );
 
 		$this->assertSame( 5, $count );
+	}
+
+	/**
+	 * @covers ::get_order_refund_count
+	 */
+	public function test_get_order_refund_count_with_range_last_year_should_be_0() {
+		$count = self::$stats->get_order_refund_count( array(
+			'range' => 'last_year',
+		) );
+
+		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * @covers ::get_order_refund_count
+	 */
+	public function test_get_order_refund_count_with_range_this_year_should_be_2() {
+		$count = self::$stats->get_order_refund_count( array(
+			'range' => 'this_year',
+		) );
+
+		$this->assertSame( 2, $count );
 	}
 }

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -172,4 +172,26 @@ class Stats_Tests extends \EDD_UnitTestCase {
 
 		$this->assertSame( 2, $count );
 	}
+
+	/**
+	 * @covers ::get_order_refund_amount
+	 */
+	public function test_get_order_refund_amount_with_range_last_year_should_be_0() {
+		$earnings = self::$stats->get_order_refund_amount( array(
+			'range' => 'last_year',
+		) );
+
+		$this->assertSame( 0.00, $earnings );
+	}
+
+	/**
+	 * @covers ::get_order_refund_amount
+	 */
+	public function test_get_order_refund_amount_with_range_this_year_should_be_240() {
+		$earnings = self::$stats->get_order_refund_amount( array(
+			'range' => 'this_year',
+		) );
+
+		$this->assertSame( 240.00, $earnings );
+	}
 }

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -1,8 +1,6 @@
 <?php
 namespace EDD;
 
-use EDD\Orders\Order;
-
 /**
  * Stats Tests.
  *
@@ -23,7 +21,7 @@ class Stats_Tests extends \EDD_UnitTestCase {
 	/**
 	 * Orders test fixture.
 	 *
-	 * @var Order[]
+	 * @var int[]
 	 */
 	protected static $orders;
 

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -194,4 +194,30 @@ class Stats_Tests extends \EDD_UnitTestCase {
 
 		$this->assertSame( 240.00, $earnings );
 	}
+
+	/**
+	 * @covers ::get_refund_rate
+	 */
+	public function test_get_get_refund_rate_with_range_last_year_should_be_0() {
+		$refund_rate = self::$stats->get_refund_rate( array(
+			'range'  => 'last_year',
+			'output' => 'raw',
+			'status' => array( 'complete', 'revoked', 'refunded', 'partially_refunded' ),
+		) );
+
+		$this->assertSame( 0, $refund_rate );
+	}
+
+	/**
+	 * @covers ::get_refund_rate
+	 */
+	public function test_get_get_refund_rate_with_range_this_year_should_be_40() {
+		$refund_rate = self::$stats->get_refund_rate( array(
+			'range'  => 'this_year',
+			'output' => 'raw',
+			'status' => array( 'complete', 'revoked', 'refunded', 'partially_refunded' ),
+		) );
+
+		$this->assertSame( 40.0, $refund_rate );
+	}
 }

--- a/tests/orders/tests-stats.php
+++ b/tests/orders/tests-stats.php
@@ -152,4 +152,26 @@ class Stats_Tests extends \EDD_UnitTestCase {
 
 		$this->assertSame( 2, $count );
 	}
+
+	/**
+	 * @covers ::get_order_item_refund_count
+	 */
+	public function test_get_order_item_refund_count_with_range_last_year_should_be_0() {
+		$count = self::$stats->get_order_item_refund_count( array(
+			'range' => 'last_year',
+		) );
+
+		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * @covers ::get_order_item_refund_count
+	 */
+	public function test_get_order_item_refund_count_with_range_this_year_should_be_2() {
+		$count = self::$stats->get_order_item_refund_count( array(
+			'range' => 'this_year',
+		) );
+
+		$this->assertSame( 2, $count );
+	}
 }


### PR DESCRIPTION
Fixes #7637 

Proposed Changes:
1. Include type SQL in `get_order_count()`. This ensures `type = 'refund'` condition is picked up in refund count queries, and that refund records are not picked up in order queries.
2. Include type SQL `get_order_earnings()`. This ensures `type = 'refund'` condition is picked up refund amounts queries, and that refund records are not picked up in order queries.
3. `get_order_earnings()` now sets default query vars for `type = 'sale'` and `status = array( 'complete', 'revoked', 'refunded', 'partially_refunded' );`. These can be overridden. But these changes ensure that the `Sale / Earnings` report shows gross earnings, before factoring in refunds. See https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7637#issuecomment-597617049
4. `get_order_item_refund_count()` now joins with the orders table to ensure it only picks up the order item records from `refund` objects. See https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7637#issuecomment-597171748
5. Add more unit tests to cover `get_order_refund_count()`, `get_order_refund_amount()`, and `get_order_item_refund_count()` stat methods.
6. Adjust `get_order_refund_amount()` so that it saves and uses the originally requested `output`. Previously it was impossible to get a `raw` value out; it was only and always returning a formatted value. Now it can handle either. I needed/wanted `raw` for unit tests.
7. Rework refund rate query to count the number of records, as opposed to number of earnings. See: https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7637#issuecomment-597692996
8. Remove `partially_refunded` status from refund object queries. This is under the assumption that `partially_refund` status is meant to be associated with _orders_ and not _refunds_.