### PR TITLE
Update bulk actions for trashed orders

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -659,6 +659,10 @@ function edd_orders_list_table_process_bulk_actions() {
 			case 'resend-receipt':
 				edd_email_purchase_receipt( $id, false );
 				break;
+
+			case 'delete':
+				edd_destroy_order( $id );
+				break;
 		}
 
 		do_action( 'edd_payments_table_do_bulk_action', $id, $action );

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -658,7 +658,7 @@ class EDD_Payment_History_Table extends List_Table {
 			$action['restore'] = __( 'Restore', 'easy-digital-downloads' );
 			$action['delete']  = __( 'Delete Permanently', 'easy-digital-downloads' );
 		} else {
-			$action['trash'] = __( 'Trash', 'easy-digital-downloads' );
+			$action['trash'] = __( 'Move to Trash', 'easy-digital-downloads' );
 		}
 
 		return apply_filters( 'edd_payments_table_bulk_actions', $action );

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -637,7 +637,7 @@ class EDD_Payment_History_Table extends List_Table {
 	 * @return array $actions Bulk actions.
 	 */
 	public function get_bulk_actions() {
-		if ( 'refund' !== $this->type ) {
+		if ( 'refund' !== $this->type && 'trash' !== $this->get_status() ) {
 			$action = array(
 				'set-status-complete'     => __( 'Mark Completed',   'easy-digital-downloads' ),
 				'set-status-pending'     => __( 'Mark Pending',     'easy-digital-downloads' ),
@@ -656,6 +656,7 @@ class EDD_Payment_History_Table extends List_Table {
 
 		if ( 'trash' === $this->get_status() ) {
 			$action['restore'] = __( 'Restore', 'easy-digital-downloads' );
+			$action['delete']  = __( 'Delete Permanently', 'easy-digital-downloads' );
 		} else {
 			$action['trash'] = __( 'Trash', 'easy-digital-downloads' );
 		}

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -901,6 +901,9 @@ class EDD_Payment_History_Table extends List_Table {
 		$this->items = $this->get_data();
 
 		$this->_column_headers = array( $columns, $hidden, $sortable );
+		if ( empty( $this->counts[ $status ] ) ) {
+			return;
+		}
 
 		$this->set_pagination_args( array(
 			'total_pages' => ceil( $this->counts[ $status ] / $this->per_page ),


### PR DESCRIPTION
Fixes #7937

Proposed Changes:
1. Changes the bulk actions list when viewing trashed orders.
2. Removes pagination if no orders match the current status.
