### PR TITLE
Fix download pie chart report queries

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -486,9 +486,6 @@ function edd_register_downloads_report( $reports ) {
 		$download       = edd_get_download();
 		$prices         = array();
 
-		$country = Reports\get_filter_value( 'countries' );
-		$region  = Reports\get_filter_value( 'regions' );
-
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
 			$prices   = $download->get_prices();
@@ -499,30 +496,6 @@ function edd_register_downloads_report( $reports ) {
 				$download_label = esc_html( ' (' . $download->post_title . ': ' . $prices[0]['name'] . ')' );
 			} else {
 				$download_label = esc_html( ' (' . $download->post_title . ')' );
-			}
-
-			if ( ! empty( $download_label ) ) {
-				$location = '';
-
-				if ( ! empty( $country ) && 'all' !== $country ) {
-					$location = ' ' . __( 'for', 'easy-digital-downloads' ) . ' ';
-
-					if ( ! empty( $region ) && 'all' !== $region ) {
-						$location .= edd_get_state_name( $country, $region ) . ', ';
-					}
-
-					$location .= edd_get_country_name( $country );
-				}
-
-				$country = 'all' !== $country
-					? $country
-					: '';
-
-				$region = 'all' !== $region
-					? $region
-					: '';
-
-				$endpoint_label .= $location;
 			}
 		}
 
@@ -577,7 +550,7 @@ function edd_register_downloads_report( $reports ) {
 				'charts' => $charts,
 				'tables' => $tables,
 			),
-			'filters'  => array( 'products', 'countries', 'regions', 'taxes' )
+			'filters'   => array( 'products', 'taxes' ),
 		) );
 
 		$reports->register_endpoint( 'most_valuable_download', array(
@@ -640,14 +613,12 @@ function edd_register_downloads_report( $reports ) {
 			'label' => $endpoint_label,
 			'views' => array(
 				'tile' => array(
-					'data_callback' => function () use ( $download_data, $country, $region, $dates ) {
+					'data_callback' => function () use ( $download_data, $dates ) {
 						$stats = new EDD\Stats( array(
 							'product_id' => absint( $download_data['download_id'] ),
 							'price_id'   => absint( $download_data['price_id'] ),
 							'range'      => $dates['range'],
 							'output'     => 'formatted',
-							'country'    => $country,
-							'region'     => $region
 						) );
 
 						$earnings = $stats->get_order_item_earnings();
@@ -690,14 +661,12 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Sales by Variation', 'easy-digital-downloads' ) . $download_label,
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function() use ( $download_data, $download, $dates, $country, $region ) {
+					'data_callback' => function() use ( $download_data, $download, $dates ) {
 						$stats = new EDD\Stats();
 						$sales = $stats->get_order_item_count( array(
 							'product_id' => absint( $download_data['download_id'] ),
 							'range'      => $dates['range'],
 							'grouped'    => true,
-							'country'    => $country,
-							'region'     => $region
 						) );
 
 						$prices = $download->get_prices();
@@ -743,14 +712,12 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Earnings by Variation', 'easy-digital-downloads' ) . $download_label,
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function() use ( $download_data, $prices, $dates, $country, $region ) {
+					'data_callback' => function() use ( $download_data, $prices, $dates ) {
 						$stats = new EDD\Stats();
 						$earnings = $stats->get_order_item_earnings( array(
 							'product_id' => absint( $download_data['download_id'] ),
 							'range'      => $dates['range'],
 							'grouped'    => true,
-							'country'    => $country,
-							'region'     => $region
 						) );
 
 						// Set all values to 0.
@@ -794,7 +761,7 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Sales and Earnings', 'easy-digital-downloads' ) . esc_html( $download_label ),
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function () use ( $download_data, $country, $region ) {
+					'data_callback' => function () use ( $download_data ) {
 						global $wpdb;
 
 						$dates        = Reports\get_dates_filter( 'objects' );

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -690,12 +690,14 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Sales by Variation', 'easy-digital-downloads' ) . $download_label,
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function() use ( $download_data, $download, $dates ) {
+					'data_callback' => function() use ( $download_data, $download, $dates, $country, $region ) {
 						$stats = new EDD\Stats();
 						$sales = $stats->get_order_item_count( array(
 							'product_id' => absint( $download_data['download_id'] ),
 							'range'      => $dates['range'],
 							'grouped'    => true,
+							'country'    => $country,
+							'region'     => $region
 						) );
 
 						$prices = $download->get_prices();
@@ -741,12 +743,14 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Earnings by Variation', 'easy-digital-downloads' ) . $download_label,
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function() use ( $download_data, $prices, $dates ) {
+					'data_callback' => function() use ( $download_data, $prices, $dates, $country, $region ) {
 						$stats = new EDD\Stats();
 						$earnings = $stats->get_order_item_earnings( array(
 							'product_id' => absint( $download_data['download_id'] ),
 							'range'      => $dates['range'],
 							'grouped'    => true,
+							'country'    => $country,
+							'region'     => $region
 						) );
 
 						// Set all values to 0.
@@ -790,7 +794,7 @@ function edd_register_downloads_report( $reports ) {
 			'label' => __( 'Sales and Earnings', 'easy-digital-downloads' ) . esc_html( $download_label ),
 			'views' => array(
 				'chart' => array(
-					'data_callback' => function () use ( $download_data ) {
+					'data_callback' => function () use ( $download_data, $country, $region ) {
 						global $wpdb;
 
 						$dates        = Reports\get_dates_filter( 'objects' );

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2581,7 +2581,7 @@ class Stats {
 
 		$country = isset( $this->query_vars['country'] )
 			? sanitize_text_field( $this->query_vars['country'] )
-			: edd_get_shop_country();
+			: '';
 
 		// Maybe convert country code to country name.
 		$country = in_array( $country, array_flip( $country_list ), true )
@@ -2603,7 +2603,7 @@ class Stats {
 
 		$state = isset( $this->query_vars['region'] )
 			? sanitize_text_field( $this->query_vars['region'] )
-			: edd_get_shop_state();
+			: '';
 
 		// Only parse state if one was passed.
 		if ( $state ) {

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2577,28 +2577,29 @@ class Stats {
 
 		/** Parse country ****************************************************/
 
-		$country_list = array_filter( edd_get_country_list() );
-
 		$country = isset( $this->query_vars['country'] )
 			? sanitize_text_field( $this->query_vars['country'] )
 			: '';
 
-		// Maybe convert country code to country name.
-		$country = in_array( $country, array_flip( $country_list ), true )
-			? $country_list[ $country ]
-			: $country;
+		if ( $country ) {
+			$country_list = array_filter( edd_get_country_list() );
 
-		// Ensure a valid county has been passed.
-		$country = in_array( $country, $country_list, true )
-			? $country
-			: null;
+			// Maybe convert country code to country name.
+			$country = in_array( $country, array_flip( $country_list ), true )
+				? $country_list[ $country ]
+				: $country;
 
-		// Convert back to country code for SQL query.
-		$country_list                = array_flip( $country_list );
-		$this->query_vars['country'] = is_null( $country )
-			? ''
-			: $country_list[ $country ];
+			// Ensure a valid county has been passed.
+			$country = in_array( $country, $country_list, true )
+				? $country
+				: null;
 
+			// Convert back to country code for SQL query.
+			$country_list                = array_flip( $country_list );
+			$this->query_vars['country'] = is_null( $country )
+				? ''
+				: $country_list[ $country ];
+		}
 		/** Parse state ******************************************************/
 
 		$state = isset( $this->query_vars['region'] )

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2576,7 +2576,6 @@ class Stats {
 		}
 
 		/** Parse country ****************************************************/
-
 		$country = isset( $this->query_vars['country'] )
 			? sanitize_text_field( $this->query_vars['country'] )
 			: '';
@@ -2600,6 +2599,7 @@ class Stats {
 				? ''
 				: $country_list[ $country ];
 		}
+
 		/** Parse state ******************************************************/
 
 		$state = isset( $this->query_vars['region'] )


### PR DESCRIPTION
Fixes #7919

Proposed Changes:
1. Changes default region/country for the `Stats` class to be an empty string, not the shop region/country
2. Updates the country parsing logic to match the state

I don't know why this was affecting pie charts (download sales/earnings) and did not seem to be affecting other queries, but I tracked the reported issue down to the database query erroneously setting the state and country (none were selected).

To test, make sure your store has products with variations, and has a base state/region and country set. Create orders for the variations, hopefully with addresses not matching the shop state/region. In release/3.0, pie graphs should be broken; this PR should fix them.

Since the fix is in where the query is being parsed, this may have deeper ramifications I'm not aware of, so extra insight would be appreciated.