### PR TITLE
When migrating, use order date as address creation date if possible

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -52,17 +52,20 @@ class Data_Migrator {
 		) );
 
 		if ( $customer ) {
-			edd_add_customer_address( array(
-				'customer_id' => $customer->id,
-				'type'        => 'primary',
-				'name'        => $customer->name,
-				'address'     => $address['line1'],
-				'address2'    => $address['line2'],
-				'city'        => $address['city'],
-				'region'      => $address['state'],
-				'postal_code' => $address['zip'],
-				'country'     => $address['country'],
-			) );
+			edd_add_customer_address(
+				array(
+					'customer_id'  => $customer->id,
+					'type'         => 'primary',
+					'name'         => $customer->name,
+					'address'      => $address['line1'],
+					'address2'     => $address['line2'],
+					'city'         => $address['city'],
+					'region'       => $address['state'],
+					'postal_code'  => $address['zip'],
+					'country'      => $address['country'],
+					'date_created' => $customer->date_created,
+				)
+			);
 		}
 	}
 
@@ -80,12 +83,18 @@ class Data_Migrator {
 			return;
 		}
 
-		$customer_id = absint( $data->edd_customer_id );
+		$customer = edd_get_customer_by( 'user_id', absint( $data->edd_customer_id ) );
+		if ( ! $customer ) {
+			return;
+		}
 
-		edd_add_customer_email_address( array(
-			'customer_id' => $customer_id,
-			'email'       => $data->meta_value,
-		) );
+		edd_add_customer_email_address(
+			array(
+				'customer_id'  => $customer->id,
+				'email'        => $data->meta_value,
+				'date_created' => $customer->date_created,
+			)
+		);
 	}
 
 	/**

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -568,13 +568,23 @@ class Data_Migrator {
 		unset( $customer_address_data['first_name'] );
 		unset( $customer_address_data['last_name'] );
 
+		// If possible, set the order date as the address creation date.
+		$customer_address_data['date_created'] = $date_completed;
+
 		// Maybe add address to customer record.
 		edd_maybe_add_customer_address( $customer_id, $customer_address_data );
 
 		// Maybe add email address to customer record
 		if ( ! empty( $customer ) && $customer instanceof \EDD_Customer ) {
-			$primary = ( $customer->email === $purchase_email );
-			$customer->add_email( $purchase_email, $primary );
+			$type = ( $customer->email === $purchase_email ) ? 'primary' : 'secondary';
+			edd_add_customer_email_address(
+				array(
+					'customer_id'  => $customer_id,
+					'date_created' => $date_completed,
+					'email'        => $purchase_email,
+					'type'         => $type,
+				)
+			);
 		}
 
 		/** Migrate meta *********************************************/

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -565,7 +565,6 @@ class Data_Migrator {
 			'state'   => '',
 		) );
 
-		$address_created    = ! empty( $date_completed ) ? $date_completed : $date_created_gmt;
 		$order_address_data = array(
 			'order_id'     => $order_id,
 			'name'         => trim( $user_info['first_name'] . ' ' . $user_info['last_name'] ),
@@ -575,7 +574,7 @@ class Data_Migrator {
 			'region'       => isset( $user_info['address']['state'] )   ? $user_info['address']['state']   : '',
 			'country'      => isset( $user_info['address']['country'] ) ? $user_info['address']['country'] : '',
 			'postal_code'  => isset( $user_info['address']['zip'] )     ? $user_info['address']['zip']     : '',
-			'date_created' => $address_created,
+			'date_created' => $date_created_gmt,
 		);
 
 		// Remove empty data.
@@ -593,7 +592,7 @@ class Data_Migrator {
 		unset( $customer_address_data['last_name'] );
 
 		// If possible, set the order date as the address creation date.
-		$customer_address_data['date_created'] = $address_created;
+		$customer_address_data['date_created'] = $date_created_gmt;
 
 		// Maybe add address to customer record.
 		edd_maybe_add_customer_address( $customer_id, $customer_address_data );
@@ -604,7 +603,7 @@ class Data_Migrator {
 			edd_add_customer_email_address(
 				array(
 					'customer_id'  => $customer_id,
-					'date_created' => $address_created,
+					'date_created' => $date_created_gmt,
 					'email'        => $purchase_email,
 					'type'         => $type,
 				)

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -565,15 +565,17 @@ class Data_Migrator {
 			'state'   => '',
 		) );
 
+		$address_created    = ! empty( $date_completed ) ? $date_completed : $date_created_gmt;
 		$order_address_data = array(
-			'order_id'    => $order_id,
-			'name'        => trim( $user_info['first_name'] . ' ' . $user_info['last_name'] ),
-			'address'     => isset( $user_info['address']['line1'] )   ? $user_info['address']['line1']   : '',
-			'address2'    => isset( $user_info['address']['line2'] )   ? $user_info['address']['line2']   : '',
-			'city'        => isset( $user_info['address']['city'] )    ? $user_info['address']['city']    : '',
-			'region'      => isset( $user_info['address']['state'] )   ? $user_info['address']['state']   : '',
-			'country'     => isset( $user_info['address']['country'] ) ? $user_info['address']['country'] : '',
-			'postal_code' => isset( $user_info['address']['zip'] )     ? $user_info['address']['zip']     : '',
+			'order_id'     => $order_id,
+			'name'         => trim( $user_info['first_name'] . ' ' . $user_info['last_name'] ),
+			'address'      => isset( $user_info['address']['line1'] )   ? $user_info['address']['line1']   : '',
+			'address2'     => isset( $user_info['address']['line2'] )   ? $user_info['address']['line2']   : '',
+			'city'         => isset( $user_info['address']['city'] )    ? $user_info['address']['city']    : '',
+			'region'       => isset( $user_info['address']['state'] )   ? $user_info['address']['state']   : '',
+			'country'      => isset( $user_info['address']['country'] ) ? $user_info['address']['country'] : '',
+			'postal_code'  => isset( $user_info['address']['zip'] )     ? $user_info['address']['zip']     : '',
+			'date_created' => $address_created,
 		);
 
 		// Remove empty data.
@@ -591,7 +593,7 @@ class Data_Migrator {
 		unset( $customer_address_data['last_name'] );
 
 		// If possible, set the order date as the address creation date.
-		$customer_address_data['date_created'] = $date_completed;
+		$customer_address_data['date_created'] = $address_created;
 
 		// Maybe add address to customer record.
 		edd_maybe_add_customer_address( $customer_id, $customer_address_data );
@@ -602,7 +604,7 @@ class Data_Migrator {
 			edd_add_customer_email_address(
 				array(
 					'customer_id'  => $customer_id,
-					'date_created' => $date_completed,
+					'date_created' => $address_created,
 					'email'        => $purchase_email,
 					'type'         => $type,
 				)


### PR DESCRIPTION
Proposed changes:
1. When adding the customer address to the database, use the related order completion date as the address creation date
2. Change the way the email address is added to the database so the order completion date will be the email address creation date

If there is not an associated order, the creation date for the address record will be the migration date.

Fixes #7859