### PR TITLE
Do not add email address if it already exists for the customer

### DIFF
--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -749,8 +749,8 @@ function edd_get_customer_address_counts( $args = array() ) {
  */
 function edd_add_customer_email_address( $data ) {
 
-	// A customer ID must be supplied for every address inserted.
-	if ( empty( $data['customer_id'] ) ) {
+	// A customer ID and email must be supplied for every address inserted.
+	if ( empty( $data['customer_id'] ) || empty( $data['email'] ) ) {
 		return false;
 	}
 

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -760,9 +760,8 @@ function edd_add_customer_email_address( $data ) {
 	// Check if the address already exists for this customer.
 	$existing_addresses = $customer_email_addresses->query(
 		array(
-			'customer_id'   => $data['customer_id'],
-			'no_found_rows' => true,
-			'email'         => $data['email'],
+			'customer_id' => $data['customer_id'],
+			'email'       => $data['email'],
 		)
 	);
 	if ( ! empty( $existing_addresses ) ) {

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -753,14 +753,23 @@ function edd_add_customer_email_address( $data ) {
 	if ( empty( $data['customer_id'] ) ) {
 		return false;
 	}
-	$exists = edd_get_customer_email_address_by( 'email', $data['email'] );
-	if ( $exists ) {
-		return false;
-	}
 
 	// Instantiate a query object.
 	$customer_email_addresses = new EDD\Database\Queries\Customer_Email_Address();
 
+	// Check if the address already exists for this customer.
+	$existing_addresses = $customer_email_addresses->query(
+		array(
+			'customer_id'   => $data['customer_id'],
+			'no_found_rows' => true,
+			'email'         => $data['email'],
+		)
+	);
+	if ( ! empty( $existing_addresses ) ) {
+		return false;
+	}
+
+	// Add the email address to the customer.
 	return $customer_email_addresses->add_item( $data );
 }
 

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -753,6 +753,15 @@ function edd_add_customer_email_address( $data ) {
 	if ( empty( $data['customer_id'] ) ) {
 		return false;
 	}
+	$email_addresses = edd_get_customer_email_addresses(
+		array(
+			'customer_id'   => $data['customer_id'],
+			'no_found_rows' => true,
+		)
+	);
+	if ( is_array( $email_addresses ) && in_array( $data['email'], array_column( $email_addresses, 'email' ), true ) ) {
+		return false;
+	}
 
 	// Instantiate a query object.
 	$customer_email_addresses = new EDD\Database\Queries\Customer_Email_Address();

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -753,13 +753,8 @@ function edd_add_customer_email_address( $data ) {
 	if ( empty( $data['customer_id'] ) ) {
 		return false;
 	}
-	$email_addresses = edd_get_customer_email_addresses(
-		array(
-			'customer_id'   => $data['customer_id'],
-			'no_found_rows' => true,
-		)
-	);
-	if ( is_array( $email_addresses ) && in_array( $data['email'], array_column( $email_addresses, 'email' ), true ) ) {
+	$exists = edd_get_customer_email_address_by( 'email', $data['email'] );
+	if ( $exists ) {
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #7822

This can be tested with this code:

```php
add_action( 'wp_head', function() {
	edd_add_customer_email_address( 
		array(
			'customer_id' => 142, // replace with a valid customer ID
			'email'       => 'Aurelio.Kogut@affwp.example', // replace with an email belonging to that customer
		) 
	);
} );
```
In `release/3.0` the above code will add a duplicate email address to the database; switch to this branch and that should no longer happen.