### PR TITLE
sanitized tax amount so that it does not cause "non well formed numer…

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1412,10 +1412,10 @@ class EDD_Payment {
 		$merged_item = array_merge( $current_args, $args );
 
 		// Format the item_price correctly now
-		$merged_item['item_price']  = edd_sanitize_amount( $merged_item['item_price'] );
-		$new_subtotal               = floatval( $merged_item['item_price'] ) * $merged_item['quantity'];
-		$merged_item['tax']  = edd_sanitize_amount( $merged_item['tax'] );
-		$merged_item['price']       = edd_prices_include_tax() ? $new_subtotal : $new_subtotal + $merged_item['tax'];
+		$merged_item['item_price'] = edd_sanitize_amount( $merged_item['item_price'] );
+		$new_subtotal              = floatval( $merged_item['item_price'] ) * $merged_item['quantity'];
+		$merged_item['tax']        = edd_sanitize_amount( $merged_item['tax'] );
+		$merged_item['price']      = edd_prices_include_tax() ? $new_subtotal : $new_subtotal + $merged_item['tax'];
 
 		// Sort the current and new args, and checksum them. If no changes. No need to fire a modification.
 		ksort( $current_args );

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1414,6 +1414,7 @@ class EDD_Payment {
 		// Format the item_price correctly now
 		$merged_item['item_price']  = edd_sanitize_amount( $merged_item['item_price'] );
 		$new_subtotal               = floatval( $merged_item['item_price'] ) * $merged_item['quantity'];
+		$merged_item['tax']  = edd_sanitize_amount( $merged_item['tax'] );
 		$merged_item['price']       = edd_prices_include_tax() ? $new_subtotal : $new_subtotal + $merged_item['tax'];
 
 		// Sort the current and new args, and checksum them. If no changes. No need to fire a modification.


### PR DESCRIPTION
sanitized tax amount so that it does not cause "non well formed numeric value" with tax amount over $999, issue#7434

Fixes #7434

Proposed Changes:
1. Ran tax through `edd_sanitize_amount()`
2. Put new sanitized tax amount into totals including tax

For testing:
1. Enable taxes.
2. Complete a payment on the frontend checkout.
3. View the Payment Record in the WordPress dashboard.
4. Modify a cart item's tax amount to be greater than 999, and include a comma in the amount, such as `1,000`
- Verify there are no errors in the error log.

(Thanks, @spencerfinnell )

