### PR TITLE
Deactivate any country wide tax rates when importing a country wide tax rate that is for the same country #7602

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1085,6 +1085,27 @@ class Data_Migrator {
 			? sanitize_text_field( $data['state'] )
 			: '';
 
+		// If the scope is 'country', look for other active rates that are country wide and set them as 'inactive'.
+		if ( 'country' === $scope ) {
+			$tax_rates = edd_get_adjustments(
+				array(
+					'type'        => 'tax_rate',
+					'status'      => 'active',
+					'scope'       => 'country',
+					'name'        => $data['country'],
+				)
+			);
+
+			if ( ! empty( $tax_rates ) ) {
+				foreach ( $tax_rates as $tax_rate ) {
+					edd_update_adjustment(
+						$tax_rate->id,
+						array( 'status' => 'inactive', )
+					);
+				}
+			}
+		}
+
 		$adjustment_data = array(
 			'name'        => $data['country'],
 			'status'      => 'active',


### PR DESCRIPTION
Fixes #7602 

Proposed Changes:
1. In the `Data_Migrator::tax_rates` method, check for any other country wide tax rates for the same country and deactivate them.