### PR TITLE
Use 'public' for token if key is public, otherwise set to empty string instead of null #7807

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -240,6 +240,10 @@ class Data_Migrator {
 				'_edd_log_time'       => '',
 			) );
 
+			if ( empty( $post_meta['_edd_log_token'] ) ) {
+				$post_meta['_edd_log_token'] = 'public' === $post_meta['_edd_log_key'] ? 'public' : '';
+			}
+
 			$log_data = array(
 				'ip'            => $post_meta['_edd_log_request_ip'],
 				'user_id'       => $post_meta['_edd_log_user'],


### PR DESCRIPTION
Fixes #7807

Proposed Changes:
1. If API request token is empty, but the key is `public`, then set the token to be `public` as well.
2. If API request token is empty, but the key is not `public`, then set the token to an empty string. This prevents database errors when the token was actually `null`.