### PR TITLE
Fix report charts markup

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2479,6 +2479,7 @@ body.download_page_edd-reports {
 	margin: 0 0 20px;
 }
 
+.edd-reports-chart,
 .edd-reports-table {
 	margin-bottom: 20px;
 }
@@ -2807,12 +2808,16 @@ body.download_page_edd-reports {
 	color: #777;
 }
 
-@media screen and ( min-width: 656px ) {
+@media screen and ( min-width: 600px ) {
 	#edd-reports-charts-wrap {
 		display: -ms-grid;
 		display: grid;
 		grid-template-columns: repeat(2, minmax(200px, 50%));
 		grid-gap: 20px;
+	}
+
+	.edd-reports-chart {
+		margin-bottom: 0;
 	}
 
 	.edd-reports-chart-line {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2479,7 +2479,6 @@ body.download_page_edd-reports {
 	margin: 0 0 20px;
 }
 
-.edd-reports-chart,
 .edd-reports-table {
 	margin-bottom: 20px;
 }
@@ -2808,13 +2807,17 @@ body.download_page_edd-reports {
 	color: #777;
 }
 
-.edd-reports-chart-pie,
-.edd-reports-chart-doughnut {
-	box-sizing: border-box;
-	-moz-box-sizing: border-box;
-	-webkit-box-sizing: border-box;
-	float: left;
-	width: 50%;
+@media screen and ( min-width: 656px ) {
+	#edd-reports-charts-wrap {
+		display: -ms-grid;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(200px, 50%));
+		grid-gap: 20px;
+	}
+
+	.edd-reports-chart-line {
+		grid-column: 1 / span 2;
+	}
 }
 
 #edd-chartjs-tooltip {

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -938,24 +938,24 @@ function default_display_charts_group( $report ) {
 		return;
 	}
 
+	?>
+	<div id="edd-reports-charts-wrap" class="edd-report-wrap">
+	<?php
+
 	$charts = $report->get_endpoints( 'charts' );
 
 	foreach ( $charts as $endpoint_id => $chart ) {
-?>
+		?>
+		<div class="edd-reports-chart edd-reports-chart-<?php echo esc_attr( $chart->get_type() ); ?>" id="edd-reports-table-<?php echo esc_attr( $endpoint_id ); ?>">
+			<h3><?php echo esc_html( $chart->get_label() ); ?></h3>
 
-	<div id="edd-reports-charts-wrap" class="edd-report-wrap">
-
-			<div class="edd-reports-chart edd-reports-chart-<?php echo esc_attr( $chart->get_type() ); ?>" id="edd-reports-table-<?php echo esc_attr( $endpoint_id ); ?>">
-				<h3><?php echo esc_html( $chart->get_label() ); ?></h3>
-
-				<?php $chart->display(); ?>
-			</div>
-
-			<div class="clear"></div>
-
-	</div>
-<?php
+			<?php $chart->display(); ?>
+		</div>
+		<?php
 	}
+	?>
+	</div>
+	<?php
 }
 
 /**


### PR DESCRIPTION
Fixes #7976 

Proposed Changes:
1. Fix the reports chart markup to avoid duplicate `id`s.

Keeping this PR in draft as I'm checking with @LisaCee about updating the CSS to handle pie charts better and be mobile responsive.