### PR TITLE
removed css that made dropdowns appear disabled #7649

### DIFF
--- a/assets/css/edd-admin-chosen.css
+++ b/assets/css/edd-admin-chosen.css
@@ -1,12 +1,6 @@
 /* Chosen styles
 -------------------------------------------------------------- */
 
-body.js select.edd-select-chosen {
-	height: 27px;
-	opacity: 0.2;
-	max-width: 300px;
-}
-
 .chosen-container.chosen-container-multi {
 	width: 100% !important;
 }


### PR DESCRIPTION
Fixes #7649

Proposed Changes:
1. Removed css opacity for `select` drop downs so they do not appear disabled on mobile
2. Removed height and max-width from same rule so as not to override WP Core styles
