### PR TITLE
Add gross/net order status functions to aid in consistent reporting #7985

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -887,7 +887,7 @@ function default_display_tiles_group( $report ) {
 
 	<div id="edd-reports-tiles-wrap" class="edd-report-wrap">
 		<?php
-		foreach ( $tiles as $endpoint_id => $tile ) : 
+		foreach ( $tiles as $endpoint_id => $tile ) :
 			$tile->display();
 		endforeach;
 		?>
@@ -1041,7 +1041,7 @@ function display_taxes_filter() {
 		return;
 	}
 
-	$taxes         = get_filter_value( 'taxes' ); 
+	$taxes         = get_filter_value( 'taxes' );
 	$exclude_taxes = isset( $taxes['exclude_taxes'] ) && true == $taxes['exclude_taxes'];
 ?>
 	<span class="edd-graph-filter-options graph-option-section">
@@ -1277,6 +1277,65 @@ function filter_items( $report = false ) {
 	echo ob_get_clean();
 }
 add_action( 'edd_admin_filter_bar_reports', 'EDD\Reports\filter_items' );
+
+/**
+ * Get the order status array keys that can be used to run reporting related to gross reporting.
+ *
+ * @since 3.0
+ *
+ * @return array An array of order status array keys that can be related to gross reporting.
+ */
+function edd_gross_order_statuses() {
+	$statuses = array(
+		'completed',
+		'refunded',
+		'partially_refunded',
+		'revoked',
+	);
+
+	/**
+	 * Statuses that affect gross order statistics.
+	 *
+	 * This filter allows extensions and developers to alter the statuses that can affect the reporting of gross
+	 * sales statistics.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $statuses {
+	 *     An array of order status array keys.
+	 *
+	 */
+	return apply_filters( 'edd_gross_order_statuses', $statuses );
+}
+
+/**
+ * Get the order status array keys that can be used to run reporting related to net reporting.
+ *
+ * @since 3.0
+ *
+ * @return array An array of order status array keys that can be related to net reporting.
+ */
+function edd_net_order_statuses() {
+	$statuses = array(
+		'completed',
+		'partially_refunded',
+		'revoked',
+	);
+
+	/**
+	 * Statuses that affect net order statistics.
+	 *
+	 * This filter allows extensions and developers to alter the statuses that can affect the reporting of net
+	 * sales statistics.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $statuses {
+	 *     An array of order status array keys.
+	 *
+	 */
+	return apply_filters( 'edd_net_order_statuses', $statuses );
+}
 
 /** Compat ********************************************************************/
 

--- a/tests/reports/tests-reports-functions.php
+++ b/tests/reports/tests-reports-functions.php
@@ -790,6 +790,27 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, get_filter_value( 'dates' ) );
 	}
 
+	public function test_gross_order_status() {
+		$expected = array(
+			'completed',
+			'refunded',
+			'partially_refunded',
+			'revoked',
+		);
+
+		$this->assertSame( $expected, edd_gross_order_statuses() );
+	}
+
+	public function test_net_order_status() {
+		$expected = array(
+			'completed',
+			'partially_refunded',
+			'revoked',
+		);
+
+		$this->assertSame( $expected, edd_net_order_statuses() );
+	}
+
 	/**
 	 * Strips the seconds from start and end datetime strings to guard against slow tests.
 	 *


### PR DESCRIPTION
Fixes #7985 

Proposed Changes:
1. Introduces the `edd_gross/net_order_statuses()` functions into the reporting functions.
2. Introduces two filters to allow filtering these statuses (with doc blocks)
3. Adds unit tests for the two functions.