### PR TITLE
Update admin tables' responsive CSS

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1105,7 +1105,6 @@ textarea[name="edd-note"] {
 }
 
 .wp-list-table.addresses .column-type,
-.wp-list-table.emails .column-type,
 .wp-list-table.posts .column-download_category,
 .wp-list-table.posts .column-download_tag,
 .wp-list-table.posts .column-price {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -3340,28 +3340,9 @@ body.download_page_edd-reports {
 #edd-item-tables-wrapper .no-items {
 	text-align: left;
 }
-#edd-item-tables-wrapper .column-actions {
-	width: 25%;
-}
-#edd-item-tables-wrapper .downloads tr > th:first-child,
-#edd-item-tables-wrapper .downloads tr > td:first-child,
-#edd-item-tables-wrapper .emails tr > th:first-child,
-#edd-item-tables-wrapper .emails tr > td:first-child  {
-	text-align: left;
-}
-#edd-item-tables-wrapper .downloads tr > td:only-child {
-	text-align: center;
-}
 #edd-item-tables-wrapper .emails .add-customer-email-row td {
 	background-color: #f4f4f4;
 	border-top: 1px solid #e5e5e5;
-}
-#edd-item-tables-wrapper .emails .primary-email-icon {
-	font-size: 14px;
-	line-height: 14px;
-	height: 14px;
-	width: 14px;
-	padding: 2px 0;
 }
 #edd-item-tables-wrapper .emails input {
 	vertical-align: middle;
@@ -3444,10 +3425,6 @@ body.download_page_edd-reports {
 		border-top: 1px solid #e5e5e5;
 		border-left: 0;
 		margin-top: -1px;
-	}
-	#edd-item-tables-wrapper .wp-list-table tbody tr:not(.inline-edit-row):not(.no-items) td.column-primary ~ td:not(.check-column) {
-		display: block;
-		padding-left: 10px;
 	}
 }
 @media screen and ( max-width: 656px ) {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -3340,6 +3340,14 @@ body.download_page_edd-reports {
 #edd-item-tables-wrapper .no-items {
 	text-align: left;
 }
+#edd-item-tables-wrapper .addresses tbody tr {
+	display: flex;
+	justify-content: flex-start;
+	flex-wrap: wrap;
+}
+#edd-item-tables-wrapper .addresses td:last-of-type {
+	display: none;
+}
 #edd-item-tables-wrapper .emails .add-customer-email-row td {
 	background-color: #f4f4f4;
 	border-top: 1px solid #e5e5e5;

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2216,6 +2216,15 @@ input[class*="edd-price-field"] {
 	.edd-refund-submit-line-total td:last-of-type {
 		flex: 0 0 120px;
 	}
+
+	#edd-item-tables-wrapper .addresses tbody tr {
+		display: flex;
+		justify-content: flex-start;
+		flex-wrap: wrap;
+	}
+	#edd-item-tables-wrapper .addresses td:last-of-type {
+		display: none;
+	}
 }
 
 @media screen and ( max-width: 600px ) {
@@ -3340,14 +3349,6 @@ body.download_page_edd-reports {
 #edd-item-tables-wrapper .no-items {
 	text-align: left;
 }
-#edd-item-tables-wrapper .addresses tbody tr {
-	display: flex;
-	justify-content: flex-start;
-	flex-wrap: wrap;
-}
-#edd-item-tables-wrapper .addresses td:last-of-type {
-	display: none;
-}
 #edd-item-tables-wrapper .emails .add-customer-email-row td {
 	background-color: #f4f4f4;
 	border-top: 1px solid #e5e5e5;
@@ -3363,7 +3364,6 @@ body.download_page_edd-reports {
 #edd-item-tables-wrapper .notice-error {
 	background-color: #fff5f5;
 }
-
 #edd-item-notes-wrapper {
 	min-height: 50px;
 }

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2173,6 +2173,49 @@ input[class*="edd-price-field"] {
 	.order-data-column input[type="email"] {
 		padding: 6px 10px;
 	}
+
+	.refunditems tr {
+		display: flex;
+	}
+
+	.refunditems tr.refunditem {
+		flex-wrap: wrap;
+	}
+
+	.refunditems td {
+		flex: 1 0 2.5em;
+	}
+
+	.refunditems tr.refunditem td:not(.check-column) {
+		flex-basis: calc(100% - 60px);
+	}
+
+	.refunditems tr.refunditem td:not(.check-column):not(.column-name) {
+		flex-basis: 100px;
+		display: inline-flex;
+		justify-content: flex-start;
+	}
+
+	.refunditems th:not(.column-name),
+	.refunditems tr.refunditem td.column-name:before {
+		display: none !important;
+	}
+
+	.refunditems tr.refunditem td:not(.check-column):not(.column-name):before {
+		position: relative;
+		display: inline-block;
+		margin-right: 10px;
+		left: unset;
+		width: unset;
+	}
+
+	.wp-list-table.refunditems .column-name {
+		width: 100%;
+	}
+
+	.edd-refund-submit-line-total td:last-of-type {
+		flex: 0 0 120px;
+	}
 }
 
 @media screen and ( max-width: 600px ) {

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -684,7 +684,7 @@ function edd_customers_view( $customer = null ) {
 		<table class="wp-list-table widefat striped addresses">
 			<thead>
 				<tr>
-					<th><?php esc_html_e( 'Address',     'easy-digital-downloads' ); ?></th>
+					<th class="column-primary"><?php esc_html_e( 'Address',     'easy-digital-downloads' ); ?></th>
 					<th><?php esc_html_e( 'City',        'easy-digital-downloads' ); ?></th>
 					<th><?php esc_html_e( 'Region',      'easy-digital-downloads' ); ?></th>
 					<th><?php esc_html_e( 'Postal Code', 'easy-digital-downloads' ); ?></th>
@@ -762,8 +762,8 @@ function edd_customers_view( $customer = null ) {
 		<table class="wp-list-table widefat striped emails">
 			<thead>
 				<tr>
-					<th class="column-primary"><?php esc_html_e( 'Email',   'easy-digital-downloads' ); ?></th>
-					<th class="column-actions"><?php esc_html_e( 'Actions', 'easy-digital-downloads' ); ?></th>
+					<th><?php esc_html_e( 'Email',   'easy-digital-downloads' ); ?></th>
+					<th><?php esc_html_e( 'Actions', 'easy-digital-downloads' ); ?></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -698,7 +698,7 @@ function edd_customers_view( $customer = null ) {
 				foreach ( $addresses as $address ) : ?>
 
 					<tr data-id="<?php echo esc_attr( $address->id ); ?>">
-						<td class="column-primary">
+						<td>
 							<?php
 							echo ! empty( $address->address )
 								? esc_html( $address->address )

--- a/includes/admin/payments/class-refund-items-table.php
+++ b/includes/admin/payments/class-refund-items-table.php
@@ -124,7 +124,7 @@ class Refund_Items_Table extends List_Table {
 	 * @return string Name of the primary column.
 	 */
 	protected function get_primary_column_name() {
-		return 'name';
+		return '';
 	}
 
 	/**
@@ -333,6 +333,7 @@ class Refund_Items_Table extends List_Table {
 		$classes = array_map( 'sanitize_html_class', array(
 			'order-' . $item->order_id,
 			$item->status,
+			'refunditem',
 		) );
 
 		// Turn into a string.


### PR DESCRIPTION
Fixes #7922

Proposed Changes:
1. Update the refund modal for smaller screens (iPads and lower). The WP Core primary column toggle doesn't work with the modal, so that has been removed, and the table CSS overridden to display necessary data on small screens. (It will look better in conjunction with PR #7899, but is not required.)
2. Fix the customer details physical address table to display only the primary column, although this feels awkward because just the street address doesn't feel helpful. Reworking to be more like the refund modal might make more sense.
3. Remove the primary column from the customer emails table (this was added in 3.0 but should not have been, as it hides the ability to remove emails on smaller screens).
