### PR TITLE
Report Tiles Incorrect #7921

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2312,6 +2312,8 @@ function edd_register_customer_report( $reports ) {
 				'tiles'  => array(
 					'lifetime_value_of_customer',
 					'average_customer_value',
+					// this line removes tile
+					'average_number_of_orders_per_customer',
 					'customer_average_age',
 					'most_valuable_customer',
 				),

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2312,7 +2312,6 @@ function edd_register_customer_report( $reports ) {
 				'tiles'  => array(
 					'lifetime_value_of_customer',
 					'average_customer_value',
-					'average_number_of_orders_per_customer',
 					'customer_average_age',
 					'most_valuable_customer',
 				),

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2311,9 +2311,8 @@ function edd_register_customer_report( $reports ) {
 			'endpoints' => array(
 				'tiles'  => array(
 					'lifetime_value_of_customer',
-					'average_customer_value',
 					'average_number_of_orders_per_customer',
-					'most_valuable_customer',
+					'average_customer_value',
 				),
 				'tables' => array(
 					'top_five_customers',

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2312,9 +2312,7 @@ function edd_register_customer_report( $reports ) {
 				'tiles'  => array(
 					'lifetime_value_of_customer',
 					'average_customer_value',
-					// this line removes tile
 					'average_number_of_orders_per_customer',
-					'customer_average_age',
 					'most_valuable_customer',
 				),
 				'tables' => array(
@@ -2373,20 +2371,6 @@ function edd_register_customer_report( $reports ) {
 						return apply_filters( 'edd_reports_customers_average_order_count', $stats->get_customer_order_count( array(
 							'function' => 'AVG',
 						) ) );
-					},
-				),
-			),
-		) );
-
-		$reports->register_endpoint( 'customer_average_age', array(
-			'label' => __( 'Average Age', 'easy-digital-downloads' ),
-			'views' => array(
-				'tile' => array(
-					'data_callback' => function () {
-						global $wpdb;
-						$average_value = (int) $wpdb->get_var( "SELECT AVG(DATEDIFF(NOW(), date_created)) AS average FROM {$wpdb->edd_customers}" );
-
-						return apply_filters( 'edd_reports_customers_average_age', $average_value . ' ' . __( 'days', 'easy-digital-downloads' ) );
 					},
 				),
 			),

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2086,7 +2086,6 @@ class Stats {
 	 * @return int Number of orders made by a customer.
 	 */
 	public function get_customer_order_count( $query = array() ) {
-
 		// Add table and column name to query_vars to assist with date query generation.
 		$this->query_vars['table']             = $this->get_db()->edd_orders;
 		$this->query_vars['column']            = 'id';
@@ -2115,19 +2114,14 @@ class Stats {
 			: '';
 
 		if ( 'AVG' === $function ) {
-			$sql = "SELECT COUNT(id) / total_customers AS average
+			$sql = "SELECT COUNT(id) / COUNT(DISTINCT customer_id) AS average
 					FROM {$this->query_vars['table']}
-					CROSS JOIN (
-						SELECT COUNT(DISTINCT customer_id) AS total_customers
-						FROM {$this->query_vars['table']}
-					) o
 					WHERE 1=1 {$this->query_vars['status_sql']} {$user} {$customer} {$email} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		} else {
 			$sql = "SELECT COUNT(id)
 					FROM {$this->query_vars['table']}
 					WHERE 1=1 {$this->query_vars['status_sql']} {$user} {$customer} {$email} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		}
-
 		$result = $this->get_db()->get_var( $sql );
 
 		$total = null === $result

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2096,7 +2096,7 @@ class Stats {
 		$this->pre_query( $query );
 
 		// Only `COUNT` and `AVG` are accepted by this method.
-		$accepted_functions = array( 'COUNT', 'AVG' );
+		$accepted_functions = array( 'COUNT', 'AVG(id)' );
 
 		$function = isset( $this->query_vars['function'] ) && in_array( strtoupper( $this->query_vars['function'] ), $accepted_functions, true )
 			? $this->query_vars['function'] . "({$this->query_vars['column']})"
@@ -2114,7 +2114,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND email = %s', sanitize_email( $this->query_vars['email'] ) )
 			: '';
 
-		if ( 'AVG' === $function ) {
+		if ( 'AVG(id)' === $function ) {
 			$sql = "SELECT COUNT(id) / total_customers AS average
 					FROM {$this->query['table']}
 					CROSS JOIN (
@@ -2136,7 +2136,6 @@ class Stats {
 
 		// Reset query vars.
 		$this->post_query();
-
 		return $total;
 	}
 

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2116,10 +2116,10 @@ class Stats {
 
 		if ( 'AVG' === $function ) {
 			$sql = "SELECT COUNT(id) / total_customers AS average
-					FROM {$this->query['table']}
+					FROM {$this->query_vars['table']}
 					CROSS JOIN (
 						SELECT COUNT(DISTINCT customer_id) AS total_customers
-						FROM {$this->query['table']}
+						FROM {$this->query_vars['table']}
 					) o
 					WHERE 1=1 {$this->query_vars['status_sql']} {$user} {$customer} {$email} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		} else {

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2096,7 +2096,7 @@ class Stats {
 		$this->pre_query( $query );
 
 		// Only `COUNT` and `AVG` are accepted by this method.
-		$accepted_functions = array( 'COUNT', 'AVG(id)' );
+		$accepted_functions = array( 'COUNT', 'AVG' );
 
 		$function = isset( $this->query_vars['function'] ) && in_array( strtoupper( $this->query_vars['function'] ), $accepted_functions, true )
 			? $this->query_vars['function'] . "({$this->query_vars['column']})"
@@ -2114,7 +2114,7 @@ class Stats {
 			? $this->get_db()->prepare( 'AND email = %s', sanitize_email( $this->query_vars['email'] ) )
 			: '';
 
-		if ( 'AVG(id)' === $function ) {
+		if ( 'AVG' === $function ) {
 			$sql = "SELECT COUNT(id) / total_customers AS average
 					FROM {$this->query['table']}
 					CROSS JOIN (

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -2099,8 +2099,8 @@ class Stats {
 		$accepted_functions = array( 'COUNT', 'AVG' );
 
 		$function = isset( $this->query_vars['function'] ) && in_array( strtoupper( $this->query_vars['function'] ), $accepted_functions, true )
-			? $this->query_vars['function'] . "({$this->query_vars['column']})"
-			: 'COUNT(id)';
+			? strtoupper( $this->query_vars['function'] )
+			: '';
 
 		$user = isset( $this->query_vars['user_id'] )
 			? $this->get_db()->prepare( 'AND user_id = %d', absint( $this->query_vars['user_id'] ) )
@@ -2123,7 +2123,7 @@ class Stats {
 					) o
 					WHERE 1=1 {$this->query_vars['status_sql']} {$user} {$customer} {$email} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		} else {
-			$sql = "SELECT {$function}
+			$sql = "SELECT COUNT(id)
 					FROM {$this->query_vars['table']}
 					WHERE 1=1 {$this->query_vars['status_sql']} {$user} {$customer} {$email} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}";
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1911,6 +1911,12 @@
 					"requires": {
 						"type-fest": "^0.8.1"
 					}
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@1.19.1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
+					"dev": true
 				}
 			}
 		},
@@ -1997,6 +2003,12 @@
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
+				},
+				"prettier": {
+					"version": "npm:wp-prettier@1.19.1",
+					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
+					"dev": true
 				}
 			}
 		},
@@ -2027,7 +2039,7 @@
 		"abbrev": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
 			"dev": true
 		},
 		"accepts": {
@@ -2875,7 +2887,7 @@
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
@@ -7156,7 +7168,7 @@
 		"grunt-contrib-cssmin": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/grunt-contrib-cssmin/-/grunt-contrib-cssmin-2.2.1.tgz",
-			"integrity": "sha512-IXNomhQ5ekVZbDbj/ik5YccoD9khU6LT2fDXqO1+/Txjq8cp0tQKjVS8i8EAbHOrSDkL7/UD6A7b+xj98gqh9w==",
+			"integrity": "sha1-ZMvr5gE0vBJwykFUUU7EAHzBb38=",
 			"dev": true,
 			"requires": {
 				"chalk": "^1.0.0",
@@ -9727,7 +9739,7 @@
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
@@ -11331,12 +11343,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
-		},
-		"prettier": {
-			"version": "npm:wp-prettier@1.19.1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -14043,7 +14049,7 @@
 		"tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
 			"dev": true,
 			"requires": {
 				"os-tmpdir": "~1.0.2"


### PR DESCRIPTION
Fixes #7921 

Proposed Changes:
1. I removed the `Average Age` tile and endpoint based on [this comment](https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7921#issuecomment-630328620)
2. Changed name of the `$accepted_functions` argument to match the name of the AVG function name

**Steps to reproduce the behavior**
Visit Downloads > Reports > Customers
   - Average customer age should be gone
   - Average number of orders should be correct

I don't have a ton of customer data to pull from, but I _think_ the average number of orders is correct.  Please check in your own stores.  If it is not correct, I can just pull out the tile until I / we can figure out where that number is going sideways.
