### PR TITLE
issue/7693 - 3.0 - Ensure last_month Is Parsed With No Overflow

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -545,12 +545,13 @@ function get_dates_filter( $values = 'strings', $timezone = null ) {
  *
  * @param string          $range Optional. Range value to generate start and end dates for against `$date`.
  *                               Default is the current range as derived from the session.
+ * @param string          $date  Date string converted to `\EDD\Utils\Date` to anchor calculations to.
  * @return \EDD\Utils\Date[] Array of start and end date objects.
  */
-function parse_dates_for_range( $range = null ) {
+function parse_dates_for_range( $range = null, $date = 'now' ) {
 
 	// Set the time ranges in the user's timezone, so they ultimately see them in their own timezone.
-	$date = EDD()->utils->date( 'now', edd_get_timezone_id(), false );
+	$date = EDD()->utils->date( $date, edd_get_timezone_id(), false );
 
 	if ( null === $range || ! array_key_exists( $range, get_dates_filter_options() ) ) {
 		$range = get_dates_filter_range();

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -568,8 +568,8 @@ function parse_dates_for_range( $range = null, $date = 'now' ) {
 
 		case 'last_month':
 			$dates = array(
-				'start' => $date->copy()->subMonth( 1 )->startOfMonth(),
-				'end'   => $date->copy()->subMonth( 1 )->endOfMonth(),
+				'start' => $date->copy()->subMonthNoOverflow( 1 )->startOfMonth(),
+				'end'   => $date->copy()->subMonthNoOverflow( 1 )->endOfMonth(),
 			);
 			break;
 

--- a/tests/reports/tests-reports-functions.php
+++ b/tests/reports/tests-reports-functions.php
@@ -408,8 +408,8 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 	 */
 	public function test_parse_dates_for_range_with_last_month_range_should_return_those_dates() {
 		$expected = array(
-			'start' => self::$date->copy()->subMonth( 1 )->startOfMonth()->toDateTimeString(),
-			'end'   => self::$date->copy()->subMonth( 1 )->endOfMonth()->toDateTimeString(),
+			'start' => self::$date->copy()->subMonthNoOverflow( 1 )->startOfMonth()->toDateTimeString(),
+			'end'   => self::$date->copy()->subMonthNoOverflow( 1 )->endOfMonth()->toDateTimeString(),
 			'range' => 'last_month',
 		);
 

--- a/tests/reports/tests-reports-functions.php
+++ b/tests/reports/tests-reports-functions.php
@@ -426,6 +426,29 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 	 * @covers \EDD\Reports\parse_dates_for_range()
 	 * @group edd_dates
 	 */
+	public function test_parse_dates_for_range_with_overflow_last_month_range_should_return_those_dates() {
+		$overflow_day  = '2020-03-30';
+		$overflow_date = EDD()->utils->date( $overflow_day );
+
+		$expected = array(
+			'start' => $overflow_date->copy()->subMonthNoOverflow( 1 )->startOfMonth()->toDateTimeString(),
+			'end'   => $overflow_date->copy()->subMonthNoOverflow( 1 )->endOfMonth()->toDateTimeString(),
+			'range' => 'last_month',
+		);
+
+		$result = parse_dates_for_range( 'last_month', $overflow_day );
+
+		// Explicitly strip seconds in case the test is slow.
+		$expected = $this->strip_seconds( $expected );
+		$result   = $this->strip_seconds( $this->objects_to_date_strings( $result ) );
+
+		$this->assertEqualSetsWithIndex( $expected, $result );
+	}
+
+	/**
+	 * @covers \EDD\Reports\parse_dates_for_range()
+	 * @group edd_dates
+	 */
 	public function test_parse_dates_for_range_with_today_range_should_return_those_dates() {
 		$expected = array(
 			'start' => self::$date->copy()->setTimezone( edd_get_timezone_id() )->startOfDay()->setTimezone( 'UTC' ),

--- a/tests/reports/tests-reports-functions.php
+++ b/tests/reports/tests-reports-functions.php
@@ -427,20 +427,19 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 	 * @group edd_dates
 	 */
 	public function test_parse_dates_for_range_with_overflow_last_month_range_should_return_those_dates() {
-		$overflow_day  = '2020-03-30';
+		$overflow_day  = '2020-03-30 00:00:00';
 		$overflow_date = EDD()->utils->date( $overflow_day );
 
 		$expected = array(
-			'start' => $overflow_date->copy()->subMonthNoOverflow( 1 )->startOfMonth()->toDateTimeString(),
-			'end'   => $overflow_date->copy()->subMonthNoOverflow( 1 )->endOfMonth()->toDateTimeString(),
+			'start' => ( new \DateTime( '2020-02-01 00:00:00' ) )->format( 'Y-m-d H:i' ),
+			'end'   => ( new \DateTime( '2020-02-29 23:59:59' ) )->format( 'Y-m-d H:i' ),
 			'range' => 'last_month',
 		);
 
 		$result = parse_dates_for_range( 'last_month', $overflow_day );
 
 		// Explicitly strip seconds in case the test is slow.
-		$expected = $this->strip_seconds( $expected );
-		$result   = $this->strip_seconds( $this->objects_to_date_strings( $result ) );
+		$result = $this->strip_seconds( $this->objects_to_date_strings( $result ) );
 
 		$this->assertEqualSetsWithIndex( $expected, $result );
 	}


### PR DESCRIPTION
Fixes #7693

Proposed Changes:
1. Ensures parsing `last_month` on a date with more days than the previous still fetches the true "last month"