### PR TITLE
Fallback to site currency when payment currency meta is empty.

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -475,7 +475,7 @@ class Data_Migrator {
 			'ip'             => $ip,
 			'gateway'        => $gateway,
 			'mode'           => $mode,
-			'currency'       => $payment_meta['currency'],
+			'currency'       => ! empty( $payment_meta['currency'] ) ? $payment_meta['currency'] : edd_get_curreny(),
 			'payment_key'    => $purchase_key,
 			'subtotal'       => $subtotal,
 			'tax'            => $tax,

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -475,7 +475,7 @@ class Data_Migrator {
 			'ip'             => $ip,
 			'gateway'        => $gateway,
 			'mode'           => $mode,
-			'currency'       => ! empty( $payment_meta['currency'] ) ? $payment_meta['currency'] : edd_get_curreny(),
+			'currency'       => ! empty( $payment_meta['currency'] ) ? $payment_meta['currency'] : edd_get_currency(),
 			'payment_key'    => $purchase_key,
 			'subtotal'       => $subtotal,
 			'tax'            => $tax,


### PR DESCRIPTION
Fixes #7689

Uses fallback `edd_get_currency()` when the payment meta currency is empty (as suggested in #7689). 