### PR TITLE
Check if email tag label exists before using #7808

### DIFF
--- a/includes/emails/tags.php
+++ b/includes/emails/tags.php
@@ -265,7 +265,8 @@ function edd_setup_email_tags() {
 
 	// Add email tags
 	foreach ( $email_tags as $email_tag ) {
-		edd_add_email_tag( $email_tag['tag'], $email_tag['description'], $email_tag['function'], $email_tag['label'] );
+		$label = isset( $email_tag['label'] ) ? $email_tag['label'] : '';
+		edd_add_email_tag( $email_tag['tag'], $email_tag['description'], $email_tag['function'], $label );
 	}
 
 }


### PR DESCRIPTION
Fixes #7808

Proposed Changes:
1. Checks if `$email_tag['label']` exists. If not, falls back to an empty string.