### PR TITLE
issue/7644 - Enable "Exclude Taxes" in Reports

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -810,7 +810,7 @@ textarea[name="edd-note"] {
 
 #edd-filters .filter-items > span:not(.edd-date-range-options) {
 	display: inline-block;
-	margin: 10px 4px 10px 0;
+	margin: 10px 6px 10px 0;
 	max-width: 200px;
 }
 
@@ -1967,10 +1967,15 @@ body.download_page_edd-reports {
 }
 
 .download_page_edd-reports #edd-filters {
-	margin-bottom: -5px;
+	margin-bottom: -1px;
+	box-shadow: none;
+	z-index: 3;
+	justify-content: space-between;
+	display: flex;
 }
 .download_page_edd-reports #edd-filters .filter-items {
-	float: none;
+	display: flex;
+	align-items: center;
 }
 .download_page_edd-reports #edd-item-wrapper {
 	margin: 0;

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -806,11 +806,12 @@ textarea[name="edd-note"] {
 
 .download_page_edd-reports #edd-filters {
 	margin-top: 8px;
+	padding-bottom: 0;
 }
 
 #edd-filters .filter-items > span:not(.edd-date-range-options) {
 	display: inline-block;
-	margin: 10px 6px 10px 0;
+	margin: 10px 6px 0 0;
 	max-width: 200px;
 }
 
@@ -1972,11 +1973,24 @@ body.download_page_edd-reports {
 	z-index: 3;
 	justify-content: space-between;
 	display: flex;
+	flex-wrap: wrap;
 }
+
 .download_page_edd-reports #edd-filters .filter-items {
 	display: flex;
 	align-items: center;
+	flex-wrap: wrap;
+	flex: 1 1 75%;
+	padding-bottom: 10px;
 }
+
+@media screen and ( max-width: 782px ) {
+
+	.download_page_edd-reports #edd-filters .filter-items {
+		flex-basis: 100%:
+	}
+}
+
 .download_page_edd-reports #edd-item-wrapper {
 	margin: 0;
 }

--- a/includes/admin/reporting/graphing.php
+++ b/includes/admin/reporting/graphing.php
@@ -761,7 +761,9 @@ function edd_parse_report_dates( $form_data ) {
 				break;
 
 			case 'taxes':
-				$session_data = isset( $form_data['exclude_taxes'] );
+				$session_data = array(
+					'exclude_taxes' => isset( $form_data['exclude_taxes'] ),
+				);
 
 				break;
 

--- a/includes/admin/reporting/reports-callbacks.php
+++ b/includes/admin/reporting/reports-callbacks.php
@@ -120,8 +120,8 @@ function edd_overview_refunds_chart() {
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
 
 	$column = true === $taxes['exclude_taxes']
-			? 'subtotal'
-			: 'total';
+		? 'subtotal'
+		: 'total';
 
 	$sql_clauses = array(
 		'select'  => 'date_created AS date',

--- a/includes/admin/reporting/reports-callbacks.php
+++ b/includes/admin/reporting/reports-callbacks.php
@@ -24,19 +24,15 @@ function edd_overview_sales_earnings_chart() {
 	global $wpdb;
 
 	$dates        = Reports\get_dates_filter( 'objects' );
-	$taxes        = Reports\get_filter_value( 'taxes' );
 	$day_by_day   = Reports\get_dates_filter_day_by_day();
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
+	$column       = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
 
 	$sql_clauses = array(
 		'select'  => 'date_created AS date',
 		'groupby' => 'DATE(date_created)',
 		'orderby' => 'DATE(date_created)',
 	);
-
-	$column = isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes']
-		? 'subtotal'
-		: 'total';
 
 	$results = $wpdb->get_results(
 		$wpdb->prepare(
@@ -120,13 +116,9 @@ function edd_overview_refunds_chart() {
 	global $wpdb;
 
 	$dates        = Reports\get_dates_filter( 'objects' );
-	$taxes        = Reports\get_filter_value( 'taxes' );
 	$day_by_day   = Reports\get_dates_filter_day_by_day();
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
-
-	$column = isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes']
-		? 'subtotal'
-		: 'total';
+	$column       = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
 
 	$sql_clauses = array(
 		'select'  => 'date_created AS date',

--- a/includes/admin/reporting/reports-callbacks.php
+++ b/includes/admin/reporting/reports-callbacks.php
@@ -115,8 +115,13 @@ function edd_overview_refunds_chart() {
 	global $wpdb;
 
 	$dates        = Reports\get_dates_filter( 'objects' );
+	$taxes        = Reports\get_filter_value( 'taxes' );
 	$day_by_day   = Reports\get_dates_filter_day_by_day();
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
+
+	$column = true === $taxes['exclude_taxes']
+			? 'subtotal'
+			: 'total';
 
 	$sql_clauses = array(
 		'select'  => 'date_created AS date',
@@ -126,7 +131,7 @@ function edd_overview_refunds_chart() {
 
 	$results = $wpdb->get_results(
 		$wpdb->prepare(
-			"SELECT COUNT(id) AS number, SUM(total) AS amount, {$sql_clauses['select']}
+			"SELECT COUNT(id) AS number, SUM({$column}) AS amount, {$sql_clauses['select']}
  				 FROM {$wpdb->edd_orders} edd_o
  				 WHERE status IN (%s, %s) AND date_created >= %s AND date_created <= %s AND type = 'refund'
 				 GROUP BY {$sql_clauses['groupby']}

--- a/includes/admin/reporting/reports-callbacks.php
+++ b/includes/admin/reporting/reports-callbacks.php
@@ -34,7 +34,7 @@ function edd_overview_sales_earnings_chart() {
 		'orderby' => 'DATE(date_created)',
 	);
 
-	$column = true === $taxes['exclude_taxes']
+	$column = isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes']
 		? 'subtotal'
 		: 'total';
 
@@ -124,7 +124,7 @@ function edd_overview_refunds_chart() {
 	$day_by_day   = Reports\get_dates_filter_day_by_day();
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
 
-	$column = true === $taxes['exclude_taxes']
+	$column = isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes']
 		? 'subtotal'
 		: 'total';
 

--- a/includes/admin/reporting/reports-callbacks.php
+++ b/includes/admin/reporting/reports-callbacks.php
@@ -24,6 +24,7 @@ function edd_overview_sales_earnings_chart() {
 	global $wpdb;
 
 	$dates        = Reports\get_dates_filter( 'objects' );
+	$taxes        = Reports\get_filter_value( 'taxes' );
 	$day_by_day   = Reports\get_dates_filter_day_by_day();
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
 
@@ -33,9 +34,13 @@ function edd_overview_sales_earnings_chart() {
 		'orderby' => 'DATE(date_created)',
 	);
 
+	$column = true === $taxes['exclude_taxes']
+		? 'subtotal'
+		: 'total';
+
 	$results = $wpdb->get_results(
 		$wpdb->prepare(
-			"SELECT COUNT(id) AS sales, SUM(total) AS earnings, {$sql_clauses['select']}
+			"SELECT COUNT(id) AS sales, SUM({$column}) AS earnings, {$sql_clauses['select']}
  				 FROM {$wpdb->edd_orders} edd_o
  				 WHERE date_created >= %s AND date_created <= %s
 				 GROUP BY {$sql_clauses['groupby']}

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -183,8 +183,9 @@ function edd_register_overview_report( $reports ) {
 
 		// Variables to hold date filter values.
 		$options = Reports\get_dates_filter_options();
-		$filter  = Reports\get_filter_value( 'dates' );
-		$label   = $options[ $filter['range'] ];
+		$dates   = Reports\get_filter_value( 'dates' );
+		$taxes   = Reports\get_filter_value( 'taxes' );
+		$label   = $options[ $dates['range'] ];
 
 		$reports->add_report( 'overview', array(
 			'label'     => __( 'Overview', 'easy-digital-downloads' ),
@@ -215,10 +216,11 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Sales / Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats( array(
-							'range'  => $filter['range'],
-							'output' => 'formatted',
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'output'        => 'formatted',
 						) );
 
 						return $stats->get_order_count() . ' / ' . $stats->get_order_earnings();
@@ -235,9 +237,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Sales / Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () {
+					'data_callback' => function () use ( $taxes ) {
 						$stats = new EDD\Stats( array(
-							'output' => 'formatted',
+							'output'        => 'formatted',
+							'exclude_taxes' => $taxes['exclude_taxes'],
 						) );
 
 						return $stats->get_order_count() . ' / ' . $stats->get_order_earnings();
@@ -254,11 +257,12 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_earnings', $stats->get_order_earnings( array(
-							'range'    => $filter['range'],
-							'relative' => true,
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'relative'      => true,
 						) ) );
 					},
 					'display_args'  => array(
@@ -273,10 +277,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Sales', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_sales', $stats->get_order_count( array(
-							'range'    => $filter['range'],
+							'range'    => $dates['range'],
 							'relative' => true,
 						) ) );
 					},
@@ -292,10 +296,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Refunds', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_refunds', $stats->get_order_refund_count( array(
-							'range' => $filter['range'],
+							'range' => $dates['range'],
 							'relative' => true,
 						) ) );
 					},
@@ -311,11 +315,11 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Average Revenue per Customer', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_average_customer_revenue', $stats->get_customer_lifetime_value( array(
 							'function' => 'AVG',
-							'range'    => $filter['range'],
+							'range'    => $dates['range'],
 							'output'   => 'formatted',
 							'relative' => true,
 						) ) );
@@ -332,13 +336,14 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Average Order Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_average_order_value', $stats->get_order_earnings( array(
-							'function' => 'AVG',
-							'output'   => 'formatted',
-							'relative' => true,
-							'range'    => $filter['range'],
+							'function'      => 'AVG',
+							'output'        => 'formatted',
+							'relative'      => true,
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
 						) ) );
 					},
 					'display_args'  => array(
@@ -353,10 +358,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Customer Growth', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_new_customers', $stats->get_customer_count( array(
-							'range'    => $filter['range'],
+							'range'    => $dates['range'],
 							'relative' => true,
 						) ) );
 					},
@@ -372,10 +377,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'File Downloads', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_new_customers', $stats->get_file_download_count( array(
-							'range'    => $filter['range'],
+							'range'    => $dates['range'],
 							'relative' => true,
 						) ) );
 					},
@@ -391,10 +396,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Taxes', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_taxes', $stats->get_tax( array(
-							'range'    => $filter['range'],
+							'range'    => $dates['range'],
 							'relative' => true,
 						) ) );
 					},
@@ -410,10 +415,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Busiest Day', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_busiest_day', $stats->get_busiest_day( array(
-							'range' => $filter['range'],
+							'range' => $dates['range'],
 						) ) );
 					},
 					'display_args'  => array(
@@ -478,8 +483,9 @@ function edd_register_downloads_report( $reports ) {
 
 		// Variables to hold date filter values.
 		$options = Reports\get_dates_filter_options();
-		$filter  = Reports\get_filter_value( 'dates' );
-		$label   = $options[ $filter['range'] ];
+		$dates   = Reports\get_filter_value( 'dates' );
+		$taxes   = Reports\get_filter_value( 'taxes' );
+		$label   = $options[ $dates['range'] ];
 
 		$download_data = Reports\get_filter_value( 'products' );
 		$download_data = ! empty( $download_data ) && 'all' !== Reports\get_filter_value( 'products' )
@@ -516,24 +522,24 @@ function edd_register_downloads_report( $reports ) {
 				'charts' => array(
 					'download_sales_by_variations',
 					'download_earnings_by_variations',
-                    'download_sales_earnings_chart'
+					'download_sales_earnings_chart'
 				),
 				'tables' => array(
 					'top_selling_downloads',
 					'earnings_by_taxonomy',
 				),
 			),
-            'filters'   => array( 'products', 'countries', 'regions' )
+			'filters'  => array( 'products', 'countries', 'regions', 'taxes' )
 		) );
 
 		$reports->register_endpoint( 'most_valuable_download', array(
 			'label' => sprintf( __( 'Most Valuable %s', 'easy-digital-downloads' ), edd_get_label_singular() ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						$d = $stats->get_most_valuable_order_items( array(
-							'range' => $filter['range'],
+							'range' => $dates['range'],
 						) );
 
 						if ( ! empty( $d ) && isset( $d[0] ) ) {
@@ -566,11 +572,12 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Average Sales / Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats( array(
-							'function' => 'AVG',
-							'range'    => $filter['range'],
-							'output'   => 'formatted',
+							'function'      => 'AVG',
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'output'        => 'formatted',
 						) );
 
 						return $stats->get_order_item_count() . ' / ' . $stats->get_order_item_earnings();
@@ -928,8 +935,9 @@ function edd_register_refunds_report( $reports ) {
 
 		// Variables to hold date filter values.
 		$options = Reports\get_dates_filter_options();
-		$filter  = Reports\get_filter_value( 'dates' );
-		$label   = $options[ $filter['range'] ];
+		$dates   = Reports\get_filter_value( 'dates' );
+		$taxes   = Reports\get_filter_value( 'taxes' );
+		$label   = $options[ $dates['range'] ];
 
 		$reports->add_report( 'refunds', array(
 			'label'     => __( 'Refunds', 'easy-digital-downloads' ),
@@ -949,17 +957,17 @@ function edd_register_refunds_report( $reports ) {
 					'refunds_chart',
 				),
 			),
-			'filters'   => array( 'products' ),
+			'filters'   => array( 'products', 'taxes' ),
 		) );
 
 		$reports->register_endpoint( 'refund_count', array(
 			'label' => __( 'Number of Refunds', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats  = new EDD\Stats();
 						$number = $stats->get_order_refund_count( array(
-							'range' => $filter['range'],
+							'range' => $dates['range'],
 						) );
 						return apply_filters( 'edd_reports_refunds_refund_count', esc_html( $number ) );
 					},
@@ -975,10 +983,10 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Number of Fully Refunded Orders', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats  = new EDD\Stats();
 						$number = $stats->get_order_refund_count( array(
-							'range'  => $filter['range'],
+							'range'  => $dates['range'],
 							'status' => array( 'complete' ),
 						) );
 						return apply_filters( 'edd_reports_refunds_fully_refunded_order_count', esc_html( $number ) );
@@ -995,10 +1003,10 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Number of Fully Refunded Items', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats  = new EDD\Stats();
 						$number = $stats->get_order_item_refund_count( array(
-							'range'  => $filter['range'],
+							'range'  => $dates['range'],
 							'status' => array( 'refunded' ),
 						) );
 						return apply_filters( 'edd_reports_refunds_fully_refunded_order_item_count', esc_html( $number ) );
@@ -1015,11 +1023,12 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Total Refund Amount', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats  = new EDD\Stats();
 						$amount = $stats->get_order_refund_amount( array(
-							'range'  => $filter['range'],
-							'output' => 'formatted',
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'output'        => 'formatted',
 						) );
 
 						return apply_filters( 'edd_reports_refunds_refund_amount', esc_html( $amount ) );
@@ -1036,12 +1045,13 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Average Refund Amount', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_refunds_average_refund_amount', $stats->get_order_refund_amount( array(
-							'function' => 'AVG',
-							'range'    => $filter['range'],
-							'output'   => 'formatted',
+							'function'      => 'AVG',
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'output'        => 'formatted',
 						) ) );
 					},
 					'display_args'  => array(
@@ -1056,10 +1066,10 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Average Time to Refund', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return $stats->get_average_refund_time( array(
-							'range' => $filter['range'],
+							'range' => $dates['range'],
 						) );
 					},
 					'display_args'  => array(
@@ -1074,10 +1084,10 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Refund Rate', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_refunds_refund_rate', $stats->get_refund_rate( array(
-							'range'  => $filter['range'],
+							'range'  => $dates['range'],
 							'output' => 'formatted',
 						) ) );
 					},
@@ -1143,14 +1153,15 @@ function edd_register_payment_gateways_report( $reports ) {
 
 		// Variables to hold date filter values.
 		$options = Reports\get_dates_filter_options();
-		$filter  = Reports\get_filter_value( 'dates' );
+		$dates   = Reports\get_filter_value( 'dates' );
+		$taxes   = Reports\get_filter_value( 'taxes' );
 		$gateway = Reports\get_filter_value( 'gateways' );
 
 		$gateway = ! empty( $gateway ) && 'all' !== $gateway
 			? ' (' . esc_html( edd_get_gateway_admin_label( $gateway ) ) . ')'
 			: '';
 
-		$label = $options[ $filter['range'] ] . $gateway;
+		$label = $options[ $dates['range'] ] . $gateway;
 
 		$reports->add_report( 'gateways', array(
 			'label'     => __( 'Payment Gateways', 'easy-digital-downloads' ),
@@ -1172,14 +1183,14 @@ function edd_register_payment_gateways_report( $reports ) {
 					'gateway_sales_earnings_chart',
 				),
 			),
-			'filters'   => array( 'gateways' ),
+			'filters'   => array( 'gateways', 'taxes' ),
 		) );
 
 		$reports->register_endpoint( 'sales_per_gateway', array(
 			'label' => __( 'Sales', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$gateway = 'all' !== Reports\get_filter_value( 'gateways' )
 							? Reports\get_filter_value( 'gateways' )
 							: '';
@@ -1187,7 +1198,7 @@ function edd_register_payment_gateways_report( $reports ) {
 						$stats = new EDD\Stats();
 
 						return apply_filters( 'edd_reports_gateways_sales', $stats->get_gateway_sales( array(
-							'range'   => $filter['range'],
+							'range'   => $dates['range'],
 							'gateway' => $gateway,
 						) ) );
 					},
@@ -1203,7 +1214,7 @@ function edd_register_payment_gateways_report( $reports ) {
 			'label' => __( 'Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$gateway = 'all' !== Reports\get_filter_value( 'gateways' )
 							? Reports\get_filter_value( 'gateways' )
 							: '';
@@ -1211,9 +1222,10 @@ function edd_register_payment_gateways_report( $reports ) {
 						$stats = new EDD\Stats();
 
 						return apply_filters( 'edd_reports_gateways_earnings', $stats->get_gateway_earnings( array(
-							'range'   => $filter['range'],
-							'gateway' => $gateway,
-							'output'  => 'formatted',
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'gateway'       => $gateway,
+							'output'        => 'formatted',
 						) ) );
 					},
 					'display_args'  => array(
@@ -1228,7 +1240,7 @@ function edd_register_payment_gateways_report( $reports ) {
 			'label' => __( 'Refunds', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$gateway = 'all' !== Reports\get_filter_value( 'gateways' )
 							? Reports\get_filter_value( 'gateways' )
 							: '';
@@ -1236,7 +1248,7 @@ function edd_register_payment_gateways_report( $reports ) {
 						$stats = new EDD\Stats();
 
 						return apply_filters( 'edd_reports_gateways_refunds', $stats->get_gateway_earnings( array(
-							'range'   => $filter['range'],
+							'range'   => $dates['range'],
 							'gateway' => $gateway,
 							'output'  => 'formatted',
 							'status'  => array( 'refunded' ),
@@ -1254,7 +1266,7 @@ function edd_register_payment_gateways_report( $reports ) {
 			'label' => __( 'Average Order Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$gateway = 'all' !== Reports\get_filter_value( 'gateways' )
 							? Reports\get_filter_value( 'gateways' )
 							: '';
@@ -1263,16 +1275,18 @@ function edd_register_payment_gateways_report( $reports ) {
 
 						if ( empty( $gateway ) ) {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_order_earnings( array(
-								'range'    => $filter['range'],
-								'function' => 'AVG',
-								'output'   => 'formatted',
+								'range'         => $dates['range'],
+								'exclude_taxes' => $taxes['exclude_taxes'],
+								'function'      => 'AVG',
+								'output'        => 'formatted',
 							) ) );
 						} else {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_gateway_earnings( array(
-								'range'    => $filter['range'],
-								'gateway'  => $gateway,
-								'function' => 'AVG',
-								'output'   => 'formatted',
+								'range'         => $dates['range'],
+								'exclude_taxes' => $taxes['exclude_taxes'],
+								'gateway'       => $gateway,
+								'function'      => 'AVG',
+								'output'        => 'formatted',
 							) ) );
 						}
 					},
@@ -1285,7 +1299,7 @@ function edd_register_payment_gateways_report( $reports ) {
 		) );
 
 		$reports->register_endpoint( 'gateway_stats', array(
-			'label' => __( 'Gateway Stats', 'easy-digital-downloads' ) . ' &mdash; ' . $options[ $filter['range'] ],
+			'label' => __( 'Gateway Stats', 'easy-digital-downloads' ) . ' &mdash; ' . $options[ $dates['range'] ],
 			'views' => array(
 				'table' => array(
 					'display_args' => array(
@@ -1299,13 +1313,13 @@ function edd_register_payment_gateways_report( $reports ) {
 		$gateway_list = array_map( 'edd_get_gateway_admin_label', array_keys( edd_get_payment_gateways() ) );
 
 		$reports->register_endpoint( 'gateway_sales_breakdown', array(
-			'label' => __( 'Gateway Sales', 'easy-digital-downloads' ) . ' &mdash; ' . $options[ $filter['range'] ],
+			'label' => __( 'Gateway Sales', 'easy-digital-downloads' ) . ' &mdash; ' . $options[ $dates['range'] ],
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function() use ( $filter ) {
+					'data_callback' => function() use ( $dates ) {
 						$stats = new EDD\Stats();
 						$g = $stats->get_gateway_sales( array(
-							'range'    => $filter['range'],
+							'range'    => $dates['range'],
 							'grouped'  => true,
 						) );
 
@@ -1347,14 +1361,15 @@ function edd_register_payment_gateways_report( $reports ) {
 		) );
 
 		$reports->register_endpoint( 'gateway_earnings_breakdown', array(
-			'label' => __( 'Gateway Earnings', 'easy-digital-downloads' ) . ' &mdash; ' . $options[ $filter['range'] ],
+			'label' => __( 'Gateway Earnings', 'easy-digital-downloads' ) . ' &mdash; ' . $options[ $dates['range'] ],
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function() use ( $filter ) {
+					'data_callback' => function() use ( $dates, $taxes ) {
 						$stats = new EDD\Stats();
 						$g = $stats->get_gateway_earnings( array(
-							'grouped' => true,
-							'range'   => $filter['range'],
+							'grouped'       => true,
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
 						) );
 
 						$gateways = array_flip( array_keys( edd_get_payment_gateways() ) );
@@ -1400,7 +1415,7 @@ function edd_register_payment_gateways_report( $reports ) {
 				'label' => __( 'Sales and Earnings', 'easy-digital-downloads' ) . ' &mdash; ' . $label,
 				'views' => array(
 					'chart' => array(
-						'data_callback' => function () use ( $filter ) {
+						'data_callback' => function () use ( $dates, $taxes ) {
 							global $wpdb;
 
 							$dates        = Reports\get_dates_filter( 'objects' );
@@ -1428,9 +1443,12 @@ function edd_register_payment_gateways_report( $reports ) {
 							}
 
 							$gateway = Reports\get_filter_value( 'gateways' );
+							$column  = true === $taxes['exclude_taxes']
+								? 'subtotal'
+								: 'total';
 
 							$results = $wpdb->get_results( $wpdb->prepare(
-								"SELECT COUNT(total) AS sales, SUM(total) AS earnings, {$sql_clauses['select']}
+								"SELECT COUNT({$column}) AS sales, SUM({$column}) AS earnings, {$sql_clauses['select']}
 								 FROM {$wpdb->edd_orders} o
 								 WHERE gateway = %s AND status IN ('complete', 'revoked') AND date_created >= %s AND date_created <= %s
 								 GROUP BY {$sql_clauses['groupby']}
@@ -1549,8 +1567,8 @@ function edd_register_taxes_report( $reports ) {
 
 		// Variables to hold date filter values.
 		$options = Reports\get_dates_filter_options();
-		$filter  = Reports\get_filter_value( 'dates' );
-		$label   = $options[ $filter['range'] ];
+		$dates   = Reports\get_filter_value( 'dates' );
+		$label   = $options[ $dates['range'] ];
 
 		$download_data = Reports\get_filter_value( 'products' );
 		$download_data = ! empty( $download_data ) && 'all' !== Reports\get_filter_value( 'products' )
@@ -1594,7 +1612,7 @@ function edd_register_taxes_report( $reports ) {
 			'label' => __( 'Total Tax Collected', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates ) {
 						$download = Reports\get_filter_value( 'products' );
 						$download = ! empty( $download ) && 'all' !== Reports\get_filter_value( 'products' )
 							? edd_parse_product_dropdown_value( Reports\get_filter_value( 'products' ) )
@@ -1603,7 +1621,7 @@ function edd_register_taxes_report( $reports ) {
 						$stats = new EDD\Stats();
 						return $stats->get_tax( array(
 							'output'      => 'formatted',
-							'range'       => $filter['range'],
+							'range'       => $dates['range'],
 							'download_id' => $download['download_id'],
 							'price_id'    => (string) $download['price_id'],
 						) );
@@ -1629,7 +1647,7 @@ function edd_register_taxes_report( $reports ) {
 				'label' => __( 'Total Tax Collected for ', 'easy-digital-downloads' ) . $location,
 				'views' => array(
 					'tile' => array(
-						'data_callback' => function () use ( $filter, $country, $region ) {
+						'data_callback' => function () use ( $dates, $country, $region ) {
 							$download = Reports\get_filter_value( 'products' );
 							$download = ! empty( $download ) && 'all' !== Reports\get_filter_value( 'products' )
 								? edd_parse_product_dropdown_value( Reports\get_filter_value( 'products' ) )
@@ -1639,7 +1657,7 @@ function edd_register_taxes_report( $reports ) {
 
 							return $stats->get_tax_by_location( array(
 								'output'      => 'formatted',
-								'range'       => $filter['range'],
+								'range'       => $dates['range'],
 								'download_id' => $download['download_id'],
 								'price_id'    => (string) $download['price_id'],
 								'country'     => $country,
@@ -2263,8 +2281,9 @@ function edd_register_customer_report( $reports ) {
 
 		// Variables to hold date filter values.
 		$options = Reports\get_dates_filter_options();
-		$filter  = Reports\get_filter_value( 'dates' );
-		$label   = $options[ $filter['range'] ];
+		$dates   = Reports\get_filter_value( 'dates' );
+		$taxes   = Reports\get_filter_value( 'taxes' );
+		$label   = $options[ $dates['range'] ];
 
 		$reports->add_report( 'customers', array(
 			'label'     => __( 'Customers', 'easy-digital-downloads' ),
@@ -2286,18 +2305,19 @@ function edd_register_customer_report( $reports ) {
 					'new_customers',
 				),
 			),
-			'filters'   => array( 'dates' ),
+			'filters'   => array( 'dates', 'taxes' ),
 		) );
 
 		$reports->register_endpoint( 'lifetime_value_of_customer', array(
 			'label' => __( 'Average Lifetime Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () {
+					'data_callback' => function () use ( $taxes ) {
 						$stats = new EDD\Stats();
 						return $stats->get_customer_lifetime_value( array(
-							'function' => 'AVG',
-							'output'   => 'formatted',
+							'function'      => 'AVG',
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'output'        => 'formatted',
 						) );
 					},
 				),
@@ -2308,12 +2328,13 @@ function edd_register_customer_report( $reports ) {
 			'label' => __( 'Average Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_customers_average_customer_value', $stats->get_customer_lifetime_value( array(
-							'function' => 'AVG',
-							'range'    => $filter['range'],
-							'output'   => 'formatted',
+							'function'      => 'AVG',
+							'range'         => $dates['range'],
+							'exclude_taxes' => $taxes['exclude_taxes'],
+							'output'        => 'formatted',
 						) ) );
 					},
 					'display_args'  => array(
@@ -2386,7 +2407,7 @@ function edd_register_customer_report( $reports ) {
 			'label' => __( 'New Customers', 'easy-digital-downloads' ) . ' &mdash; ' . $label,
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function () use ( $filter ) {
+					'data_callback' => function () {
 						global $wpdb;
 
 						$dates        = Reports\get_dates_filter( 'objects' );

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -219,7 +219,7 @@ function edd_register_overview_report( $reports ) {
 					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'output'        => 'formatted',
 						) );
 
@@ -240,7 +240,7 @@ function edd_register_overview_report( $reports ) {
 					'data_callback' => function () use ( $taxes ) {
 						$stats = new EDD\Stats( array(
 							'output'        => 'formatted',
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 						) );
 
 						return $stats->get_order_count() . ' / ' . $stats->get_order_earnings();
@@ -261,7 +261,7 @@ function edd_register_overview_report( $reports ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_earnings', $stats->get_order_earnings( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'relative'      => true,
 						) ) );
 					},
@@ -343,7 +343,7 @@ function edd_register_overview_report( $reports ) {
 							'output'        => 'formatted',
 							'relative'      => true,
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 						) ) );
 					},
 					'display_args'  => array(
@@ -576,7 +576,7 @@ function edd_register_downloads_report( $reports ) {
 						$stats = new EDD\Stats( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'output'        => 'formatted',
 						) );
 
@@ -1027,7 +1027,7 @@ function edd_register_refunds_report( $reports ) {
 						$stats  = new EDD\Stats();
 						$amount = $stats->get_order_refund_amount( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'output'        => 'formatted',
 						) );
 
@@ -1050,7 +1050,7 @@ function edd_register_refunds_report( $reports ) {
 						return apply_filters( 'edd_reports_refunds_average_refund_amount', $stats->get_order_refund_amount( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'output'        => 'formatted',
 						) ) );
 					},
@@ -1223,7 +1223,7 @@ function edd_register_payment_gateways_report( $reports ) {
 
 						return apply_filters( 'edd_reports_gateways_earnings', $stats->get_gateway_earnings( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'gateway'       => $gateway,
 							'output'        => 'formatted',
 						) ) );
@@ -1276,14 +1276,14 @@ function edd_register_payment_gateways_report( $reports ) {
 						if ( empty( $gateway ) ) {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_order_earnings( array(
 								'range'         => $dates['range'],
-								'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+								'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 								'function'      => 'AVG',
 								'output'        => 'formatted',
 							) ) );
 						} else {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_gateway_earnings( array(
 								'range'         => $dates['range'],
-								'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+								'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 								'gateway'       => $gateway,
 								'function'      => 'AVG',
 								'output'        => 'formatted',
@@ -1369,7 +1369,7 @@ function edd_register_payment_gateways_report( $reports ) {
 						$g = $stats->get_gateway_earnings( array(
 							'grouped'       => true,
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 						) );
 
 						$gateways = array_flip( array_keys( edd_get_payment_gateways() ) );
@@ -2316,7 +2316,7 @@ function edd_register_customer_report( $reports ) {
 						$stats = new EDD\Stats();
 						return $stats->get_customer_lifetime_value( array(
 							'function'      => 'AVG',
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'output'        => 'formatted',
 						) );
 					},
@@ -2333,7 +2333,7 @@ function edd_register_customer_report( $reports ) {
 						return apply_filters( 'edd_reports_customers_average_customer_value', $stats->get_customer_lifetime_value( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
 							'output'        => 'formatted',
 						) ) );
 					},

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -182,10 +182,10 @@ function edd_register_overview_report( $reports ) {
 	try {
 
 		// Variables to hold date filter values.
-		$options = Reports\get_dates_filter_options();
-		$dates   = Reports\get_filter_value( 'dates' );
-		$taxes   = Reports\get_filter_value( 'taxes' );
-		$label   = $options[ $dates['range'] ];
+		$options       = Reports\get_dates_filter_options();
+		$dates         = Reports\get_filter_value( 'dates' );
+		$exclude_taxes = Reports\get_taxes_excluded_filter();
+		$label         = $options[ $dates['range'] ];
 
 		$reports->add_report( 'overview', array(
 			'label'     => __( 'Overview', 'easy-digital-downloads' ),
@@ -216,10 +216,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Sales / Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$stats = new EDD\Stats( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'output'        => 'formatted',
 						) );
 
@@ -237,10 +237,10 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Sales / Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $taxes ) {
+					'data_callback' => function () use ( $exclude_taxes ) {
 						$stats = new EDD\Stats( array(
 							'output'        => 'formatted',
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 						) );
 
 						return $stats->get_order_count() . ' / ' . $stats->get_order_earnings();
@@ -257,11 +257,11 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_earnings', $stats->get_order_earnings( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'relative'      => true,
 						) ) );
 					},
@@ -336,14 +336,14 @@ function edd_register_overview_report( $reports ) {
 			'label' => __( 'Average Order Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_average_order_value', $stats->get_order_earnings( array(
 							'function'      => 'AVG',
 							'output'        => 'formatted',
 							'relative'      => true,
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 						) ) );
 					},
 					'display_args'  => array(
@@ -482,10 +482,10 @@ function edd_register_downloads_report( $reports ) {
 	try {
 
 		// Variables to hold date filter values.
-		$options = Reports\get_dates_filter_options();
-		$dates   = Reports\get_filter_value( 'dates' );
-		$taxes   = Reports\get_filter_value( 'taxes' );
-		$label   = $options[ $dates['range'] ];
+		$options       = Reports\get_dates_filter_options();
+		$dates         = Reports\get_filter_value( 'dates' );
+		$exclude_taxes = Reports\get_taxes_excluded_filter();
+		$label         = $options[ $dates['range'] ];
 
 		$download_data = Reports\get_filter_value( 'products' );
 		$download_data = ! empty( $download_data ) && 'all' !== Reports\get_filter_value( 'products' )
@@ -572,11 +572,11 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Average Sales / Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$stats = new EDD\Stats( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'output'        => 'formatted',
 						) );
 
@@ -934,10 +934,10 @@ function edd_register_refunds_report( $reports ) {
 	try {
 
 		// Variables to hold date filter values.
-		$options = Reports\get_dates_filter_options();
-		$dates   = Reports\get_filter_value( 'dates' );
-		$taxes   = Reports\get_filter_value( 'taxes' );
-		$label   = $options[ $dates['range'] ];
+		$options       = Reports\get_dates_filter_options();
+		$dates         = Reports\get_filter_value( 'dates' );
+		$exclude_taxes = Reports\get_taxes_excluded_filter();
+		$label         = $options[ $dates['range'] ];
 
 		$reports->add_report( 'refunds', array(
 			'label'     => __( 'Refunds', 'easy-digital-downloads' ),
@@ -1023,11 +1023,11 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Total Refund Amount', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$stats  = new EDD\Stats();
 						$amount = $stats->get_order_refund_amount( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'output'        => 'formatted',
 						) );
 
@@ -1045,12 +1045,12 @@ function edd_register_refunds_report( $reports ) {
 			'label' => __( 'Average Refund Amount', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_refunds_average_refund_amount', $stats->get_order_refund_amount( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'output'        => 'formatted',
 						) ) );
 					},
@@ -1152,10 +1152,10 @@ function edd_register_payment_gateways_report( $reports ) {
 	try {
 
 		// Variables to hold date filter values.
-		$options = Reports\get_dates_filter_options();
-		$dates   = Reports\get_filter_value( 'dates' );
-		$taxes   = Reports\get_filter_value( 'taxes' );
-		$gateway = Reports\get_filter_value( 'gateways' );
+		$options       = Reports\get_dates_filter_options();
+		$dates         = Reports\get_filter_value( 'dates' );
+		$exclude_taxes = Reports\get_taxes_excluded_filter();
+		$label         = $options[ $dates['range'] ];
 
 		$gateway = ! empty( $gateway ) && 'all' !== $gateway
 			? ' (' . esc_html( edd_get_gateway_admin_label( $gateway ) ) . ')'
@@ -1214,7 +1214,7 @@ function edd_register_payment_gateways_report( $reports ) {
 			'label' => __( 'Earnings', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$gateway = 'all' !== Reports\get_filter_value( 'gateways' )
 							? Reports\get_filter_value( 'gateways' )
 							: '';
@@ -1223,7 +1223,7 @@ function edd_register_payment_gateways_report( $reports ) {
 
 						return apply_filters( 'edd_reports_gateways_earnings', $stats->get_gateway_earnings( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'gateway'       => $gateway,
 							'output'        => 'formatted',
 						) ) );
@@ -1266,7 +1266,7 @@ function edd_register_payment_gateways_report( $reports ) {
 			'label' => __( 'Average Order Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$gateway = 'all' !== Reports\get_filter_value( 'gateways' )
 							? Reports\get_filter_value( 'gateways' )
 							: '';
@@ -1276,14 +1276,14 @@ function edd_register_payment_gateways_report( $reports ) {
 						if ( empty( $gateway ) ) {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_order_earnings( array(
 								'range'         => $dates['range'],
-								'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+								'exclude_taxes' => $exclude_taxes,
 								'function'      => 'AVG',
 								'output'        => 'formatted',
 							) ) );
 						} else {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_gateway_earnings( array(
 								'range'         => $dates['range'],
-								'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+								'exclude_taxes' => $exclude_taxes,
 								'gateway'       => $gateway,
 								'function'      => 'AVG',
 								'output'        => 'formatted',
@@ -1364,12 +1364,12 @@ function edd_register_payment_gateways_report( $reports ) {
 			'label' => __( 'Gateway Earnings', 'easy-digital-downloads' ) . ' &mdash; ' . $options[ $dates['range'] ],
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function() use ( $dates, $taxes ) {
+					'data_callback' => function() use ( $dates, $exclude_taxes ) {
 						$stats = new EDD\Stats();
 						$g = $stats->get_gateway_earnings( array(
 							'grouped'       => true,
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 						) );
 
 						$gateways = array_flip( array_keys( edd_get_payment_gateways() ) );
@@ -1415,7 +1415,7 @@ function edd_register_payment_gateways_report( $reports ) {
 				'label' => __( 'Sales and Earnings', 'easy-digital-downloads' ) . ' &mdash; ' . $label,
 				'views' => array(
 					'chart' => array(
-						'data_callback' => function () use ( $dates, $taxes ) {
+						'data_callback' => function () use ( $dates, $exclude_taxes ) {
 							global $wpdb;
 
 							$dates        = Reports\get_dates_filter( 'objects' );
@@ -1443,7 +1443,7 @@ function edd_register_payment_gateways_report( $reports ) {
 							}
 
 							$gateway = Reports\get_filter_value( 'gateways' );
-							$column  = isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes']
+							$column  = $exclude_taxes
 								? 'subtotal'
 								: 'total';
 
@@ -1566,9 +1566,10 @@ function edd_register_taxes_report( $reports ) {
 	try {
 
 		// Variables to hold date filter values.
-		$options = Reports\get_dates_filter_options();
-		$dates   = Reports\get_filter_value( 'dates' );
-		$label   = $options[ $dates['range'] ];
+		$options       = Reports\get_dates_filter_options();
+		$dates         = Reports\get_filter_value( 'dates' );
+		$exclude_taxes = Reports\get_taxes_excluded_filter();
+		$label         = $options[ $dates['range'] ];
 
 		$download_data = Reports\get_filter_value( 'products' );
 		$download_data = ! empty( $download_data ) && 'all' !== Reports\get_filter_value( 'products' )
@@ -2280,10 +2281,10 @@ function edd_register_customer_report( $reports ) {
 	try {
 
 		// Variables to hold date filter values.
-		$options = Reports\get_dates_filter_options();
-		$dates   = Reports\get_filter_value( 'dates' );
-		$taxes   = Reports\get_filter_value( 'taxes' );
-		$label   = $options[ $dates['range'] ];
+		$options       = Reports\get_dates_filter_options();
+		$dates         = Reports\get_filter_value( 'dates' );
+		$exclude_taxes = Reports\get_taxes_excluded_filter();
+		$label         = $options[ $dates['range'] ];
 
 		$reports->add_report( 'customers', array(
 			'label'     => __( 'Customers', 'easy-digital-downloads' ),
@@ -2312,11 +2313,11 @@ function edd_register_customer_report( $reports ) {
 			'label' => __( 'Average Lifetime Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $taxes ) {
+					'data_callback' => function () use ( $exclude_taxes ) {
 						$stats = new EDD\Stats();
 						return $stats->get_customer_lifetime_value( array(
 							'function'      => 'AVG',
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'output'        => 'formatted',
 						) );
 					},
@@ -2328,12 +2329,12 @@ function edd_register_customer_report( $reports ) {
 			'label' => __( 'Average Value', 'easy-digital-downloads' ),
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $dates, $taxes ) {
+					'data_callback' => function () use ( $dates, $exclude_taxes ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_customers_average_customer_value', $stats->get_customer_lifetime_value( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes'],
+							'exclude_taxes' => $exclude_taxes,
 							'output'        => 'formatted',
 						) ) );
 					},

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -219,7 +219,7 @@ function edd_register_overview_report( $reports ) {
 					'data_callback' => function () use ( $dates, $taxes ) {
 						$stats = new EDD\Stats( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'output'        => 'formatted',
 						) );
 
@@ -240,7 +240,7 @@ function edd_register_overview_report( $reports ) {
 					'data_callback' => function () use ( $taxes ) {
 						$stats = new EDD\Stats( array(
 							'output'        => 'formatted',
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 						) );
 
 						return $stats->get_order_count() . ' / ' . $stats->get_order_earnings();
@@ -261,7 +261,7 @@ function edd_register_overview_report( $reports ) {
 						$stats = new EDD\Stats();
 						return apply_filters( 'edd_reports_overview_earnings', $stats->get_order_earnings( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'relative'      => true,
 						) ) );
 					},
@@ -343,7 +343,7 @@ function edd_register_overview_report( $reports ) {
 							'output'        => 'formatted',
 							'relative'      => true,
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 						) ) );
 					},
 					'display_args'  => array(
@@ -576,7 +576,7 @@ function edd_register_downloads_report( $reports ) {
 						$stats = new EDD\Stats( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'output'        => 'formatted',
 						) );
 
@@ -1027,7 +1027,7 @@ function edd_register_refunds_report( $reports ) {
 						$stats  = new EDD\Stats();
 						$amount = $stats->get_order_refund_amount( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'output'        => 'formatted',
 						) );
 
@@ -1050,7 +1050,7 @@ function edd_register_refunds_report( $reports ) {
 						return apply_filters( 'edd_reports_refunds_average_refund_amount', $stats->get_order_refund_amount( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'output'        => 'formatted',
 						) ) );
 					},
@@ -1223,7 +1223,7 @@ function edd_register_payment_gateways_report( $reports ) {
 
 						return apply_filters( 'edd_reports_gateways_earnings', $stats->get_gateway_earnings( array(
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'gateway'       => $gateway,
 							'output'        => 'formatted',
 						) ) );
@@ -1276,14 +1276,14 @@ function edd_register_payment_gateways_report( $reports ) {
 						if ( empty( $gateway ) ) {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_order_earnings( array(
 								'range'         => $dates['range'],
-								'exclude_taxes' => $taxes['exclude_taxes'],
+								'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 								'function'      => 'AVG',
 								'output'        => 'formatted',
 							) ) );
 						} else {
 							return apply_filters( 'edd_reports_gateways_average_order_value', $stats->get_gateway_earnings( array(
 								'range'         => $dates['range'],
-								'exclude_taxes' => $taxes['exclude_taxes'],
+								'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 								'gateway'       => $gateway,
 								'function'      => 'AVG',
 								'output'        => 'formatted',
@@ -1369,7 +1369,7 @@ function edd_register_payment_gateways_report( $reports ) {
 						$g = $stats->get_gateway_earnings( array(
 							'grouped'       => true,
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 						) );
 
 						$gateways = array_flip( array_keys( edd_get_payment_gateways() ) );
@@ -1443,7 +1443,7 @@ function edd_register_payment_gateways_report( $reports ) {
 							}
 
 							$gateway = Reports\get_filter_value( 'gateways' );
-							$column  = true === $taxes['exclude_taxes']
+							$column  = isset( $taxes['exclude_taxes'] ) && true === $taxes['exclude_taxes']
 								? 'subtotal'
 								: 'total';
 
@@ -2316,7 +2316,7 @@ function edd_register_customer_report( $reports ) {
 						$stats = new EDD\Stats();
 						return $stats->get_customer_lifetime_value( array(
 							'function'      => 'AVG',
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'output'        => 'formatted',
 						) );
 					},
@@ -2333,7 +2333,7 @@ function edd_register_customer_report( $reports ) {
 						return apply_filters( 'edd_reports_customers_average_customer_value', $stats->get_customer_lifetime_value( array(
 							'function'      => 'AVG',
 							'range'         => $dates['range'],
-							'exclude_taxes' => $taxes['exclude_taxes'],
+							'exclude_taxes' => isset( $taxes['exclude_taxes'] ),
 							'output'        => 'formatted',
 						) ) );
 					},

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -584,7 +584,7 @@ class Stats {
 	 *     @type string $end       End day and time (based on the end of the given day).
 	 *     @type string $range     Date range. If a range is passed, this will override and `start` and `end`
 	 *                             values passed. See \EDD\Reports\get_dates_filter_options() for valid date ranges.
-	 *     @type string $function  SQL function. Accepts `COUNT` and `AVG`. Default `COUNT`.
+	 *     @type string $function  SQL function. Accepts `AVG` only. Default `AVG`.
 	 *     @type string $where_sql Reserved for internal use. Allows for additional WHERE clauses to be appended to the
 	 *                             query.
 	 *     @type string $output    The output format of the calculation. Accepts `raw` and `formatted`. Default `raw`.

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -1966,7 +1966,9 @@ class Stats {
 					) o
 					WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		} else {
-			$column = true === $this->query_vars['exclude_taxes'] ? 'subtotal' : 'total';
+			$column = true === $this->query_vars['exclude_taxes']
+				? 'subtotal'
+				: 'total';
 
 			$sql = "SELECT {$function} AS total
 					FROM (

--- a/includes/reports/data/class-report-registry.php
+++ b/includes/reports/data/class-report-registry.php
@@ -109,7 +109,10 @@ class Report_Registry extends Reports\Registry implements Utils\Static_Registry 
 			'priority'   => 10,
 			'group'      => 'core',
 			'capability' => 'view_shop_reports',
-			'filters'    => array( 'dates' )
+			'filters'    => array(
+				'dates',
+				'taxes',
+			)
 		);
 
 		$attributes['id'] = $report_id;

--- a/includes/reports/data/customers/class-most-valuable-customers-list-table.php
+++ b/includes/reports/data/customers/class-most-valuable-customers-list-table.php
@@ -42,13 +42,10 @@ class Most_Valuable_Customers_List_Table extends \EDD_Customer_Reports_Table {
 		$dates      = Reports\get_filter_value( 'dates' );
 		$taxes      = Reports\get_filter_value( 'taxes' );
 		$date_range = Reports\parse_dates_for_range( $dates['range'] );
+		$column     = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
 
 		$start_date = sanitize_text_field( date( 'Y-m-d 00:00:00', strtotime( $date_range['start'] ) ) );
 		$end_date   = sanitize_text_field( date( 'Y-m-d 23:59:59', strtotime( $date_range['end'] ) ) );
-
-		$column = true === $taxes['exclude_taxes']
-			? 'subtotal'
-			: 'total';
 
 		$sql = "SELECT customer_id, COUNT(id) AS order_count, SUM({$column}) AS total_spent
 				FROM {$wpdb->edd_orders}

--- a/includes/reports/data/customers/class-most-valuable-customers-list-table.php
+++ b/includes/reports/data/customers/class-most-valuable-customers-list-table.php
@@ -39,13 +39,18 @@ class Most_Valuable_Customers_List_Table extends \EDD_Customer_Reports_Table {
 
 		$data = array();
 
-		$filter     = Reports\get_filter_value( 'dates' );
-		$date_range = Reports\parse_dates_for_range( $filter['range'] );
+		$dates      = Reports\get_filter_value( 'dates' );
+		$taxes      = Reports\get_filter_value( 'taxes' );
+		$date_range = Reports\parse_dates_for_range( $dates['range'] );
 
 		$start_date = sanitize_text_field( date( 'Y-m-d 00:00:00', strtotime( $date_range['start'] ) ) );
 		$end_date   = sanitize_text_field( date( 'Y-m-d 23:59:59', strtotime( $date_range['end'] ) ) );
 
-		$sql = "SELECT customer_id, COUNT(id) AS order_count, SUM(total) AS total_spent
+		$column = true === $taxes['exclude_taxes']
+			? 'subtotal'
+			: 'total';
+
+		$sql = "SELECT customer_id, COUNT(id) AS order_count, SUM({$column}) AS total_spent
 				FROM {$wpdb->edd_orders}
 				WHERE status IN (%s, %s) AND date_created >= %s AND date_created <= %s AND type = 'sale'
 				GROUP BY customer_id

--- a/includes/reports/data/customers/class-top-five-customers-list-table.php
+++ b/includes/reports/data/customers/class-top-five-customers-list-table.php
@@ -69,9 +69,7 @@ class Top_Five_Customers_List_Table extends \EDD_Customer_Reports_Table {
 
 			// @todo DRY with Most_Valuable_Customers_List_Table
 
-			$column = true === $taxes['exclude_taxes']
-				? 'subtotal'
-				: 'total';
+			$column = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
 
 			$sql = "SELECT customer_id, COUNT(id) AS order_count, SUM({$column}) AS total_spent
 					FROM {$wpdb->edd_orders}

--- a/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
+++ b/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
@@ -33,8 +33,9 @@ class Earnings_By_Taxonomy_List_Table extends List_Table {
 	public function get_data() {
 		global $wpdb;
 
-		$filter     = Reports\get_filter_value( 'dates' );
-		$date_range = Reports\parse_dates_for_range( $filter['range'] );
+		$dates      = Reports\get_filter_value( 'dates' );
+		$taxes      = Reports\get_filter_value( 'taxes' );
+		$date_range = Reports\parse_dates_for_range( $dates['range'] );
 
 		// Generate date query SQL if dates have been set.
 		$date_query_sql = '';
@@ -88,7 +89,11 @@ class Earnings_By_Taxonomy_List_Table extends List_Table {
 			$placeholders   = implode( ', ', array_fill( 0, count( $taxonomies[ $k ]['object_ids'] ), '%d' ) );
 			$product_id__in = $wpdb->prepare( "product_id IN({$placeholders})", $taxonomies[ $k ]['object_ids'] );
 
-			$sql = "SELECT total, COUNT(id) AS sales
+			$column = true === $taxes['exclude_taxes']
+				? 'subtotal'
+				: 'total';
+
+			$sql = "SELECT {$column} as total, COUNT(id) AS sales
 					FROM {$wpdb->edd_order_items}
 					WHERE {$product_id__in} {$date_query_sql}";
 

--- a/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
+++ b/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
@@ -89,9 +89,7 @@ class Earnings_By_Taxonomy_List_Table extends List_Table {
 			$placeholders   = implode( ', ', array_fill( 0, count( $taxonomies[ $k ]['object_ids'] ), '%d' ) );
 			$product_id__in = $wpdb->prepare( "product_id IN({$placeholders})", $taxonomies[ $k ]['object_ids'] );
 
-			$column = true === $taxes['exclude_taxes']
-				? 'subtotal'
-				: 'total';
+			$column = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
 
 			$sql = "SELECT {$column} as total, COUNT(id) AS sales
 					FROM {$wpdb->edd_order_items}

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -767,6 +767,23 @@ function get_dates_filter_day_by_day() {
 	return $day_by_day;
 }
 
+/**
+ * Retrieves the tax exclusion filter.
+ *
+ * @since 3.0
+ *
+ * @return bool True if taxes should be excluded from calculations.
+ */
+function get_taxes_excluded_filter() {
+	$taxes = get_filter_value( 'taxes' );
+
+	if ( ! isset( $taxes['exclude_taxes'] ) ) {
+		return false;
+	}
+
+	return (bool) $taxes['exclude_taxes'];
+}
+
 /** Display *******************************************************************/
 
 /**

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1036,6 +1036,10 @@ function display_products_filter() {
  * @since 3.0
  */
 function display_taxes_filter() {
+	if ( false === edd_use_taxes() ) {
+		return;
+	}
+
 	$taxes         = get_filter_value( 'taxes' ); 
 	$exclude_taxes = isset( $taxes['exclude_taxes'] ) && true == $taxes['exclude_taxes'];
 ?>

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1036,10 +1036,12 @@ function display_products_filter() {
  * @since 3.0
  */
 function display_taxes_filter() {
-	$taxes = get_filter_value( 'taxes' ); ?>
+	$taxes         = get_filter_value( 'taxes' ); 
+	$exclude_taxes = isset( $taxes['exclude_taxes'] ) && true == $taxes['exclude_taxes'];
+?>
 
     <span class="edd-graph-filter-options graph-option-section">
-        <input type="checkbox" id="exclude_taxes" <?php checked( true, $taxes, true ); ?> value="1" name="exclude_taxes"/>
+        <input type="checkbox" id="exclude_taxes" <?php checked( true, $exclude_taxes, true ); ?> value="1" name="exclude_taxes"/>
         <label for="exclude_taxes"><?php esc_html_e( 'Exclude Taxes', 'easy-digital-downloads' ); ?></label>
     </span><?php
 }

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1039,11 +1039,13 @@ function display_taxes_filter() {
 	$taxes         = get_filter_value( 'taxes' ); 
 	$exclude_taxes = isset( $taxes['exclude_taxes'] ) && true == $taxes['exclude_taxes'];
 ?>
-
-    <span class="edd-graph-filter-options graph-option-section">
-        <input type="checkbox" id="exclude_taxes" <?php checked( true, $exclude_taxes, true ); ?> value="1" name="exclude_taxes"/>
-        <label for="exclude_taxes"><?php esc_html_e( 'Exclude Taxes', 'easy-digital-downloads' ); ?></label>
-    </span><?php
+	<span class="edd-graph-filter-options graph-option-section">
+		<label for="exclude_taxes">
+			<input type="checkbox" id="exclude_taxes" <?php checked( true, $exclude_taxes, true ); ?> value="1" name="exclude_taxes"/>
+			<?php esc_html_e( 'Exclude Taxes', 'easy-digital-downloads' ); ?>
+		</label>
+	</span>
+<?php
 }
 
 /**

--- a/tests/reports/data/tests-reports-registry.php
+++ b/tests/reports/data/tests-reports-registry.php
@@ -211,7 +211,7 @@ class Report_Registry_Tests extends \EDD_UnitTestCase {
 
 		$report = $this->registry->get_report( 'foo' );
 
-		$this->assertEqualSets( array( 'dates' ), $report['filters'] );
+		$this->assertEqualSets( array( 'dates', 'taxes' ), $report['filters'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7644 

Proposed Changes:
1. Reintroduce filter to "Exclude taxes" in report calculations.