### PR TITLE
Revert adding "delete permanently" to orders bulk actions

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -658,10 +658,6 @@ function edd_orders_list_table_process_bulk_actions() {
 			case 'resend-receipt':
 				edd_email_purchase_receipt( $id, false );
 				break;
-
-			case 'delete':
-				edd_destroy_order( $id );
-				break;
 		}
 
 		do_action( 'edd_payments_table_do_bulk_action', $id, $action );

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -657,9 +657,9 @@ class EDD_Payment_History_Table extends List_Table {
 		}
 
 		if ( 'trash' === $this->get_status() ) {
-			$action['restore'] = __( 'Restore', 'easy-digital-downloads' );
-
-			unset( $action['resend-receipt'] );
+			$action = array(
+				'restore' => __( 'Restore', 'easy-digital-downloads' ),
+			);
 		} else {
 			$action['trash'] = __( 'Move to Trash', 'easy-digital-downloads' );
 		}

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -544,6 +544,8 @@ class EDD_Payment_History_Table extends List_Table {
 				'purchase_id' => $order->id,
 			), $this->base_url ), 'edd_payment_nonce' );
 			$row_actions['delete'] = '<a href="' . esc_url( $delete_url ) . '">' . esc_html__( 'Delete Permanently', 'easy-digital-downloads' ) . '</a>';
+
+			unset( $row_actions['view'] );
 		}
 
 		if ( has_filter( 'edd_payment_row_actions' ) ) {
@@ -574,8 +576,8 @@ class EDD_Payment_History_Table extends List_Table {
 		$actions = $this->row_actions( $row_actions );
 
 		// Primary link
-		$order_number = $order->type == 'sale' ? $order->get_number() : $order->order_number;
-		$link = '<a class="row-title" href="' . esc_url( $view_url ) . '">' . esc_html( $order_number ) . '</a>';
+		$order_number = 'sale' === $order->type ? $order->get_number() : $order->order_number;
+		$link         = edd_is_order_restorable( $order->id ) ? '<span class="row-title">' . esc_html( $order_number ) . '</span>' : '<a class="row-title" href="' . esc_url( $view_url ) . '">' . esc_html( $order_number ) . '</a>';
 
 		// Concatenate & return the results
 		return $link . $actions;

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -637,7 +637,7 @@ class EDD_Payment_History_Table extends List_Table {
 	 * @return array $actions Bulk actions.
 	 */
 	public function get_bulk_actions() {
-		if ( 'refund' !== $this->type && 'trash' !== $this->get_status() ) {
+		if ( 'refund' !== $this->type ) {
 			$action = array(
 				'set-status-complete'     => __( 'Mark Completed',   'easy-digital-downloads' ),
 				'set-status-pending'     => __( 'Mark Pending',     'easy-digital-downloads' ),
@@ -656,7 +656,6 @@ class EDD_Payment_History_Table extends List_Table {
 
 		if ( 'trash' === $this->get_status() ) {
 			$action['restore'] = __( 'Restore', 'easy-digital-downloads' );
-			$action['delete']  = __( 'Delete Permanently', 'easy-digital-downloads' );
 		} else {
 			$action['trash'] = __( 'Move to Trash', 'easy-digital-downloads' );
 		}

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -543,7 +543,7 @@ class EDD_Payment_History_Table extends List_Table {
 				'edd-action'  => 'delete_order',
 				'purchase_id' => $order->id,
 			), $this->base_url ), 'edd_payment_nonce' );
-			$row_actions['delete'] = '<a href="' . esc_url( $delete_url ) . '">' . esc_html__( 'Delete', 'easy-digital-downloads' ) . '</a>';
+			$row_actions['delete'] = '<a href="' . esc_url( $delete_url ) . '">' . esc_html__( 'Delete Permanently', 'easy-digital-downloads' ) . '</a>';
 		}
 
 		if ( has_filter( 'edd_payment_row_actions' ) ) {

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -656,6 +656,8 @@ class EDD_Payment_History_Table extends List_Table {
 
 		if ( 'trash' === $this->get_status() ) {
 			$action['restore'] = __( 'Restore', 'easy-digital-downloads' );
+
+			unset( $action['resend-receipt'] );
 		} else {
 			$action['trash'] = __( 'Move to Trash', 'easy-digital-downloads' );
 		}


### PR DESCRIPTION
Fixes #7937 

Proposed Changes:
1. Revert the changes to the list of bulk actions for trashed orders.

Looking over this, I wonder if the trashed orders bulk actions should be limited to simply "Restore" instead of the standard list of actions, since restoring the order will check the order meta and automatically change the restored order to its pending/cancelled/complete/etc. state, instead of allowing the bulk actions to potentially significantly change that.

(Also, some of the actions, such as "Resend Receipts", seem inappropriate for trashed orders.)
