### PR TITLE
issue/7615 - Fix Filters for Legacy Reports

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2141,6 +2141,11 @@ body.download_page_edd-reports {
 	width: 33.3%;
 }
 
+/** Hide legacy report empty navigations */
+.download_page_edd-reports .section-content .tablenav.top {
+	display: none;
+}
+
 #edd_tax_rates {
 	margin: 1em 0 0;
 }
@@ -2709,6 +2714,7 @@ body.download_page_edd-reports {
 .edd-sections-wrap .edd-vertical-sections:not(.meta-box) .section-wrap > div {
 	min-height: 500px;
 	height: 100%;
+	overflow: hidden;
 }
 .edd-sections-wrap .section-wrap .customer-section:not(:last-child) {
 	border-bottom: 1px solid #eee;
@@ -2719,12 +2725,11 @@ body.download_page_edd-reports {
 .edd-sections-wrap .section-wrap .section-content {
 	border-left: 1px solid #e5e5e5;
 }
-.edd-sections-wrap .section-wrap .section-content > div {
-	padding: 0px 20px 5px;
+
+.edd-sections-wrap .section-wrap .section-content > * {
+	margin: 20px;
 }
-.edd-sections-wrap .section-wrap .section-content > div:not(.tablenav):first-child {
-	padding: 20px;
-}
+
 .edd-sections-wrap .section-wrap .avatar-wrap {
 	float: left;
 	padding-right: 20px;

--- a/includes/admin/reporting/class-categories-reports-table.php
+++ b/includes/admin/reporting/class-categories-reports-table.php
@@ -94,7 +94,6 @@ class EDD_Categories_Reports_Table extends List_Table {
 				<?php
 				if ( 'top' === $which ) {
 					edd_report_views();
-					edd_reports_graph_controls();
 				}
 				?>
 			</div>

--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -623,16 +623,6 @@ function edd_reports_graph_of_download( $download_id = 0 ) {
 }
 
 /**
- * Show report graph date filters
- *
- * @since 1.3
- * @deprecated Deprecated since 3.0 as report graph controls are automatically output.
- */
-function edd_reports_graph_controls() {
-	_doing_it_wrong( __FUNCTION__, 'Report graph controls are automatically output.', 'EDD 3.0' );
-}
-
-/**
  * Grabs all of the selected date info and then redirects appropriately
  *
  * @since 1.3

--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -696,7 +696,28 @@ function edd_parse_report_dates( $form_data ) {
 	}
 
 	if ( ! empty( $form_data['edd_redirect'] ) ) {
-		edd_redirect( $form_data['edd_redirect'] );
+		$redirect = $form_data['edd_redirect'];
+
+		// Ensure data is available in the URL for legacy reports.
+		if ( ! empty( $form_data['range'] ) ) {
+			$redirect = add_query_arg(
+				array(
+					'range' => $form_data['range'],
+				),
+				$redirect
+			);
+		}
+
+		if ( ! empty( $form_data['exclude_taxes'] ) ) {
+			$redirect = add_query_arg(
+				array(
+					'exclude_taxes' => true,
+				),
+				$redirect
+			);
+		}
+
+		edd_redirect( $redirect );
 	}
 }
 add_action( 'edd_filter_reports', 'edd_parse_report_dates' );

--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -312,7 +312,6 @@ function edd_reports_graph() {
 
 				<div class="inside">
 					<?php
-					edd_reports_graph_controls();
 					$graph = new EDD_Graph( $data );
 					$graph->set( 'x_mode', 'time' );
 					$graph->set( 'multiple_y_axes', true );
@@ -607,7 +606,6 @@ function edd_reports_graph_of_download( $download_id = 0 ) {
 
 			<div class="inside">
 				<?php
-				edd_reports_graph_controls();
 				$graph = new EDD_Graph( $data );
 				$graph->set( 'x_mode', 'time' );
 				$graph->set( 'multiple_y_axes', true );
@@ -628,88 +626,10 @@ function edd_reports_graph_of_download( $download_id = 0 ) {
  * Show report graph date filters
  *
  * @since 1.3
- * @return void
-*/
+ * @deprecated Deprecated since 3.0 as report graph controls are automatically output.
+ */
 function edd_reports_graph_controls() {
-	$date_options = Reports\get_dates_filter_options();
-
-	$dates = edd_get_report_dates();
-	$view  = edd_get_reporting_view();
-	$taxes = ! empty( $_GET['exclude_taxes'] )
-		? false
-		: true;
-	$range = isset( $dates['range'] )
-		? sanitize_key( $dates['range'] )
-		: get_dates_filter_range();
-	$class = ( $range === 'other' )
-		? ''
-		: ' screen-reader-text';
-
-	$dates_values = \EDD\Reports\get_filter_value( 'dates' );
-
-	$from = empty( $dates_values['from'] ) ? '' : $dates_values['from'];
-	$to   = empty( $dates_values['to'] )   ? '' : $dates_values['to'];
-
-	if ( empty( $dates['day_end'] ) ) {
-		$dates['day_end'] = cal_days_in_month( CAL_GREGORIAN, date( 'n' ), date( 'Y' ) );
-	} ?>
-
-	<form id="edd-graphs-filter" method="get">
-		<div class="tablenav top">
-			<div class="alignleft actions">
-
-				<input type="hidden" name="post_type" value="download"/>
-				<input type="hidden" name="page" value="edd-reports"/>
-				<input type="hidden" name="view" value="<?php echo esc_attr( $view ); ?>"/>
-
-				<?php if( isset( $_GET['download-id'] ) ) : ?>
-					<input type="hidden" name="download-id" value="<?php echo absint( $_GET['download-id'] ); ?>"/>
-				<?php endif; ?>
-
-				<select class="edd-graphs-date-options" name="range">
-				<?php foreach ( $date_options as $key => $option ) : ?>
-					<option value="<?php echo esc_attr( $key ); ?>"<?php selected( $key, $dates['range'] ); ?>><?php echo esc_html( $option ); ?></option>
-				<?php endforeach; ?>
-				</select>
-
-				<div class="edd-date-range-options <?php echo esc_attr( $class ); ?>">
-					<fieldset>
-						<legend class="screen-reader-text"><?php esc_html_e( 'To and From dates for use with the Custom date option.', 'easy-digital-downloads' ); ?></legend>
-
-						<span id="edd-date-filters" class="edd-from-to-wrapper">
-							<?php
-
-							echo EDD()->html->date_field( array(
-								'id'          => 'filter_from',
-								'name'        => 'filter_from',
-								'placeholder' => _x( 'From', 'date filter', 'easy-digital-downloads' ),
-								'value'       => $from
-							) );
-
-							echo EDD()->html->date_field( array(
-								'id'          => 'filter_to',
-								'name'        => 'filter_to',
-								'placeholder' => _x( 'To', 'date filter', 'easy-digital-downloads' ),
-								'value'       => $to
-							) );
-
-						?></span>
-					</fieldset>
-				</div>
-
-				<div class="edd-graph-filter-options graph-option-section">
-					<input type="checkbox" id="exclude_taxes" <?php checked( false, $taxes, true ); ?> value="1" name="exclude_taxes" />
-					<label for="exclude_taxes"><?php _e( 'Exclude Taxes', 'easy-digital-downloads' ); ?></label>
-				</div>
-
-				<div class="edd-graph-filter-submit graph-option-section">
-					<input type="hidden" name="edd_action" value="filter_reports" />
-					<input type="submit" class="button-secondary" value="<?php _e( 'Filter', 'easy-digital-downloads' ); ?>"/>
-				</div>
-			</div>
-		</div>
-	</form>
-	<?php
+	_doing_it_wrong( __FUNCTION__, 'Report graph controls are automatically output.', 'EDD 3.0' );
 }
 
 /**

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -1000,6 +1000,16 @@ function edd_report_views() {
 }
 
 /**
+ * Show report graph date filters.
+ *
+ * @since 1.3
+ * @deprecated 3.0 Unused.
+ */
+function edd_reports_graph_controls() {
+	_edd_deprecated_function( __FUNCTION__, 'EDD 3.0' );
+}
+
+/**
  * Sets up the dates used to filter graph data
  *
  * Date sent via $_GET is read first and then modified (if needed) to match the

--- a/includes/reports/class-init.php
+++ b/includes/reports/class-init.php
@@ -217,7 +217,11 @@ final class Init {
 					'group'            => 'core',
 					'icon'             => 'chart-area',
 					'priority'         => $priority,
-					'display_callback' => $callback
+					'display_callback' => $callback,
+					'filters'          => array(
+						'dates',
+						'taxes',
+					),
 				) );
 			} catch ( \EDD_Exception $exception ) {
 				edd_debug_log_exception( $exception );


### PR DESCRIPTION
Fixes #7615 

Proposed Changes:
1. Deprecates `edd_reports_graph_controls()` in favor of attaching filters to registered legacy reports.
2. Ensures filter data is available in URLs for legacy reports that still access it directly.