### PR TITLE
Export File Download Logs Dropdown, #7785

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -3167,7 +3167,6 @@ body.download_page_edd-reports {
 .js .edd-sections-wrap .edd-vertical-sections:not(.meta-box) .section-wrap > div {
 	min-height: 500px;
 	height: 100%;
-	overflow: hidden;
 }
 .edd-sections-wrap .section-wrap .customer-section:not(:last-child) {
 	border-bottom: 1px solid #eee;


### PR DESCRIPTION
Fixes #7785 

Proposed Changes:
1. Removed `overflow:hidden` from `edd-vertical-sections:not(.meta-box)

This class is also used in class-sections for vertically tabbed UI, but that still looks okay (to me) with this change.
