### PR TITLE
removed incorrect listing for Caltanissetta

### DIFF
--- a/includes/country-functions.php
+++ b/includes/country-functions.php
@@ -1359,7 +1359,6 @@ function edd_get_italian_states_list() {
 		'CA' => 'Cagliari',
 		'CL' => 'Caltanissetta',
 		'CB' => 'Campobasso',
-		'CI' => 'Caltanissetta',
 		'CE' => 'Caserta',
 		'CT' => 'Catania',
 		'CZ' => 'Catanzaro',


### PR DESCRIPTION
Fixes #7797

Proposed Changes:
1. Verified ISO code for Caltanissetta (CL)
2. Double checked that no other province has the ISO code CI
3. Removed incorrect listing for Caltanissetta
