### PR TITLE
Fix division by zero error

### DIFF
--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -686,7 +686,8 @@ class EDD_Cart {
 								}
 							}
 
-							$subtotal_percent  = ( ( $price * $item['quantity'] ) / $items_subtotal );
+							$subtotal_quantity = ( $price * $item['quantity'] );
+							$subtotal_percent  = ! empty( $items_subtotal ) ? ( $subtotal_quantity / $items_subtotal ) : 0;
 							$code_amount       = edd_get_discount_amount( $code_id );
 							$discounted_amount = $code_amount * $subtotal_percent;
 							$discounted_price -= $discounted_amount;

--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -686,8 +686,8 @@ class EDD_Cart {
 								}
 							}
 
-							$subtotal_quantity = ( $price * $item['quantity'] );
-							$subtotal_percent  = ! empty( $items_subtotal ) ? ( $subtotal_quantity / $items_subtotal ) : 0;
+							$item_subtotal       = ( $price * $item['quantity'] );
+							$subtotal_percent  = ! empty( $items_subtotal ) ? ( $item_subtotal / $items_subtotal ) : 0;
 							$code_amount       = edd_get_discount_amount( $code_id );
 							$discounted_amount = $code_amount * $subtotal_percent;
 							$discounted_price -= $discounted_amount;

--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -686,7 +686,7 @@ class EDD_Cart {
 								}
 							}
 
-							$item_subtotal       = ( $price * $item['quantity'] );
+							$item_subtotal     = ( $price * $item['quantity'] );
 							$subtotal_percent  = ! empty( $items_subtotal ) ? ( $item_subtotal / $items_subtotal ) : 0;
 							$code_amount       = edd_get_discount_amount( $code_id );
 							$discounted_amount = $code_amount * $subtotal_percent;


### PR DESCRIPTION
Adds the additional suggested fix from #6901. In some cases, it was
still possible for the items subtotal to be 0, which caused a
mathematical error.

Fixes #7613