### PR TITLE
Issue 7725, Add Hidden Label for Email Field

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -800,7 +800,7 @@ function edd_customers_view( $customer = null ) {
 						<div class="add-customer-email-wrapper">
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
-							<label class="screen-reader-text" for="additional-email"><?php esc_html_e( 'Email Address', 'easy-ditigal-downloads' ); ?></label>
+							<label class="screen-reader-text" for="additional-email"><?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?></label>
 							<input type="email" name="additional-email" id="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -801,7 +801,7 @@ function edd_customers_view( $customer = null ) {
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
 							<label class="screen-reader-text" for="additional-email"><?php esc_html_e( 'Email Address', 'easy-ditigal-downloads' ); ?></label>
-							<input type="email" name="additional-email" id="additional-email" value="" placeholder="<?php esc_html__( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
+							<input type="email" name="additional-email" id="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>
 					</td>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -800,7 +800,7 @@ function edd_customers_view( $customer = null ) {
 						<div class="add-customer-email-wrapper">
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
-							<label class = "hidden" for="additional-email">Email Address</label>
+							<label class = "hidden" for="additional-email"><?php_e( 'Email Address', 'easy-ditigal-downloads' ); ?></label>
 							<input type="email" name="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -800,7 +800,7 @@ function edd_customers_view( $customer = null ) {
 						<div class="add-customer-email-wrapper">
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
-							<label class = "hidden" for="additional-email"><?php_e( 'Email Address', 'easy-ditigal-downloads' ); ?></label>
+							<label class="screen-reader-text" for="additional-email"><?php esc_html_e( 'Email Address', 'easy-ditigal-downloads' ); ?></label>
 							<input type="email" name="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -801,7 +801,7 @@ function edd_customers_view( $customer = null ) {
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
 							<label class="screen-reader-text" for="additional-email"><?php esc_html_e( 'Email Address', 'easy-ditigal-downloads' ); ?></label>
-							<input type="email" name="additional-email" id="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
+							<input type="email" name="additional-email" id="additional-email" value="" placeholder="<?php esc_html__( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>
 					</td>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -801,7 +801,7 @@ function edd_customers_view( $customer = null ) {
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
 							<label class="screen-reader-text" for="additional-email"><?php esc_html_e( 'Email Address', 'easy-ditigal-downloads' ); ?></label>
-							<input type="email" name="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
+							<input type="email" name="additional-email" id="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>
 					</td>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -800,8 +800,8 @@ function edd_customers_view( $customer = null ) {
 						<div class="add-customer-email-wrapper">
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
-							<label class="screen-reader-text" for="additional-email"><?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?></label>
-							<input type="email" name="additional-email" id="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
+							<label class="screen-reader-text" for="edd-additional-email"><?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?></label>
+							<input type="email" name="additional-email" id="edd-additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>
 					</td>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -800,6 +800,7 @@ function edd_customers_view( $customer = null ) {
 						<div class="add-customer-email-wrapper">
 							<input type="hidden" name="customer-id" value="<?php echo esc_attr( $customer->id ); ?>" />
 							<?php wp_nonce_field( 'edd-add-customer-email', 'add_email_nonce', false, true ); ?>
+							<label class = "hidden" for="additional-email">Email Address</label>
 							<input type="email" name="additional-email" value="" placeholder="<?php esc_html_e( 'Email Address', 'easy-digital-downloads' ); ?>" />&nbsp;
 							<input type="checkbox" name="make-additional-primary" value="1" id="make-additional-primary" />&nbsp;<label for="make-additional-primary"><?php esc_html_e( 'Make Primary', 'easy-digital-downloads' ); ?></label>
 						</div>


### PR DESCRIPTION
Fixes #7725 

Proposed Changes:
1. Added hidden label to email field for screen reader accessibility

To Test:
1. Downloads -> Customers -> Customer Emails
2. No label visible, only placeholder text
3. Inspect field element and see hidden label
