### PR TITLE
issue/7670 - Remove Product Filtering From Refund Reports

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -957,7 +957,7 @@ function edd_register_refunds_report( $reports ) {
 					'refunds_chart',
 				),
 			),
-			'filters'   => array( 'products', 'taxes' ),
+			'filters'   => array( 'taxes' ),
 		) );
 
 		$reports->register_endpoint( 'refund_count', array(


### PR DESCRIPTION
Fixes #7670 

Proposed Changes:
1. Remove "Product" filtering from Refund reports until queries support filtering.