### PR TITLE
Fix Product Dropdown

### DIFF
--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -91,6 +91,7 @@ $minutes      = edd_get_minute_values();
 							'selected'    => array(),
 							'multiple'    => true,
 							'chosen'      => true,
+							'variations'  => true,
 							'placeholder' => sprintf( esc_html__( 'Select %s', 'easy-digital-downloads' ), esc_html( edd_get_label_plural() ) ),
 						) ); // WPCS: XSS ok. ?>
 						<div id="edd-discount-product-conditions" style="display:none;">
@@ -128,6 +129,7 @@ $minutes      = edd_get_minute_values();
 							'selected'    => array(),
 							'multiple'    => true,
 							'chosen'      => true,
+							'variations'  => true,
 							'placeholder' => sprintf( esc_html__( 'Select %s', 'easy-digital-downloads' ), esc_html( edd_get_label_plural() ) ),
 						) ); // WPCS: XSS ok. ?>
 						<p class="description"><?php printf( esc_html__( '%s this discount cannot be applied to. Leave blank for none.', 'easy-digital-downloads' ), esc_html( edd_get_label_plural() ) ); ?></p>

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -124,6 +124,7 @@ $minutes              = edd_get_minute_values();
 							'selected'    => $product_requirements,
 							'multiple'    => true,
 							'chosen'      => true,
+							'variations'  => true,
 							'placeholder' => sprintf( __( 'Select %s', 'easy-digital-downloads' ), edd_get_label_plural() )
 						) ); ?>
                         <div id="edd-discount-product-conditions"<?php echo $condition_display; ?>>
@@ -160,7 +161,8 @@ $minutes              = edd_get_minute_values();
                             'id'          => 'excluded_products',
                             'selected'    => $excluded_products,
                             'multiple'    => true,
-                            'chosen'      => true,
+							'chosen'      => true,
+							'variations'  => true,
                             'placeholder' => sprintf( __( 'Select %s', 'easy-digital-downloads' ), edd_get_label_plural() )
                         ) ); ?>
                         <p class="description"><?php printf( __( '%s this discount cannot be applied to. Leave blank for none.', 'easy-digital-downloads' ), edd_get_label_plural() ); ?></p>

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -126,15 +126,26 @@ class EDD_HTML_Elements {
 			foreach ( $products as $product ) {
 				$has_variations = edd_has_variable_prices( $product->ID );
 
+				// If a product has no variations, just add it to the list and continue.
+				if ( ! $has_variations ) {
+					$title                             = esc_html( $product->post_title );
+					$options[ absint( $product->ID ) ] = $title;
+
+					continue;
+				}
+
+				// The product does have variations. Add the top level product to the list
+				// if not showing variations, or not showing variations only.
 				if ( false === $args['variations'] || ! $args['show_variations_only'] ) {
 					$title = esc_html( $product->post_title );
-					if ( $has_variations && ! $args['show_variations_only'] ) {
+					if ( ! $args['show_variations_only'] ) {
 						$title .= ' (' . __( 'All Price Options', 'easy-digital-downloads' ) . ')';
 					}
 					$options[ absint( $product->ID ) ] = $title;
 				}
 
-				if ( $args['variations'] && $has_variations ) {
+				// If showing variations, add them to the list.
+				if ( $args['variations'] ) {
 					$prices = edd_get_variable_prices( $product->ID );
 					foreach ( $prices as $key => $value ) {
 						$name = ! empty( $value['name'] ) ? $value['name'] : '';


### PR DESCRIPTION
Fixes #7551

Proposed Changes:
1. Updates the product_dropdown list building to include non-variable products, regardless of variation options
2. Adds some inline documentation to clarify the `foreach` behavior
3. Adds variations to the discount screens ([ref](https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7551#issuecomment-608110115))

All usages of the `product_dropdown` method were [researched](https://docs.google.com/spreadsheets/d/1fm2-KTs0bkiaP8-s5WUvezEdd3GGcn0v4Bi3ePsUztM/edit?usp=sharing); tests should be added for this.