### PR TITLE
issue/7652 - Restore `edd_payment_stats_post_statuses` Filter

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -171,6 +171,15 @@ class Stats {
 		$this->query_vars['type']   = 'sale';
 		$this->query_vars['status'] = array( 'complete', 'revoked', 'refunded', 'partially_refunded' );
 
+		/**
+		 * Filters Order statuses that should be included when calculating stats.
+		 *
+		 * @since 2.7
+		 *
+		 * @param array $statuses Order statuses to include when generating stats.
+		 */
+		$this->query_vars['status'] = apply_filters( 'edd_payment_stats_post_statuses', $this->query_vars['status'] );
+
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );
 
@@ -269,6 +278,15 @@ class Stats {
 		 */
 		$this->query_vars['type']   = 'sale';
 		$this->query_vars['status'] = array( 'complete', 'revoked', 'refunded', 'partially_refunded' );
+
+		/**
+		 * Filters Order statuses that should be included when calculating stats.
+		 *
+		 * @since 2.7
+		 *
+		 * @param array $statuses Order statuses to include when generating stats.
+		 */
+		$this->query_vars['status'] = apply_filters( 'edd_payment_stats_post_statuses', $this->query_vars['status'] );
 
 		// Run pre-query checks and maybe generate SQL.
 		$this->pre_query( $query );

--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -379,7 +379,16 @@ class EDD_Payment_Stats extends EDD_Stats {
 				$grouping = 'YEAR(edd_o.date_created), MONTH(edd_o.date_created), DAY(edd_o.date_created), HOUR(edd_o.date_created)';
 			}
 
-			$statuses = apply_filters( 'edd_payment_stats_post_statuses', array( 'complete', 'revoked' ) );
+			$statuses = array( 'complete', 'publish', 'revoked', 'refunded', 'partially_refunded' );
+
+			/**
+			 * Filters Order statuses that should be included when calculating stats.
+			 *
+			 * @since 2.7
+			 *
+			 * @param array $statuses Order statuses to include when generating stats.
+			 */
+			$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
 			$statuses = "'" . implode( "', '", $statuses ) . "'";
 
 			$sales = $wpdb->get_results( $wpdb->prepare(
@@ -451,7 +460,16 @@ class EDD_Payment_Stats extends EDD_Stats {
 				$grouping = 'YEAR(edd_o.date_created), MONTH(edd_o.date_created), DAY(edd_o.date_created), HOUR(edd_o.date_created)';
 			}
 
-			$statuses = apply_filters( 'edd_payment_stats_post_statuses', array( 'complete', 'revoked' ) );
+			$statuses = array( 'complete', 'publish', 'revoked', 'refunded', 'partially_refunded' );
+
+			/**
+			 * Filters Order statuses that should be included when calculating stats.
+			 *
+			 * @since 2.7
+			 *
+			 * @param array $statuses Order statuses to include when generating stats.
+			 */
+			$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
 			$statuses = "'" . implode( "', '", $statuses ) . "'";
 
 			$earnings = $wpdb->get_results( $wpdb->prepare(

--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -90,11 +90,23 @@ class EDD_Payment_Stats extends EDD_Stats {
 
 			remove_filter( 'date_query_valid_columns', array( $this, '__filter_valid_date_columns' ), 2 );
 
+			$statuses = array( 'complete', 'publish', 'revoked', 'refunded', 'partially_refunded' );
+
+			/**
+			 * Filters Order statuses that should be included when calculating stats.
+			 *
+			 * @since 2.7
+			 *
+			 * @param array $statuses Order statuses to include when generating stats.
+			 */
+			$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
+			$statuses = "'" . implode( "', '", $statuses ) . "'";
+
 			$result = $wpdb->get_row( $wpdb->prepare(
 				"SELECT COUNT(edd_oi.id) AS sales
 				 FROM {$wpdb->edd_order_items} edd_oi
 				 INNER JOIN {$wpdb->edd_orders} edd_o ON edd_oi.order_id = edd_o.id
-				 WHERE edd_o.status IN ('complete', 'revoked') AND edd_oi.product_id = %d {$date_query_sql}",
+				 WHERE edd_o.status IN ($statuses) AND edd_oi.product_id = %d {$date_query_sql}",
 			$download_id ) );
 
 			$count = null === $result
@@ -134,11 +146,22 @@ class EDD_Payment_Stats extends EDD_Stats {
 		}
 
 		if ( empty( $download_id ) ) {
+			$statuses = array( 'complete', 'publish', 'revoked', 'refunded', 'partially_refunded' );
+
+			/**
+			 * Filters Order statuses that should be included when calculating stats.
+			 *
+			 * @since 2.7
+			 *
+			 * @param array $statuses Order statuses to include when generating stats.
+			 */
+			$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
+
 			// Global earning stats
 			$args = array(
 				'post_type'              => 'edd_payment',
 				'nopaging'               => true,
-				'post_status'            => array( 'complete', 'revoked' ),
+				'post_status'            => $statuses,
 				'fields'                 => 'ids',
 				'update_post_term_cache' => false,
 				'suppress_filters'       => false,
@@ -237,11 +260,23 @@ class EDD_Payment_Stats extends EDD_Stats {
 
 				remove_filter( 'date_query_valid_columns', array( $this, '__filter_valid_date_columns' ), 2 );
 
+				$statuses = array( 'complete', 'publish', 'revoked', 'refunded', 'partially_refunded' );
+
+				/**
+				 * Filters Order statuses that should be included when calculating stats.
+				 *
+				 * @since 2.7
+				 *
+				 * @param array $statuses Order statuses to include when generating stats.
+				 */
+				$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
+				$statuses = "'" . implode( "', '", $statuses ) . "'";
+
 				$result = $wpdb->get_row( $wpdb->prepare(
 					"SELECT edd_oi.tax, edd_oi.total
 					 FROM {$wpdb->edd_order_items} edd_oi
 					 INNER JOIN {$wpdb->edd_orders} edd_o ON edd_oi.order_id = edd_o.id
-					 WHERE edd_o.status IN ('complete', 'revoked') AND edd_oi.product_id = %d {$date_query_sql}",
+					 WHERE edd_o.status IN ($statuses) AND edd_oi.product_id = %d {$date_query_sql}",
 				$download_id ) );
 
 				$earnings = 0;


### PR DESCRIPTION
Fixes #7652 

Proposed Changes:
1. Restore `edd_payment_stats_post_statuses` filter and ensure all stats use a consistent set of statuses.