### PR TITLE
issue/7464 - Optimize "Save Order" Routine

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -226,6 +226,8 @@ function edd_update_payment_details( $data = array() ) {
 	// Don't set the status in the update call (for back compat)
 	unset( $order_update_args['status'] );
 
+	do_action( 'edd_updated_edited_purchase', $order_id );
+
 	// Attempt to update the order
 	$updated = edd_update_order( $order_id, $order_update_args );
 

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -229,18 +229,16 @@ function edd_update_payment_details( $data = array() ) {
 	// Attempt to update the order
 	$updated = edd_update_order( $order_id, $order_update_args );
 
+	// Bail if an error occurred
+	if ( false === $updated ) {
+		wp_die( __( 'Error updating order.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 400 ) );
+	}
+
 	// Check if the status has changed, if so, we need to invoke the pertinent
 	// status processing method (for back compat)
 	if ( $new_status !== $order->status ) {
 		edd_update_order_status( $order_id, $new_status );
 	}
-
-	// Bail if an error occurred
-	if ( false === $updated ) {
-		wp_die( __( 'Error Updating Payment', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 400 ) );
-	}
-
-	do_action( 'edd_updated_edited_purchase', $order_id );
 
 	edd_redirect( edd_get_admin_url( array(
 		'page'        => 'edd-payment-history',

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -110,8 +110,6 @@ function edd_update_payment_details( $data = array() ) {
 	$date = edd_get_utc_equivalent_date( EDD()->utils->date( $date . ' ' . $hour . ':' . $minute . ':00', edd_get_timezone_id(), false ) );
 	$date = $date->format( 'Y-m-d H:i:s' );
 
-	// Address
-	$address = $data['edd_order_address'];
 	$order_update_args['date_created'] = $date;
 
 	// Customer
@@ -166,24 +164,10 @@ function edd_update_payment_details( $data = array() ) {
 		$previous_customer = new EDD_Customer( $curr_customer_id );
 	} elseif ( $curr_customer_id !== $new_customer_id ) {
 		$customer = new EDD_Customer( $new_customer_id );
-		$email    = $customer->email;
-		$name     = $customer->name;
 
 		$previous_customer = new EDD_Customer( $curr_customer_id );
 	} else {
 		$customer = new EDD_Customer( $curr_customer_id );
-		$email    = $customer->email;
-		$name     = $customer->name;
-	}
-
-	// Setup first and last name from input values.
-	$names      = explode( ' ', $name );
-	$first_name = ! empty( $names[0] ) ? $names[0] : '';
-	$last_name  = '';
-
-	if ( ! empty( $names[1] ) ) {
-		unset( $names[0] );
-		$last_name = implode( ' ', $names );
 	}
 
 	// Remove the stats and payment from the previous customer and attach it to the new customer
@@ -206,6 +190,20 @@ function edd_update_payment_details( $data = array() ) {
 	$order_update_args['user_id'] = $customer->user_id;
 	$order_update_args['email']   = $customer->email;
 
+	// Address
+	$address = $data['edd_order_address'];
+
+	// Setup first and last name from input values.
+	$name       = $customer->name;
+	$names      = explode( ' ', $name );
+	$first_name = ! empty( $names[0] ) ? $names[0] : '';
+	$last_name  = '';
+
+	if ( ! empty( $names[1] ) ) {
+		unset( $names[0] );
+		$last_name = implode( ' ', $names );
+	}
+
 	edd_update_order_address( absint( $address['address_id'] ), array(
 		'first_name'  => $first_name,
 		'last_name'   => $last_name,
@@ -217,6 +215,7 @@ function edd_update_payment_details( $data = array() ) {
 		'country'     => $address['country'],
 	) );
 
+	// Unlimited downloads.
 	if ( 1 === (int) $unlimited ) {
 		edd_update_order_meta( $order_id, 'unlimited_downloads', $unlimited );
 	} else {

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -225,8 +225,6 @@ function edd_update_payment_details( $data = array() ) {
 	// Don't set the status in the update call (for back compat)
 	unset( $order_update_args['status'] );
 
-	do_action( 'edd_updated_edited_purchase', $order_id );
-
 	// Attempt to update the order
 	$updated = edd_update_order( $order_id, $order_update_args );
 
@@ -240,6 +238,8 @@ function edd_update_payment_details( $data = array() ) {
 	if ( $new_status !== $order->status ) {
 		edd_update_order_status( $order_id, $new_status );
 	}
+
+	do_action( 'edd_updated_edited_purchase', $order_id );
 
 	edd_redirect( edd_get_admin_url( array(
 		'page'        => 'edd-payment-history',

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -231,21 +231,6 @@ function edd_update_payment_details( $data = array() ) {
 		edd_delete_order_meta( $order_id, 'unlimited_downloads' );
 	}
 
-	// Adjust total store earnings if the payment total has been changed
-	if ( $new_total !== $curr_total && ( 'complete' === $status || 'revoked' === $status ) ) {
-		if ( $new_total > $curr_total ) {
-
-			// Increase if our new total is higher
-			$difference = $new_total - $curr_total;
-			edd_increase_total_earnings( $difference );
-		} elseif ( $curr_total > $new_total ) {
-
-			// Decrease if our new total is lower
-			$difference = $curr_total - $new_total;
-			edd_decrease_total_earnings( $difference );
-		}
-	}
-
 	// Don't set the status in the update call (for back compat)
 	unset( $order_update_args['status'] );
 


### PR DESCRIPTION
Fixes #7464 

Proposed Changes:
1. Removes Order total/tax/amount related changes since those cannot change.
2. Groups some variables/processes together for better readability.
3. Avoid generating PHP errors when creating a new customer.