### PR TITLE
Update chosen select widths

### DIFF
--- a/assets/css/edd-admin-chosen.css
+++ b/assets/css/edd-admin-chosen.css
@@ -246,8 +246,12 @@
 }
 
 .edd-select-chosen {
-	width: 100% !important;
+	width: 100%;
 	max-width: 300px;
+}
+
+.edd-select-chosen.edd-customer-select {
+	width: 100% !important;
 }
 
 .edd-select-chosen.edd-time {


### PR DESCRIPTION
Resolves super narrow select issues when the first option has a short
label. Adds an override for the customer dropdown on the orders screens.

Fixes #7953