### PR TITLE
Change how order addresses are included in order exports #7878

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -120,10 +120,9 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 			/** @var EDD\Orders\Order $order */
 
 			$items        = $order->get_items();
-			$user_info    = $order->get_user_info();
-			$address      = $order->get_customer_address();
+			$address      = $order->get_address();
 			$total        = $order->total;
-			$user_id      = $order->id && $order->id != - 1 ? $order->id : $user_info['email'];
+			$user_id      = $order->id && $order->id != - 1 ? $order->id : $order->email;
 			$products     = '';
 			$products_raw = '';
 			$skus         = '';
@@ -196,14 +195,14 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 				'seq_id'       => $order->get_number(),
 				'email'        => $order->email,
 				'customer_id'  => $order->customer_id,
-				'first'        => isset( $user_info['first_name'] ) ? $user_info['first_name'] : '',
-				'last'         => isset( $user_info['last_name'] ) ? $user_info['last_name'] : '',
-				'address1'     => isset( $address['line1'] ) ? $address['line1'] : '',
-				'address2'     => isset( $address['line2'] ) ? $address['line2'] : '',
-				'city'         => isset( $address['city'] ) ? $address['city'] : '',
-				'state'        => isset( $address['state'] ) ? $address['state'] : '',
-				'country'      => isset( $address['country'] ) ? $address['country'] : '',
-				'zip'          => isset( $address['zip'] ) ? $address['zip'] : '',
+				'first'        => isset( $address->first_name ) ? $address->first_name : '',
+				'last'         => isset( $address->last_name ) ? $address->last_name : '',
+				'address1'     => isset( $address->address ) ? $address->address : '',
+				'address2'     => isset( $address->address2 ) ? $address->address2 : '',
+				'city'         => isset( $address->city ) ? $address->city : '',
+				'state'        => isset( $address->region ) ? $address->region : '',
+				'country'      => isset( $address->country ) ? $address->country : '',
+				'zip'          => isset( $address->postal_code ) ? $address->postal_code : '',
 				'products'     => $products,
 				'products_raw' => $products_raw,
 				'skus'         => $skus,
@@ -219,8 +218,8 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 				'ip'           => $order->ip,
 				'mode'         => $order->mode,
 				'status'       => $order->status,
-				'country_name' => isset( $user_info['address']['country'] ) ? edd_get_country_name( $user_info['address']['country'] ) : '',
-        'state_name'   => isset( $user_info['address']['state'] )   ? edd_get_state_name( $user_info['address']['country'], $user_info['address']['state'] ) : '',
+				'country_name' => isset( $address->country ) ? edd_get_country_name( $address->country ) : '',
+				'state_name'   => isset( $address->country ) && isset( $address->region ) ? edd_get_state_name( $address->country, $address->region ) : '',
 			);
 		}
 


### PR DESCRIPTION
Fixes #7878

Proposed Changes:
1. Gets customer name and address information from `$order->get_address()`