### PR TITLE
Remap missing EDD_Payments_Query arguments #7845

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -568,13 +568,22 @@ class EDD_Payments_Query extends EDD_Stats {
 		}
 
 		// Meta key and value
-		if ( isset( $this->initial_args['meta_key'] ) && isset( $this->initial_args['meta_value'] ) ) {
-			$arguments['meta_query'] = array(
-				array(
-					'key'   => $this->initial_args['meta_key'],
-					'value' => $this->initial_args['meta_value'],
-				),
+		if ( isset( $this->initial_args['meta_key'] ) ) {
+			$meta_query = array(
+				'key' => $this->initial_args['meta_key']
 			);
+
+			if ( isset( $this->initial_args['meta_value'] ) ) {
+				$meta_query['value'] = $this->initial_args['meta_value'];
+			}
+
+			$arguments['meta_query'] = array( $meta_query );
+		}
+
+		foreach ( array( 'year', 'month', 'week', 'day', 'hour', 'minute', 'second' ) as $date_interval ) {
+			if ( isset( $this->initial_args[ $date_interval ] ) ) {
+				$arguments['date_created_query'][ $date_interval ] = $this->initial_args[ $date_interval ];
+			}
 		}
 
 		if ( $this->args['start_date'] ) {
@@ -607,6 +616,14 @@ class EDD_Payments_Query extends EDD_Stats {
 			);
 
 			$arguments['date_created_query']['inclusive'] = true;
+		}
+
+		if ( isset( $this->initial_args['number'] ) ) {
+			if ( -1 == $this->initial_args['number'] ) {
+				$this->args['nopaging'] = true;
+			} else {
+				$arguments['number'] = $this->initial_args['number'];
+			}
 		}
 
 		$arguments['number'] = isset( $this->args['posts_per_page'] )

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -94,6 +94,7 @@ class EDD_Payments_Query extends EDD_Stats {
 			'download'        => null,
 			'gateway'         => null,
 			'post__in'        => null,
+			'post__not_in'    => null,
 			'compare'         => null,
 			'country'         => null,
 			'region'          => null,
@@ -690,6 +691,10 @@ class EDD_Payments_Query extends EDD_Stats {
 
 		if ( ! is_null( $this->args['post__in'] ) ) {
 			$arguments['id__in'] = $this->args['post__in'];
+		}
+
+		if ( ! is_null( $this->args['post__not_in'] ) ) {
+			$arguments['id__in'] = $this->args['post__not_in'];
 		}
 
 		if ( ! empty( $this->args['mode'] ) && 'all' !== $this->args['mode'] ) {

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -631,7 +631,9 @@ class EDD_Payments_Query extends EDD_Stats {
 			: 20;
 
 		if ( isset( $this->args['nopaging'] ) && true === $this->args['nopaging'] ) {
-			unset( $arguments['number'] );
+			// Setting to a really large number because we don't actually have a way to get all results.
+			// @todo Maybe trigger doing_it_wrong.
+			$arguments['number'] = 99999;
 		}
 
 		switch ( $this->args['orderby'] ) {


### PR DESCRIPTION
Fixes #7845

Proposed Changes:
1.`meta_key` can now be included without a corresponding `meta_value`.
2. Add support for "individual" date intervals: `array( 'year', 'month', 'week', 'day', 'hour', 'minute', 'second' ) `
3. Add support for `number`.
4. If `-1` is passed as `number` then `nopaging` is set to `true`.
5. If `nopaging` is set to `true` then this is meant to show all results. This was doing `unset( $arguments['number'] )` but the default in `edd_get_orders()` was then just being used instead, which was effectively setting the number to 30. So this has been adjusted to set the number to a really large integer instead.