### PR TITLE
Use unserialized meta array when computing differences #7789

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -611,11 +611,13 @@ class Data_Migrator {
 		);
 
 		// Remove all the core payment meta from the array, and...
-		$remaining_payment_meta = array_diff_key( $payment_meta, array_flip( $core_meta_keys ) );
+		if ( is_array( $payment_meta ) ) {
+			$remaining_payment_meta = array_diff_key( $payment_meta, array_flip( $core_meta_keys ) );
 
-		// ..If we have extra payment meta, it needs to be migrated across.
-		if ( 0 < count( $remaining_payment_meta ) ) {
-			edd_add_order_meta( $order_id, 'payment_meta', $remaining_payment_meta );
+			// ..If we have extra payment meta, it needs to be migrated across.
+			if ( 0 < count( $remaining_payment_meta ) ) {
+				edd_add_order_meta( $order_id, 'payment_meta', $remaining_payment_meta );
+			}
 		}
 
 		/** Create order items ***************************************/

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -611,7 +611,7 @@ class Data_Migrator {
 		);
 
 		// Remove all the core payment meta from the array, and...
-		$remaining_payment_meta = array_diff_key( $meta['_edd_payment_meta'], array_flip( $core_meta_keys ) );
+		$remaining_payment_meta = array_diff_key( $payment_meta, array_flip( $core_meta_keys ) );
 
 		// ..If we have extra payment meta, it needs to be migrated across.
 		if ( 0 < count( $remaining_payment_meta ) ) {


### PR DESCRIPTION
Fixes #7789

Proposed Changes:
1. Use the `$payment_meta` variable when computing key differences, as this has already been unserialized. `$meta['_edd_payment_meta']` is actually an array of unserialized data so this whole thing wasn't working.