### PR TITLE
 edd-item-tab-wrapper rule changed to wildcard instead of div

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -3813,7 +3813,7 @@ body.download_page_edd-reports {
 	box-sizing: border-box;
 }
 
-div:not(#edd-item-tab-wrapper) + #edd-item-card-wrapper .item-section { /** [1] */
+*:not(#edd-item-tab-wrapper) + #edd-item-card-wrapper .item-section { /** [1] */
 	margin: 25px 0;
 	padding: 20px;
 	border: 1px solid #e5e5e5;


### PR DESCRIPTION
Fixes #7866 

Proposed Changes:
1. Changed `#edd-item-tab-wrapper` to use `*` instead of `div` to add more consistent padding

I'm still working on testing each instance of this `ids` use, but you all can probably find any issues before me anyway, since I haven't yet used `commissions` or `usage-tracking` yet.
