### PR TITLE
Add 4 new values to sales REST endpoint

### DIFF
--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -390,7 +390,7 @@ class EDD_API_V2 extends EDD_API_V1 {
 
 				$sales['sales'][ $i ]['ID']             = $payment->number;
 				$sales['sales'][ $i ]['mode']           = $payment->mode;
-				$sales['sales'][ $i ]['status']         = $payment->status_nicename;
+				$sales['sales'][ $i ]['status']         = $payment->status;
 				$sales['sales'][ $i ]['transaction_id'] = ( ! empty( $payment->transaction_id ) ) ? $payment->transaction_id : null;
 				$sales['sales'][ $i ]['key']            = $payment->key;
 				$sales['sales'][ $i ]['subtotal']       = $payment->subtotal;

--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -389,6 +389,8 @@ class EDD_API_V2 extends EDD_API_V1 {
 				$user_info    = $payment->user_info;
 
 				$sales['sales'][ $i ]['ID']             = $payment->number;
+				$sales['sales'][ $i ]['mode']           = $payment->mode;
+				$sales['sales'][ $i ]['status']         = $payment->status_nicename;
 				$sales['sales'][ $i ]['transaction_id'] = ( ! empty( $payment->transaction_id ) ) ? $payment->transaction_id : null;
 				$sales['sales'][ $i ]['key']            = $payment->key;
 				$sales['sales'][ $i ]['subtotal']       = $payment->subtotal;
@@ -396,6 +398,8 @@ class EDD_API_V2 extends EDD_API_V1 {
 				$sales['sales'][ $i ]['fees']           = ( ! empty( $payment->fees ) ? $payment->fees : null );
 				$sales['sales'][ $i ]['total']          = $payment->total;
 				$sales['sales'][ $i ]['gateway']        = $payment->gateway;
+				$sales['sales'][ $i ]['customer_id']    = $payment->customer_id;
+				$sales['sales'][ $i ]['user_id']        = $payment->user_id;
 				$sales['sales'][ $i ]['email']          = $payment->email;
 				$sales['sales'][ $i ]['date']           = $payment->date;
 


### PR DESCRIPTION
Building out a data pipeline for extracting and combining data from our store, support inbox, email list, other plugins/EDD extensions, and others to build out reports. However, we need some additional data points in the sales endpoint.

Proposed Changes:
1. To be able to ensure correct joins with data from other plugins, we need user ID.
2. To ensure we are only building reports on our live data, we need the mode.
3. To combine data with other EDD reports, it would be useful to have customer ID.
4. We will also be adding in other payments with different statuses through some of the filters, such as from the Recurring Payments extension, so we need to be able to see Complete vs Renewal statuses.

Here they are in the response after adding these fields on a local test site:
![example-edd-sales](https://user-images.githubusercontent.com/9730040/82734902-e3201680-9ceb-11ea-9c54-1892a10972b3.png)


_Please do not submit PRs with minified CSS or JS files. This is managed at the time of release by the Core Team_
