### PR TITLE
Exclude refunds from order exports

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -97,6 +97,7 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 			'status'  => $this->status,
 			'order'   => 'ASC',
 			'orderby' => 'date',
+			'type'    => 'sale',
 		);
 
 		if ( ! empty( $this->start ) || ! empty( $this->end ) ) {


### PR DESCRIPTION
Branched from #7879, which should be merged first.

Fixes #7880

Proposed Changes:
Sets `type` to `sale` in order exports.