### PR TITLE
Set the object ID for order_notes when migrating via CLI

### DIFF
--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1065,6 +1065,7 @@ class EDD_CLI extends WP_CLI_Command {
 			$progress = new \cli\progress\Bar( 'Migrating Notes', $total );
 
 			foreach ( $results as $result ) {
+				$result->object_id = $result->comment_post_ID;
 				\EDD\Admin\Upgrades\v3\Data_Migrator::order_notes( $result );
 
 				$progress->tick();


### PR DESCRIPTION
Fixes #7829
