### PR TITLE
changed background and font on chip, issue #7731

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1924,7 +1924,7 @@ body.download_page_edd-reports {
 	font-size: 10px;
 	text-transform: uppercase;
 	font-weight: bold;
-	line-height: 8px;
+	line-height: 1;
 	vertical-align: middle;
 	padding: 2px 2px 3px 3px;
 	margin: -1px 0 0 2px;

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1921,7 +1921,7 @@ body.download_page_edd-reports {
 }
 
 .edd-chip {
-	font-size: 7px;
+	font-size: 10px;
 	text-transform: uppercase;
 	font-weight: bold;
 	line-height: 8px;
@@ -1930,8 +1930,7 @@ body.download_page_edd-reports {
 	margin: -1px 0 0 2px;
 	border-radius: 3px;
 	color: #fff;
-	background-color: #bbb;
-	border: 1px solid #999;
+	background-color: #444;
 	opacity: 0.8;
 }
 

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1927,7 +1927,6 @@ body.download_page_edd-reports {
 	line-height: 1;
 	vertical-align: middle;
 	padding: 2px 2px 3px 3px;
-	margin: -1px 0 0 2px;
 	border-radius: 3px;
 	color: #fff;
 	background-color: #444;

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1923,14 +1923,11 @@ body.download_page_edd-reports {
 .edd-chip {
 	font-size: 10px;
 	text-transform: uppercase;
-	font-weight: bold;
 	line-height: 1;
-	vertical-align: middle;
-	padding: 2px 2px 3px 3px;
+	padding: 3px;
 	border-radius: 3px;
 	color: #fff;
 	background-color: #444;
-	opacity: 0.8;
 }
 
 .edd-vertical-sections .edd-legacy-label {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1922,6 +1922,7 @@ body.download_page_edd-reports {
 
 .edd-chip {
 	font-size: 10px;
+	font-weight: bold;
 	text-transform: uppercase;
 	line-height: 1;
 	padding: 3px;


### PR DESCRIPTION
Fixes #7731 

Proposed Changes:
1. Increased contrast for `.edd-chip` to `#444`, the core text color
2. Removed border from `.edd-chip` to gain more space for text
3. Increased text on `.edd-chip` to 11px to meet WAVE recommendations

![image](https://user-images.githubusercontent.com/18077352/79160564-d7f1d680-7d8e-11ea-89f4-66f576a7cee4.png)

