### PR TITLE
Remove `edd_product_type` for default download

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -137,6 +137,7 @@ function edd_download_meta_box_save( $post_id, $post ) {
 
 			update_post_meta( $post_id, $field, $new_default_price_id );
 		} elseif ( '_edd_product_type' === $field && '0' === $_POST[ $field ] ) {
+			// No value stored when product type is "default" ("0") for backwards compatibility.
 			delete_post_meta( $post_id, '_edd_product_type' );
 		} else {
 			if ( isset( $_POST[ $field ] ) ) {

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -108,7 +108,6 @@ function edd_download_metabox_fields() {
  * @return void
  */
 function edd_download_meta_box_save( $post_id, $post ) {
-
 	if ( ! isset( $_POST['edd_download_meta_box_nonce'] ) || ! wp_verify_nonce( $_POST['edd_download_meta_box_nonce'], basename( __FILE__ ) ) ) {
 		return;
 	}
@@ -127,7 +126,6 @@ function edd_download_meta_box_save( $post_id, $post ) {
 
 	// The default fields that get saved
 	$fields = edd_download_metabox_fields();
-
 	foreach ( $fields as $field ) {
 		if ( '_edd_default_price_id' == $field && edd_has_variable_prices( $post_id ) ) {
 
@@ -138,8 +136,9 @@ function edd_download_meta_box_save( $post_id, $post ) {
 			}
 
 			update_post_meta( $post_id, $field, $new_default_price_id );
+		} elseif ( '_edd_product_type' === $field && '0' === $_POST[ $field ] ) {
+			delete_post_meta( $post_id, '_edd_product_type' );
 		} else {
-
 			if ( isset( $_POST[ $field ] ) ) {
 				$new = apply_filters( 'edd_metabox_save_' . $field, $_POST[ $field ] );
 				update_post_meta( $post_id, $field, $new );
@@ -147,7 +146,6 @@ function edd_download_meta_box_save( $post_id, $post ) {
 				delete_post_meta( $post_id, $field );
 			}
 		}
-
 	}
 
 	if ( edd_has_variable_prices( $post_id ) ) {

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -629,15 +629,20 @@ function edd_ajax_download_search() {
 		's'              => $new_search              // String
 	);
 
-	// Maybe exclude bundles
+	// Maybe exclude bundles.
 	if ( true === $no_bundles ) {
 		$args['meta_query'] = array(
-			'relation' => 'AND',
+			'relation' => 'OR',
 			array(
 				'key'     => '_edd_product_type',
 				'value'   => 'bundle',
-				'compare' => '!='
-			)
+				'compare' => '!=',
+			),
+			array(
+				'key'     => '_edd_product_type',
+				'value'   => 'bundle',
+				'compare' => 'NOT EXISTS',
+			),
 		);
 	}
 
@@ -1454,7 +1459,7 @@ function edd_admin_order_get_item_amounts() {
 		$product_requirements = array_filter( array_values( $product_requirements ) );
 
 		if (
-			! empty( $product_requirements ) && 
+			! empty( $product_requirements ) &&
 			( 'not_global' === $d->get_scope() ) &&
 			! in_array( $product_id, $product_requirements, true )
 		) {
@@ -1482,7 +1487,7 @@ function edd_admin_order_get_item_amounts() {
 
 	if ( true === $use_taxes && floatval( 0 ) !== floatval( $tax_rate ) ) {
 		$tax = edd_calculate_tax( floatval( $subtotal - $discount ), $country, $region );
-	} else { 
+	} else {
 		$tax = 0;
 	}
 

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -79,14 +79,19 @@ class EDD_HTML_Elements {
 			$product_args['post_status'] = array( 'publish' );
 		}
 
-		// Maybe disable bundles
+		// Maybe disable bundles.
 		if ( ! $args['bundles'] ) {
 			$product_args['meta_query'] = array(
-				'relation' => 'AND',
+				'relation' => 'OR',
 				array(
 					'key'     => '_edd_product_type',
 					'value'   => 'bundle',
 					'compare' => '!=',
+				),
+				array(
+					'key'     => '_edd_product_type',
+					'value'   => 'bundle',
+					'compare' => 'NOT EXISTS',
 				),
 			);
 		}

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -86,7 +86,7 @@ class EDD_HTML_Elements {
 				array(
 					'key'     => '_edd_product_type',
 					'value'   => 'bundle',
-					'compare' => 'NOT EXISTS',
+					'compare' => '!=',
 				),
 			);
 		}


### PR DESCRIPTION
Fixes #7811 

Proposed Changes:
1. Search and delete `edd_product_type` field from metadata for "default" products
2. Update meta query to match AJAX search

To Test:
- Create a new default download and check database
- Before database would have `_edd_product_type` of `"0"`
- Now there is no entry for default
