### PR TITLE
Move Send Receipt Option to Top of Order

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -481,7 +481,17 @@ a.edd-delete:hover {
 	}
 }
 
-.download_page_edd-payment-history .edit-post-header #publishing-action {
+.download_page_edd-payment-history .edit-post-header .edit-post-header__toolbar {
+	order: 0;
+}
+
+.download_page_edd-payment-history .edit-post-header .edit-post-header__settings {
+	order: 1;
+}
+
+.download_page_edd-payment-history .edit-post-header #publishing-action,
+.download_page_edd-payment-history .edit-post-header .edit-post-header__toolbar,
+.download_page_edd-payment-history .edit-post-header .edit-post-header__settings {
 	display: flex;
 	align-items: center;
 }
@@ -542,7 +552,7 @@ a.edd-delete:hover {
 .order-customer-info .customer-details {
 	display: flex;
 	flex-direction: column;
-} 
+}
 
 .order-customer-info .customer-details .customer-since {
 	color: #666;

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -33,6 +33,15 @@ function edd_order_details_publish( $order ) {
 		<div class="edit-post-header">
 
 			<div class="edit-post-header__settings">
+				<?php if ( edd_is_add_order_page() ) : ?>
+					<div class="edd-send-purchase-receipt edd-admin-box-inside">
+						<label class="description label label--has-tip label--has-checkbox" for="edd-order-send-receipt">
+							<input type="checkbox" name="edd_order_send_receipt" id="edd-order-send-receipt" value="1" />
+							<?php esc_html_e( 'Send Purchase Receipt', 'easy-digital-downloads' ); ?>
+							<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Send Receipt</strong>: checking this box will send the purchase receipt to the selected customer.', 'easy-digital-downloads' ); ?>"></span>
+						</label>
+					</div>
+				<?php endif; ?>
 				<div id="publishing-action">
 					<span class="spinner"></span>
 					<input
@@ -803,16 +812,6 @@ function edd_order_details_extras( $order = false ) {
 						<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Unlimited Downloads</strong>: checking this box will override all other file download limits for this purchase, granting the customer unliimited downloads of all files included on the purchase.', 'easy-digital-downloads' ); ?>"></span>
 					</label>
 				</div>
-
-				<?php if ( edd_is_add_order_page() ) : ?>
-					<div class="edd-send-purchase-receipt edd-admin-box-inside">
-						<label class="description label label--has-tip label--has-checkbox" for="edd-order-send-receipt">
-							<input type="checkbox" name="edd_order_send_receipt" id="edd-order-send-receipt" value="1" />
-							<?php esc_html_e( 'Send Purchase Receipt', 'easy-digital-downloads' ); ?>
-							<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Send Receipt</strong>: checking this box will send the purchase receipt to the selected customer.', 'easy-digital-downloads' ); ?>"></span>
-						</label>
-					</div>
-				<?php endif; ?>
 
 				<?php do_action( 'edd_view_order_details_payment_meta_after', $order->id ); ?>
 			</div>

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -32,7 +32,22 @@ function edd_order_details_publish( $order ) {
 	<div class="edit-post-editor-regions__header">
 		<div class="edit-post-header">
 
-			<div>
+			<div class="edit-post-header__settings">
+				<div id="publishing-action">
+					<span class="spinner"></span>
+					<input
+						type="submit"
+						id="edd-order-submit"
+						class="button button-primary right"
+						value="<?php echo esc_html( $action_name ); ?>"
+						<?php if ( ! edd_is_add_order_page() ) : ?>
+							autofocus
+						<?php endif; ?>
+					/>
+				</div>
+			</div>
+
+			<div class="edit-post-header__toolbar">
 				<?php if ( ! edd_is_add_order_page() ) : ?>
 				<div id="delete-action">
 					<a href="<?php echo wp_nonce_url( add_query_arg( array(
@@ -42,13 +57,6 @@ function edd_order_details_publish( $order ) {
 							class="edd-delete-payment edd-delete"><?php esc_html_e( 'Delete Order', 'easy-digital-downloads' ); ?></a>
 				</div>
 				<?php endif; ?>
-			</div>
-
-			<div>
-				<div id="publishing-action">
-					<span class="spinner"></span>
-					<input type="submit" id="edd-order-submit" class="button button-primary right" value="<?php echo esc_html( $action_name ); ?>"/>
-				</div>
 			</div>
 
 		</div>
@@ -569,7 +577,7 @@ function edd_order_details_items( $order ) {
 
 	<?php do_action( 'edd_view_order_details_files_after', $order->id ); ?>
 
-	<?php
+<?php
 }
 
 /**

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -808,7 +808,7 @@ function edd_order_details_extras( $order = false ) {
 					<div class="edd-send-purchase-receipt edd-admin-box-inside">
 						<label class="description label label--has-tip label--has-checkbox" for="edd-order-send-receipt">
 							<input type="checkbox" name="edd_order_send_receipt" id="edd-order-send-receipt" value="1" />
-							<?php esc_html_e( 'Send Receipt', 'easy-digital-downloads' ); ?>
+							<?php esc_html_e( 'Send Purchase Receipt', 'easy-digital-downloads' ); ?>
 							<span alt="f223" class="edd-help-tip dashicons dashicons-editor-help" title="<?php _e( '<strong>Send Receipt</strong>: checking this box will send the purchase receipt to the selected customer.', 'easy-digital-downloads' ); ?>"></span>
 						</label>
 					</div>

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -34,7 +34,7 @@ function edd_order_details_publish( $order ) {
 
 			<div class="edit-post-header__settings">
 				<?php if ( edd_is_add_order_page() ) : ?>
-					<div class="edd-send-purchase-receipt edd-admin-box-inside">
+					<div class="edd-send-purchase-receipt">
 						<label class="description label label--has-tip label--has-checkbox" for="edd-order-send-receipt">
 							<input type="checkbox" name="edd_order_send_receipt" id="edd-order-send-receipt" value="1" />
 							<?php esc_html_e( 'Send Purchase Receipt', 'easy-digital-downloads' ); ?>


### PR DESCRIPTION
Fixes #7738  

Proposed Changes:
1. Changed label for email receipt
2. Moved send receipt checkbox to top of order page
3. Removed `edd-admin-box-inside` class from receipt b/c it gave unnecessary styling

