### PR TITLE
Update discount amount to use user-defined currency symbol

### DIFF
--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -71,7 +71,7 @@ $minutes      = edd_get_minute_values();
 							<label for="edd-amount-type" class="screen-reader-text"><?php esc_html_e( 'Amount Type', 'easy-digital-downloads' ); ?></label>
 							<select name="amount_type" id="edd-amount-type">
 								<option value="percent">%</option>
-								<option value="flat"><?php echo esc_html( edd_currency_filter( '' ) ); ?></option>
+								<option value="flat"><?php echo esc_html( edd_currency_symbol() ); ?></option>
 							</select>
 						</span>
 						<p class="description"><?php esc_html_e( 'The amount as a percentage or flat rate. Cannot be left blank.', 'easy-digital-downloads' ); ?></p>

--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -70,7 +70,7 @@ $minutes      = edd_get_minute_values();
 							<input type="text" required="required" class="edd-price-field" id="edd-amount" name="amount" value="" placeholder="<?php esc_html_e( '10.00', 'easy-digital-downloads' ); ?>"/>
 							<label for="edd-amount-type" class="screen-reader-text"><?php esc_html_e( 'Amount Type', 'easy-digital-downloads' ); ?></label>
 							<select name="amount_type" id="edd-amount-type">
-								<option value="percent"><?php esc_html_e( '%', 'easy-digital-downloads' ); ?></option>
+								<option value="percent">%</option>
 								<option value="flat"><?php echo esc_html( edd_currency_filter( '' ) ); ?></option>
 							</select>
 						</span>

--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -71,7 +71,7 @@ $minutes      = edd_get_minute_values();
 							<label for="edd-amount-type" class="screen-reader-text"><?php esc_html_e( 'Amount Type', 'easy-digital-downloads' ); ?></label>
 							<select name="amount_type" id="edd-amount-type">
 								<option value="percent"><?php esc_html_e( '%', 'easy-digital-downloads' ); ?></option>
-								<option value="flat"><?php esc_html_e( '$', 'easy-digital-downloads' ); ?></option>
+								<option value="flat"><?php echo esc_html( edd_currency_filter( '' ) ); ?></option>
 							</select>
 						</span>
 						<p class="description"><?php esc_html_e( 'The amount as a percentage or flat rate. Cannot be left blank.', 'easy-digital-downloads' ); ?></p>

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -104,7 +104,7 @@ $minutes              = edd_get_minute_values();
 							<label for="edd-amount-type" class="screen-reader-text"><?php esc_html_e( 'Amount Type', 'easy-digital-downloads' ); ?></label>
 							<select name="amount_type" id="edd-amount-type">
 								<option value="percent" <?php selected( $type, 'percent' ); ?>>%</option>
-								<option value="flat"<?php selected( $type, 'flat' ); ?>><?php echo esc_html( edd_currency_filter( '' ) ); ?></option>
+								<option value="flat"<?php selected( $type, 'flat' ); ?>><?php echo esc_html( edd_currency_symbol() ); ?></option>
 							</select>
 						</span>
 						<p class="description"><?php _e( 'The amount as a percentage or flat rate. Cannot be left blank.', 'easy-digital-downloads' ); ?></p>

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -104,7 +104,7 @@ $minutes              = edd_get_minute_values();
 							<label for="edd-amount-type" class="screen-reader-text"><?php esc_html_e( 'Amount Type', 'easy-digital-downloads' ); ?></label>
 							<select name="amount_type" id="edd-amount-type">
 								<option value="percent" <?php selected( $type, 'percent' ); ?>><?php esc_html_e( '%', 'easy-digital-downloads' ); ?></option>
-								<option value="flat"<?php selected( $type, 'flat' ); ?>><?php esc_html_e( '$', 'easy-digital-downloads' ); ?></option>
+								<option value="flat"<?php selected( $type, 'flat' ); ?>><?php echo esc_html( edd_currency_filter( '' ) ); ?></option>
 							</select>
 						</span>
 						<p class="description"><?php _e( 'The amount as a percentage or flat rate. Cannot be left blank.', 'easy-digital-downloads' ); ?></p>

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -103,7 +103,7 @@ $minutes              = edd_get_minute_values();
 							<input type="text" required="required" class="edd-price-field" id="edd-amount" name="amount" value="<?php echo esc_attr( edd_format_amount( $discount->amount ) ); ?>" placeholder="<?php esc_html_e( '10.00', 'easy-digital-downloads' ); ?>" />
 							<label for="edd-amount-type" class="screen-reader-text"><?php esc_html_e( 'Amount Type', 'easy-digital-downloads' ); ?></label>
 							<select name="amount_type" id="edd-amount-type">
-								<option value="percent" <?php selected( $type, 'percent' ); ?>><?php esc_html_e( '%', 'easy-digital-downloads' ); ?></option>
+								<option value="percent" <?php selected( $type, 'percent' ); ?>>%</option>
 								<option value="flat"<?php selected( $type, 'flat' ); ?>><?php echo esc_html( edd_currency_filter( '' ) ); ?></option>
 							</select>
 						</span>


### PR DESCRIPTION
Fixes #7757 

Proposed Changes:
1. Changes hard coded `$` in discount type select to use the user-defined currency symbol
2. Changes `%` to no longer be a translatable string