### PR TITLE
Exclude taxes with SUM(total - tax) instead of SUM(subtotal) #7692

### DIFF
--- a/includes/admin/reporting/reports-callbacks.php
+++ b/includes/admin/reporting/reports-callbacks.php
@@ -26,7 +26,7 @@ function edd_overview_sales_earnings_chart() {
 	$dates        = Reports\get_dates_filter( 'objects' );
 	$day_by_day   = Reports\get_dates_filter_day_by_day();
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
-	$column       = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
+	$column       = Reports\get_taxes_excluded_filter() ? 'total - tax' : 'total';
 
 	$sql_clauses = array(
 		'select'  => 'date_created AS date',
@@ -132,7 +132,7 @@ function edd_overview_refunds_chart() {
 	$dates        = Reports\get_dates_filter( 'objects' );
 	$day_by_day   = Reports\get_dates_filter_day_by_day();
 	$hour_by_hour = Reports\get_dates_filter_hour_by_hour();
-	$column       = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
+	$column       = Reports\get_taxes_excluded_filter() ? 'total - tax' : 'total';
 
 	$sql_clauses = array(
 		'select'  => 'date_created AS date',

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -1445,7 +1445,7 @@ function edd_register_payment_gateways_report( $reports ) {
 
 							$gateway = Reports\get_filter_value( 'gateways' );
 							$column  = $exclude_taxes
-								? 'subtotal'
+								? 'total - tax'
 								: 'total';
 
 							$results = $wpdb->get_results( $wpdb->prepare(

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -161,7 +161,7 @@ class Stats {
 
 		// Add table and column name to query_vars to assist with date query generation.
 		$this->query_vars['table']             = $this->get_db()->edd_orders;
-		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'subtotal' : 'total';
+		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'total - tax' : 'total';
 		$this->query_vars['date_query_column'] = 'date_created';
 
 		/*
@@ -814,7 +814,7 @@ class Stats {
 
 		// Add table and column name to query_vars to assist with date query generation.
 		$this->query_vars['table']             = $this->get_db()->edd_order_items;
-		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'subtotal' : 'total';
+		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'total - tax' : 'total';
 		$this->query_vars['date_query_column'] = 'date_created';
 
 		// Run pre-query checks and maybe generate SQL.
@@ -1229,7 +1229,7 @@ class Stats {
 
 		// Add table and column name to query_vars to assist with date query generation.
 		$this->query_vars['table']             = $this->get_db()->edd_order_adjustments;
-		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'subtotal' : 'total';
+		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'total - tax' : 'total';
 		$this->query_vars['date_query_column'] = 'date_created';
 
 		// Run pre-query checks and maybe generate SQL.
@@ -1439,7 +1439,7 @@ class Stats {
 
 		// Add table and column name to query_vars to assist with date query generation.
 		$this->query_vars['table']             = $this->get_db()->edd_orders;
-		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'subtotal' : 'total';
+		$this->query_vars['column']            = true === $this->query_vars['exclude_taxes'] ? 'total - tax' : 'total';
 		$this->query_vars['date_query_column'] = 'date_created';
 		$this->query_vars['function']          = 'COUNT';
 
@@ -2012,7 +2012,7 @@ class Stats {
 					WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		} else {
 			$column = true === $this->query_vars['exclude_taxes']
-				? 'subtotal'
+				? 'total - tax'
 				: 'total';
 
 			$sql = "SELECT {$function} AS total
@@ -2235,7 +2235,7 @@ class Stats {
 			: 1;
 
 		$column = true === $this->query_vars['exclude_taxes']
-			? 'subtotal'
+			? 'total - tax'
 			: 'total';
 
 		$sql = "SELECT customer_id, SUM({$column}) AS total

--- a/includes/reports/data/customers/class-most-valuable-customers-list-table.php
+++ b/includes/reports/data/customers/class-most-valuable-customers-list-table.php
@@ -42,7 +42,7 @@ class Most_Valuable_Customers_List_Table extends \EDD_Customer_Reports_Table {
 		$dates      = Reports\get_filter_value( 'dates' );
 		$taxes      = Reports\get_filter_value( 'taxes' );
 		$date_range = Reports\parse_dates_for_range( $dates['range'] );
-		$column     = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
+		$column     = Reports\get_taxes_excluded_filter() ? 'total - tax' : 'total';
 
 		$start_date = sanitize_text_field( date( 'Y-m-d 00:00:00', strtotime( $date_range['start'] ) ) );
 		$end_date   = sanitize_text_field( date( 'Y-m-d 23:59:59', strtotime( $date_range['end'] ) ) );

--- a/includes/reports/data/customers/class-top-five-customers-list-table.php
+++ b/includes/reports/data/customers/class-top-five-customers-list-table.php
@@ -69,7 +69,7 @@ class Top_Five_Customers_List_Table extends \EDD_Customer_Reports_Table {
 
 			// @todo DRY with Most_Valuable_Customers_List_Table
 
-			$column = Reports\get_taxes_excluded_filter() ? 'total = tax' : 'total';
+			$column = Reports\get_taxes_excluded_filter() ? 'total - tax' : 'total';
 
 			$sql = "SELECT customer_id, COUNT(id) AS order_count, SUM({$column}) AS total_spent
 					FROM {$wpdb->edd_orders}

--- a/includes/reports/data/customers/class-top-five-customers-list-table.php
+++ b/includes/reports/data/customers/class-top-five-customers-list-table.php
@@ -69,7 +69,7 @@ class Top_Five_Customers_List_Table extends \EDD_Customer_Reports_Table {
 
 			// @todo DRY with Most_Valuable_Customers_List_Table
 
-			$column = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
+			$column = Reports\get_taxes_excluded_filter() ? 'total = tax' : 'total';
 
 			$sql = "SELECT customer_id, COUNT(id) AS order_count, SUM({$column}) AS total_spent
 					FROM {$wpdb->edd_orders}

--- a/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
+++ b/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
@@ -89,9 +89,9 @@ class Earnings_By_Taxonomy_List_Table extends List_Table {
 			$placeholders   = implode( ', ', array_fill( 0, count( $taxonomies[ $k ]['object_ids'] ), '%d' ) );
 			$product_id__in = $wpdb->prepare( "product_id IN({$placeholders})", $taxonomies[ $k ]['object_ids'] );
 
-			$column = Reports\get_taxes_excluded_filter() ? 'subtotal' : 'total';
+			$column = Reports\get_taxes_excluded_filter() ? 'total - tax' : 'total';
 
-			$sql = "SELECT {$column} as total, COUNT(id) AS sales
+			$sql = "SELECT SUM({$column}) as total, COUNT(id) AS sales
 					FROM {$wpdb->edd_order_items}
 					WHERE {$product_id__in} {$date_query_sql}";
 


### PR DESCRIPTION
Fixes #7692

Proposed Changes:
1. Updates all reports to exclude taxes by querying `SUM(total - tax)` instead of `SUM(subtotal)`.