### PR TITLE
Remove number formatting & cast to float #7876

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-earnings-report.php
+++ b/includes/admin/reporting/export/class-batch-export-earnings-report.php
@@ -279,7 +279,7 @@ class EDD_Batch_Earnings_Report_Export extends EDD_Batch_Export {
 		foreach ( $totals as $row ) {
 			$total_data[ $row['status'] ] = array(
 				'count'  => $row['count'],
-				'amount' => edd_format_amount( $row['total'] )
+				'amount' => floatval( $row['total'] )
 			);
 		}
 


### PR DESCRIPTION
Fixes #7876

Proposed Changes:
1. Removes use of `edd_format_amount()`. That function is intended when a number is destined for _display_. It's not appropriate if any mathematical functions will be performed, which is the case here.