### PR TITLE
Fix W3 validation issues caused by dupe `id` atts

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -213,7 +213,7 @@ function edd_get_purchase_link( $args = array() ) {
 
 		<input type="hidden" name="download_id" value="<?php echo esc_attr( $download->ID ); ?>">
 		<?php if ( $variable_pricing && isset( $price_id ) && isset( $prices[$price_id] ) ): ?>
-			<input type="hidden" name="edd_options[price_id][]" id="edd_price_option_<?php echo $download->ID; ?>_1" class="edd_price_option_<?php echo $download->ID; ?>" value="<?php echo $price_id; ?>">
+			<input type="hidden" name="edd_options[price_id][]" id="edd_price_option_<?php echo $download->ID; ?>_<?php echo esc_attr( $price_id ); ?>" class="edd_price_option_<?php echo $download->ID; ?>" value="<?php echo esc_attr( $price_id ); ?>">
 		<?php endif; ?>
 		<?php if( ! empty( $args['direct'] ) && ! $download->is_free( $args['price_id'] ) ) { ?>
 			<input type="hidden" name="edd_action" class="edd_action_input" value="straight_to_gateway">


### PR DESCRIPTION
Proposed Changes:
1. Sanitize `$price_id` before printing in the `<input>` fields
2. Use Price ID to differentiate the variable pricing `id` attributes 

![](https://i.gravityview.co/c9QjDO+)