### PR TITLE
Removed `date_completed` from `edd_add_manual_order()`

### DIFF
--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -144,11 +144,6 @@ function edd_add_manual_order( $args = array() ) {
 		? 'test'
 		: 'live';
 
-	// Get completed date if publish
-	$completed = ( 'complete' === $data['edd-payment-status'] )
-		? $date
-		: '';
-
 	// Amounts
 	$order_subtotal = floatval( $data['subtotal'] );
 	$order_tax      = floatval( $data['tax'] );

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -171,7 +171,6 @@ function edd_add_manual_order( $args = array() ) {
 		'discount'       => $order_discount,
 		'total'          => $order_total,
 		'date_created'   => $date,
-		'date_completed' => $completed,
 	) );
 
 	// Attach order to the customer record.


### PR DESCRIPTION
Fixes #7864 

Proposed Changes:
1. Removed `date_completed` from `edd_add_manual_order()`, since that was keeping the `edd_complete_purchase` hook from sending a receipt
2. `edd_complete_purchase` already sets the date completed when called.

Tested by:
- Create a manual order, check email receipt and see if email is sent

Also, I confirmed that Order Details -> Notes is the same whether order is manual or from store.  Both types of orders show "Status changed from Pending to Complete" and "After payment actions processed."

I think this may fix EDD-Software-Licensing #[1629](https://github.com/easydigitaldownloads/EDD-Software-Licensing/issues/1629).  When I create an order with a license, I receive an email receipt and see a license key generated when I view the order.


