### PR TITLE
issue/7651 - Restore `edd_payments_table_views` Filter

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -712,21 +712,21 @@ class EDD_Payment_History_Table extends List_Table {
 	}
 
 	/**
-	 * Retrieve the view types
+	 * Retrieves the Payments table views.
 	 *
 	 * @since 1.4
 	 *
-	 * @return array $views All the views available
+	 * @return array $views Available views.
 	 */
 	public function get_views() {
 		$views = parent::get_views();
 
 		/**
-		 * Filters the Payment History's view types.
+		 * Filters the Payment table's views.
 		 *
 		 * @since 1.4
 		 *
-		 * @param array $views Payment History view types.
+		 * @param array $views Payment table's views.
 		 */
 		$views = apply_filters( 'edd_payments_table_views', $views );
 

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -712,6 +712,28 @@ class EDD_Payment_History_Table extends List_Table {
 	}
 
 	/**
+	 * Retrieve the view types
+	 *
+	 * @since 1.4
+	 *
+	 * @return array $views All the views available
+	 */
+	public function get_views() {
+		$views = parent::get_views();
+
+		/**
+		 * Filters the Payment History's view types.
+		 *
+		 * @since 1.4
+		 *
+		 * @param array $views Payment History view types.
+		 */
+		$views = apply_filters( 'edd_payments_table_views', $views );
+
+		return $views;
+	}
+
+	/**
 	 * Builds an array of arguments for getting orders for the list table, counts, and pagination.
 	 *
 	 * @since 3.0


### PR DESCRIPTION
Fixes #7651 

Proposed Changes:
1. Ensures extensions using `edd_payments_table_views` can still set their own labels and counts.