### PR TITLE
issue/7616 - Ensure Legacy Flot Tooltips Appear Above Content

### DIFF
--- a/includes/admin/reporting/class-edd-graph.php
+++ b/includes/admin/reporting/class-edd-graph.php
@@ -238,7 +238,8 @@ class EDD_Graph {
 						border: '1px solid #fdd',
 						padding: '2px',
 						'background-color': '#fee',
-						opacity: 0.80
+						opacity: 0.80,
+						zIndex: 3,
 					}).appendTo("body").fadeIn(200);
 				}
 


### PR DESCRIPTION
Fixes #7616 

Proposed Changes:
1. Ensure legacy Flot tooltips appear above content.

Brings tooltips above https://github.com/easydigitaldownloads/easy-digital-downloads/blob/9f305f2ddc1250fb0cab20d73df81cddfe31fa07/assets/css/edd-admin.css#L2704-L2708