### PR TITLE
Prevent extra content being added to exported CSV files

### DIFF
--- a/includes/admin/reporting/export/class-batch-export.php
+++ b/includes/admin/reporting/export/class-batch-export.php
@@ -285,7 +285,7 @@ class EDD_Batch_Export extends EDD_Export {
 
 		echo $file;
 
-		edd_die();
+		die();
 	}
 
 	/*


### PR DESCRIPTION
Fixes #7883

Proposed changes:
Replace `edd_die()` in the batch export class with `die`.