### PR TITLE
issue/7640 - Set Orders to "Partially Refunded" When Refunding an Order Item

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1532,24 +1532,25 @@ function edd_get_status_label( $status = '' ) {
 		$labels = array(
 
 			// Payments
-			'processing' => __( 'Processing', 'easy-digital-downloads' ),
-			'complete'   => __( 'Completed',  'easy-digital-downloads' ),
-			'refunded'   => __( 'Refunded',   'easy-digital-downloads' ),
-			'revoked'    => __( 'Revoked',    'easy-digital-downloads' ),
-			'failed'     => __( 'Failed',     'easy-digital-downloads' ),
-			'abandoned'  => __( 'Abandoned',  'easy-digital-downloads' ),
+			'processing'         => __( 'Processing', 'easy-digital-downloads' ),
+			'complete'           => __( 'Completed', 'easy-digital-downloads' ),
+			'refunded'           => __( 'Refunded', 'easy-digital-downloads' ),
+			'partially_refunded' => __( 'Partially Refunded', 'easy-digital-downloads' ),
+			'revoked'            => __( 'Revoked', 'easy-digital-downloads' ),
+			'failed'             => __( 'Failed', 'easy-digital-downloads' ),
+			'abandoned'          => __( 'Abandoned', 'easy-digital-downloads' ),
 
 			// Discounts
-			'active'     => __( 'Active',     'easy-digital-downloads' ),
-			'inactive'   => __( 'Inactive',   'easy-digital-downloads' ),
-			'expired'    => __( 'Expired',    'easy-digital-downloads' ),
+			'active'             => __( 'Active', 'easy-digital-downloads' ),
+			'inactive'           => __( 'Inactive', 'easy-digital-downloads' ),
+			'expired'            => __( 'Expired', 'easy-digital-downloads' ),
 
 			// Common
-			'pending'    => __( 'Pending',    'easy-digital-downloads' ),
-			'verified'   => __( 'Verified',   'easy-digital-downloads' ),
-			'spam'       => __( 'Spam',       'easy-digital-downloads' ),
-			'deleted'    => __( 'Deleted',    'easy-digital-downloads' ),
-			'cancelled'  => __( 'Cancelled',  'easy-digital-downloads' ),
+			'pending'            => __( 'Pending', 'easy-digital-downloads' ),
+			'verified'           => __( 'Verified', 'easy-digital-downloads' ),
+			'spam'               => __( 'Spam', 'easy-digital-downloads' ),
+			'deleted'            => __( 'Deleted', 'easy-digital-downloads' ),
+			'cancelled'          => __( 'Cancelled', 'easy-digital-downloads' ),
 		);
 	}
 

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -36,7 +36,7 @@ function edd_is_order_refundable( $order_id = 0 ) {
 	}
 
 	// Only completed orders can be refunded.
-	if ( 'complete' !== $order->status ) {
+	if ( ! in_array( $order->status, array( 'complete', 'publish', 'partially_refunded', true ) ) ) {
 		return false;
 	}
 

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -289,9 +289,14 @@ function edd_refund_order( $order_id = 0, $status = 'complete', $order_items = a
 			break;
 		}
 	}
+
 	if ( 'complete' === $status && $all_refunded ) {
 		edd_update_order( $order_id, array(
 			'status' => 'refunded',
+		) );
+	} elseif ( 'complete' === $status && false === $all_refunded ) {
+		edd_update_order( $order_id, array(
+			'status' => 'partially_refunded',
 		) );
 	}
 

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -36,7 +36,7 @@ function edd_is_order_refundable( $order_id = 0 ) {
 	}
 
 	// Only completed orders can be refunded.
-	if ( ! in_array( $order->status, array( 'complete', 'publish', 'partially_refunded', true ) ) ) {
+	if ( ! in_array( $order->status, array( 'complete', 'publish', 'partially_refunded' ), true ) ) {
 		return false;
 	}
 

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -603,13 +603,14 @@ function edd_get_payment_status_label( $status = '' ) {
  */
 function edd_get_payment_statuses() {
 	return apply_filters( 'edd_payment_statuses', array(
-		'pending'    => __( 'Pending',    'easy-digital-downloads' ),
-		'processing' => __( 'Processing', 'easy-digital-downloads' ),
-		'complete'   => __( 'Completed',  'easy-digital-downloads' ),
-		'refunded'   => __( 'Refunded',   'easy-digital-downloads' ),
-		'revoked'    => __( 'Revoked',    'easy-digital-downloads' ),
-		'failed'     => __( 'Failed',     'easy-digital-downloads' ),
-		'abandoned'  => __( 'Abandoned',  'easy-digital-downloads' )
+		'pending'            => __( 'Pending',    'easy-digital-downloads' ),
+		'processing'         => __( 'Processing', 'easy-digital-downloads' ),
+		'complete'           => __( 'Completed',  'easy-digital-downloads' ),
+		'refunded'           => __( 'Refunded',   'easy-digital-downloads' ),
+		'partially_refunded' => __( 'Partially Refunded', 'easy-digital-downloads' ),
+		'revoked'            => __( 'Revoked',    'easy-digital-downloads' ),
+		'failed'             => __( 'Failed',     'easy-digital-downloads' ),
+		'abandoned'          => __( 'Abandoned',  'easy-digital-downloads' )
 	) );
 }
 

--- a/tests/orders/tests-payments.php
+++ b/tests/orders/tests-payments.php
@@ -158,13 +158,14 @@ class Payment_Tests extends \EDD_UnitTestCase {
 		$out = edd_get_payment_statuses();
 
 		$expected = array(
-			'pending'    => 'Pending',
-			'complete'   => 'Completed',
-			'refunded'   => 'Refunded',
-			'failed'     => 'Failed',
-			'revoked'    => 'Revoked',
-			'abandoned'  => 'Abandoned',
-			'processing' => 'Processing',
+			'pending'            => 'Pending',
+			'complete'           => 'Completed',
+			'refunded'           => 'Refunded',
+			'partially_refunded' => 'Partially Refunded',
+			'failed'             => 'Failed',
+			'revoked'            => 'Revoked',
+			'abandoned'          => 'Abandoned',
+			'processing'         => 'Processing',
 		);
 
 		$this->assertEquals( $expected, $out );
@@ -174,13 +175,14 @@ class Payment_Tests extends \EDD_UnitTestCase {
 		$out = edd_get_payment_status_keys();
 
 		$expected = array(
-			'pending'    => __( 'Pending',    'easy-digital-downloads' ),
-			'processing' => __( 'Processing', 'easy-digital-downloads' ),
-			'complete'   => __( 'Completed',  'easy-digital-downloads' ),
-			'refunded'   => __( 'Refunded',   'easy-digital-downloads' ),
-			'revoked'    => __( 'Revoked',    'easy-digital-downloads' ),
-			'failed'     => __( 'Failed',     'easy-digital-downloads' ),
-			'abandoned'  => __( 'Abandoned',  'easy-digital-downloads' )
+			'pending'            => __( 'Pending',    'easy-digital-downloads' ),
+			'processing'         => __( 'Processing', 'easy-digital-downloads' ),
+			'complete'           => __( 'Completed',  'easy-digital-downloads' ),
+			'refunded'           => __( 'Refunded',   'easy-digital-downloads' ),
+			'partially_refunded' => __( 'Partially Refunded', 'easy-digital-downloads' ),
+			'revoked'            => __( 'Revoked',    'easy-digital-downloads' ),
+			'failed'             => __( 'Failed',     'easy-digital-downloads' ),
+			'abandoned'          => __( 'Abandoned',  'easy-digital-downloads' )
 		);
 
 		asort( $expected );


### PR DESCRIPTION
Fixes #7640 

Proposed Changes:
1. Set an Order status to "Partially Refunded" when one or more, but not all, Order Items are refunded.