### PR TITLE
Remove edd-admin-orders script from orders

### DIFF
--- a/includes/admin/payments/add-order.php
+++ b/includes/admin/payments/add-order.php
@@ -21,6 +21,10 @@ use EDD\Database\Rows\Order as Order;
  */
 function edd_add_order_page_content() {
 
+	wp_enqueue_script( 'edd-admin-orders' );
+	// Enqueued for backwards compatibility. Empty file.
+	wp_enqueue_script( 'edd-admin-payments' );
+
 	// Create empty order object to pass to callback functions.
 	$order = new Order( array(
 		'id'              => 0,

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -684,7 +684,6 @@ function edd_order_details_overview( $order ) {
 	}
 
 	wp_localize_script(
-		'edd-admin-orders',
 		'eddAdminOrderOverview',
 		array(
 			'items'        => $_items,

--- a/includes/admin/payments/orders.php
+++ b/includes/admin/payments/orders.php
@@ -684,6 +684,7 @@ function edd_order_details_overview( $order ) {
 	}
 
 	wp_localize_script(
+		'edd-admin-orders',
 		'eddAdminOrderOverview',
 		array(
 			'items'        => $_items,

--- a/includes/admin/payments/payments-history.php
+++ b/includes/admin/payments/payments-history.php
@@ -117,10 +117,6 @@ function edd_get_payment_view() {
  */
 function edd_payment_history_page() {
 
-	wp_enqueue_script( 'edd-admin-orders' );
-	// Enqueued for backwards compatibility. Empty file.
-	wp_enqueue_script( 'edd-admin-payments' );
-
 	// What are we viewing?
 	switch ( edd_get_payment_view() ) {
 

--- a/includes/admin/payments/view-order-details.php
+++ b/includes/admin/payments/view-order-details.php
@@ -23,17 +23,18 @@ if ( ! isset( $_GET['id'] ) || ! is_numeric( $_GET['id'] ) ) {
 	wp_die( __( 'Order ID not supplied. Please try again', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
 }
 
-wp_enqueue_script( 'edd-admin-orders' );
-// Enqueued for backwards compatibility. Empty file.
-wp_enqueue_script( 'edd-admin-payments' );
-
 $order_id = absint( $_GET['id'] );
 $order    = edd_get_order( $order_id );
 
 // Check that the order exists in the database.
 if ( empty( $order ) ) {
 	wp_die( __( 'The specified ID does not belong to an order. Please try again', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
-} ?>
+}
+
+wp_enqueue_script( 'edd-admin-orders' );
+// Enqueued for backwards compatibility. Empty file.
+wp_enqueue_script( 'edd-admin-payments' );
+?>
 
 <form id="edd-edit-order-form" method="post">
 

--- a/includes/admin/payments/view-order-details.php
+++ b/includes/admin/payments/view-order-details.php
@@ -18,6 +18,11 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.6
  * @since 3.0 Updated to use the new EDD\Orders\Order object.
  */
+
+wp_enqueue_script( 'edd-admin-orders' );
+// Enqueued for backwards compatibility. Empty file.
+wp_enqueue_script( 'edd-admin-payments' );
+
 if ( ! isset( $_GET['id'] ) || ! is_numeric( $_GET['id'] ) ) {
 	wp_die( __( 'Order ID not supplied. Please try again', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
 }

--- a/includes/admin/payments/view-order-details.php
+++ b/includes/admin/payments/view-order-details.php
@@ -19,13 +19,13 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0 Updated to use the new EDD\Orders\Order object.
  */
 
-wp_enqueue_script( 'edd-admin-orders' );
-// Enqueued for backwards compatibility. Empty file.
-wp_enqueue_script( 'edd-admin-payments' );
-
 if ( ! isset( $_GET['id'] ) || ! is_numeric( $_GET['id'] ) ) {
 	wp_die( __( 'Order ID not supplied. Please try again', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
 }
+
+wp_enqueue_script( 'edd-admin-orders' );
+// Enqueued for backwards compatibility. Empty file.
+wp_enqueue_script( 'edd-admin-payments' );
 
 $order_id = absint( $_GET['id'] );
 $order    = edd_get_order( $order_id );

--- a/includes/admin/payments/view-refund.php
+++ b/includes/admin/payments/view-refund.php
@@ -24,10 +24,6 @@ function edd_view_refund_page_content() {
 		wp_die( __( 'Refund ID not supplied. Please try again.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
 	}
 
-	wp_enqueue_script( 'edd-admin-orders' );
-	// Enqueued for backwards compatibility. Empty file.
-	wp_enqueue_script( 'edd-admin-payments' );
-
 	$refund_id = absint( $_GET['id'] );
 	$refund    = edd_get_order( $refund_id );
 
@@ -38,7 +34,12 @@ function edd_view_refund_page_content() {
 	}
 ?>
 
-<?php edd_refund_details_notice( $refund ); ?>
+	<?php
+	edd_refund_details_notice( $refund );
+	wp_enqueue_script( 'edd-admin-orders' );
+	// Enqueued for backwards compatibility. Empty file.
+	wp_enqueue_script( 'edd-admin-payments' );
+	?>
 
 <div class="wrap edd-wrap">
 

--- a/includes/admin/payments/view-refund.php
+++ b/includes/admin/payments/view-refund.php
@@ -18,6 +18,11 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0
  */
 function edd_view_refund_page_content() {
+
+	wp_enqueue_script( 'edd-admin-orders' );
+	// Enqueued for backwards compatibility. Empty file.
+	wp_enqueue_script( 'edd-admin-payments' );
+
 	// @todo Avoid killing page ouput.
 	if ( ! isset( $_GET['id'] ) || ! is_numeric( $_GET['id'] ) ) {
 		wp_die( __( 'Refund ID not supplied. Please try again.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );

--- a/includes/admin/payments/view-refund.php
+++ b/includes/admin/payments/view-refund.php
@@ -18,7 +18,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0
  */
 function edd_view_refund_page_content() {
-
 	// @todo Avoid killing page ouput.
 	if ( ! isset( $_GET['id'] ) || ! is_numeric( $_GET['id'] ) ) {
 		wp_die( __( 'Refund ID not supplied. Please try again.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
@@ -32,14 +31,13 @@ function edd_view_refund_page_content() {
 	if ( empty( $refund ) || 'refund' !== $refund->type ) {
 		wp_die( __( 'The specified ID does not belong to an refund. Please try again.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
 	}
-?>
 
-	<?php
-	edd_refund_details_notice( $refund );
 	wp_enqueue_script( 'edd-admin-orders' );
 	// Enqueued for backwards compatibility. Empty file.
 	wp_enqueue_script( 'edd-admin-payments' );
-	?>
+?>
+
+<?php edd_refund_details_notice( $refund ); ?>
 
 <div class="wrap edd-wrap">
 
@@ -101,7 +99,7 @@ function edd_view_refund_page_content() {
 						 * @param $refund_id ID of the current Refund.
 						 */
 						do_action( 'edd_view_refund_details_sidebar_before', $refund->id );
-	
+
 						// Attributes.
 						edd_refund_details_attributes( $refund );
 

--- a/includes/admin/payments/view-refund.php
+++ b/includes/admin/payments/view-refund.php
@@ -19,14 +19,14 @@ defined( 'ABSPATH' ) || exit;
  */
 function edd_view_refund_page_content() {
 
-	wp_enqueue_script( 'edd-admin-orders' );
-	// Enqueued for backwards compatibility. Empty file.
-	wp_enqueue_script( 'edd-admin-payments' );
-
 	// @todo Avoid killing page ouput.
 	if ( ! isset( $_GET['id'] ) || ! is_numeric( $_GET['id'] ) ) {
 		wp_die( __( 'Refund ID not supplied. Please try again.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ) );
 	}
+
+	wp_enqueue_script( 'edd-admin-orders' );
+	// Enqueued for backwards compatibility. Empty file.
+	wp_enqueue_script( 'edd-admin-payments' );
 
 	$refund_id = absint( $_GET['id'] );
 	$refund    = edd_get_order( $refund_id );


### PR DESCRIPTION
Fixes #7882 

Proposed Changes:
1. Remove `edd-admin-orders` script from orders

I don't quite understand the technicalities of what this is doing, but I can confirm that the JavaScript error has gone away in the console. 