### PR TITLE
Update download labels for reports

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -489,8 +489,11 @@ function edd_register_downloads_report( $reports ) {
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
 			if ( $download_data['price_id'] ) {
-				$args                  = array( 'price_id' => $download_data['price_id'] );
-				$download->post_title .= ': ' . edd_get_price_name( $download->ID, $args );
+				$args       = array( 'price_id' => $download_data['price_id'] );
+				$price_name = edd_get_price_name( $download->ID, $args );
+				if ( $price_name ) {
+					$download->post_title .= ': ' . $price_name;
+				}
 			}
 			$download_label = esc_html( ' (' . $download->post_title . ')' );
 		}
@@ -1559,8 +1562,11 @@ function edd_register_taxes_report( $reports ) {
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
 			if ( $download_data['price_id'] ) {
-				$args                  = array( 'price_id' => $download_data['price_id'] );
-				$download->post_title .= ': ' . edd_get_price_name( $download->ID, $args );
+				$args       = array( 'price_id' => $download_data['price_id'] );
+				$price_name = edd_get_price_name( $download->ID, $args );
+				if ( $price_name ) {
+					$download->post_title .= ': ' . $price_name;
+				}
 			}
 			$download_label = esc_html( ' (' . $download->post_title . ')' );
 		}
@@ -1696,8 +1702,11 @@ function edd_register_file_downloads_report( $reports ) {
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
 			if ( $download_data['price_id'] ) {
-				$args                  = array( 'price_id' => $download_data['price_id'] );
-				$download->post_title .= ': ' . edd_get_price_name( $download->ID, $args );
+				$args       = array( 'price_id' => $download_data['price_id'] );
+				$price_name = edd_get_price_name( $download->ID, $args );
+				if ( $price_name ) {
+					$download->post_title .= ': ' . $price_name;
+				}
 			}
 			$download_label = esc_html( ' (' . $download->post_title . ')' );
 		}

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -485,18 +485,14 @@ function edd_register_downloads_report( $reports ) {
 		// Mock downloads and prices in case they cannot be found later.
 		$download       = edd_get_download();
 		$prices         = array();
-
+		$download_label = '';
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
-			$prices   = $download->get_prices();
-
 			if ( $download_data['price_id'] ) {
-				$prices = array_values( wp_filter_object_list( $download->get_prices(), array( 'index' => absint( $download_data['price_id'] ) ) ) );
-
-				$download_label = esc_html( ' (' . $download->post_title . ': ' . $prices[0]['name'] . ')' );
-			} else {
-				$download_label = esc_html( ' (' . $download->post_title . ')' );
+				$args                  = array( 'price_id' => $download_data['price_id'] );
+				$download->post_title .= ': ' . edd_get_price_name( $download->ID, $args );
 			}
+			$download_label = esc_html( ' (' . $download->post_title . ')' );
 		}
 
 		$tiles = array_filter( array(
@@ -1560,17 +1556,13 @@ function edd_register_taxes_report( $reports ) {
 			: false;
 
 		$download_label = '';
-
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
-
 			if ( $download_data['price_id'] ) {
-				$prices = array_values( wp_filter_object_list( $download->get_prices(), array( 'index' => absint( $download_data['price_id'] ) ) ) );
-
-				$download_label = esc_html( ' (' . $download->post_title . ': ' . $prices[0]['name'] . ')' );
-			} else {
-				$download_label = esc_html( ' (' . $download->post_title . ')' );
+				$args                  = array( 'price_id' => $download_data['price_id'] );
+				$download->post_title .= ': ' . edd_get_price_name( $download->ID, $args );
 			}
+			$download_label = esc_html( ' (' . $download->post_title . ')' );
 		}
 
 		$country = Reports\get_filter_value( 'countries' );
@@ -1701,17 +1693,13 @@ function edd_register_file_downloads_report( $reports ) {
 			: false;
 
 		$download_label = '';
-
 		if ( $download_data ) {
 			$download = edd_get_download( $download_data['download_id'] );
-
 			if ( $download_data['price_id'] ) {
-				$prices = array_values( wp_filter_object_list( $download->get_prices(), array( 'index' => absint( $download_data['price_id'] ) ) ) );
-
-				$download_label = esc_html( ' (' . $download->post_title . ': ' . $prices[0]['name'] . ')' );
-			} else {
-				$download_label = esc_html( ' (' . $download->post_title . ')' );
+				$args                  = array( 'price_id' => $download_data['price_id'] );
+				$download->post_title .= ': ' . edd_get_price_name( $download->ID, $args );
 			}
+			$download_label = esc_html( ' (' . $download->post_title . ')' );
 		}
 
 		$tiles = array_filter( array(


### PR DESCRIPTION
Fixes #7972

Proposed Changes:
1. Use `edd_get_price_name` to get price option names, if viewing a price ID.