### PR TITLE
Load Localization Scripts

### DIFF
--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -96,6 +96,7 @@ add_action( 'init', 'edd_register_styles' );
  */
 function edd_load_scripts() {
 	edd_enqueue_scripts();
+	edd_localize_scripts();
 }
 add_action( 'wp_enqueue_scripts', 'edd_load_scripts' );
 
@@ -204,7 +205,6 @@ function edd_localize_scripts() {
 		) ) );
 	}
 }
-add_action( 'wp_enqueue_scripts', 'edd_localize_scripts' );
 
 /**
  * Load head styles


### PR DESCRIPTION
Fixes #7847 

Proposed Changes:
1. Called `edd_localize_script` inside of `edd_load_scripts`
2. Unhooked (removed hook?) for `edd_localize_script` from `wp_enqueue_scripts`
