### PR TITLE
Removing unnecessary adjustment meta for the download_id and price_ids it is stored in the adjustments table columns already. #7305

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -830,24 +830,6 @@ class Data_Migrator {
 							$refund_adjustment_id = edd_add_order_adjustment( $refund_adjustment_args );
 							edd_add_order_adjustment_meta( $refund_adjustment_id, 'fee_id', $fee_id );
 						}
-
-						// Maybe store download ID.
-						if ( isset( $fee['download_id'] ) && ! empty( $fee['download_id'] ) ) {
-							edd_add_order_adjustment_meta( $adjustment_id, 'download_id', $fee['download_id'] );
-
-							if ( ! empty( $refund_adjustment_id ) ) {
-								edd_add_order_adjustment_meta( $refund_adjustment_id, 'download_id', $fee['download_id'] );
-							}
-						}
-
-						// Maybe store price ID.
-						if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-							edd_add_order_adjustment_meta( $adjustment_id, 'price_id', $fee['price_id'] );
-
-							if ( ! empty( $refund_adjustment_id ) ) {
-								edd_add_order_adjustment_meta( $refund_adjustment_id, 'price_id', $fee['price_id'] );
-							}
-						}
 					}
 				}
 			}
@@ -965,24 +947,6 @@ class Data_Migrator {
 					$refund_adjustment_args['total']    = edd_negate_amount( floatval( $fee['amount'] ) + $tax );
 
 					$refund_adjustment_id = edd_add_order_adjustment( $refund_adjustment_args );
-				}
-
-				// Maybe store download ID.
-				if ( isset( $fee['download_id'] ) && ! empty( $fee['download_id'] ) ) {
-					edd_add_order_adjustment_meta( $adjustment_id, 'download_id', $fee['download_id'] );
-
-					if ( ! empty( $refund_adjustment_id ) ) {
-						edd_add_order_adjustment_meta( $refund_adjustment_id, 'download_id', $fee['download_id'] );
-					}
-				}
-
-				// Maybe store price ID.
-				if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-					edd_add_order_adjustment_meta( $adjustment_id, 'price_id', $fee['price_id'] );
-
-					if ( ! empty( $refund_adjustment_id ) ) {
-						edd_add_order_adjustment_meta( $refund_adjustment_id, 'price_id', $fee['price_id'] );
-					}
 				}
 			}
 		}

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -947,11 +947,6 @@ function edd_build_order( $order_data = array() ) {
 					$adjustment_id = edd_add_order_adjustment( $adjustment_data );
 
 					edd_add_order_adjustment_meta( $adjustment_id, 'fee_id', $fee_id );
-					edd_add_order_adjustment_meta( $adjustment_id, 'download_id', $fee['download_id'] );
-
-					if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-						edd_add_order_adjustment_meta( $adjustment_id, 'price_id', $fee['price_id'] );
-					}
 				}
 			}
 
@@ -1022,10 +1017,6 @@ function edd_build_order( $order_data = array() ) {
 			$adjustment_id = edd_add_order_adjustment( $args );
 
 			edd_add_order_adjustment_meta( $adjustment_id, 'fee_id', $key );
-
-			if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-				edd_add_order_adjustment_meta( $adjustment_id, 'price_id', $fee['price_id'] );
-			}
 
 			$total_fees += (float) $fee['amount'];
 			$total_tax  += $tax;

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -634,8 +634,6 @@ class EDD_Payment {
 					) );
 
 					edd_add_order_adjustment_meta( $adjustment_id, 'fee_id', $key );
-					edd_add_order_adjustment_meta( $adjustment_id, 'download_id', $fee['download_id'] );
-					edd_add_order_adjustment_meta( $adjustment_id, 'price_id', $fee['price_id'] );
 
 					$this->increase_fees( $fee['amount'] );
 				}

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2368,9 +2368,6 @@ class EDD_Payment {
 
 								edd_add_order_adjustment_meta( $adjustment_id, 'fee_id', $fee_id );
 
-								if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-									edd_add_order_adjustment_meta( $adjustment_id, 'price_id', absint( $fee['price_id'] ) );
-								}
 							}
 						} else {
 							$adjustment_id = edd_get_order_adjustments( array(
@@ -2420,9 +2417,6 @@ class EDD_Payment {
 
 								edd_add_order_adjustment_meta( $adjustment_id, 'fee_id', $fee_id );
 
-								if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-									edd_add_order_adjustment_meta( $adjustment_id, 'price_id', absint( $fee['price_id'] ) );
-								}
 							}
 						}
 					}
@@ -2511,10 +2505,6 @@ class EDD_Payment {
 									) );
 
 									edd_add_order_adjustment_meta( $adjustment_id, 'fee_id', $fee_id );
-
-									if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-										edd_add_order_adjustment_meta( $adjustment_id, 'price_id', absint( $fee['price_id'] ) );
-									}
 
 									$new_tax += $tax;
 								}


### PR DESCRIPTION
Fixes #7305

Proposed Changes:
1. Removes the adjustment meta for `price_id` and `download_id` as they exist in the main columns for the adjustment itself.