### PR TITLE
implode(): Passing glue string after array is deprecated.

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -279,7 +279,7 @@ function edd_purchase_variable_pricing( $download_id = 0, $args = array() ) {
 	), $download_id );
 
 	// Sanitize those class names and form them into a string
-	$css_classes_string = implode( array_map( 'sanitize_html_class', $css_classes_array ), ' ' );
+	$css_classes_string = implode( ' ', array_map( 'sanitize_html_class', $css_classes_array ) );
 
 	if ( edd_item_in_cart( $download_id ) && ! edd_single_price_option_mode( $download_id ) ) {
 		return;


### PR DESCRIPTION
Fixes #
Since PHP 7.4 implode(): Passing glue string after the array is deprecated. So, I fixed with swapping the arguments.
