### PR TITLE
Update tax rates table markup and CSS for improved responsiveness

### DIFF
--- a/assets/css/edd-admin-tax-rates.css
+++ b/assets/css/edd-admin-tax-rates.css
@@ -2,6 +2,19 @@
 	margin: 1em 0 0;
 }
 
+#edd-admin-tax-rates table {
+	border-collapse: collapse;
+}
+
+#edd-admin-tax-rates .tablenav.top {
+	display: flex;
+	justify-content: space-between;
+}
+
+#edd-admin-tax-rates .edd-admin-tax-rates__tablenav--left {
+	display: inline-flex;
+}
+
 #edd-admin-tax-rates th:not(.check-column) {
 	padding: 15px 10px;
 	width: unset;
@@ -20,15 +33,10 @@
 	padding: 12px 8px 10px 8px;
 }
 
-#edd-admin-tax-rates .edd-tax-rates-table-country {
-	padding-left: 12px;
-}
-
 .edd-tax-rate-table-add th select,
 .edd-tax-rate-table-add th input[type="text"],
 .edd-tax-rate-table-add th input[type="number"] {
 	width: 100%;
-	height: 28px;
 	margin: 0;
 	padding: 4px;
 }
@@ -55,11 +63,6 @@
 #edd-admin-tax-rates .edd-tax-rate-row--inactive td {
 	color: #999;
 	background-color: #f9f9f9;
-}
-
-#edd-admin-tax-rates .edd-admin-tax-rates-table-hide {
-	float: right;
-	margin-right: 10px;
 }
 
 #edd-admin-tax-rates .edd-tax-rate-table-add {
@@ -113,5 +116,19 @@
 		clip-path: unset;
 		margin: 0 0 12px;
 		position: relative;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	#edd-admin-tax-rates .tablenav.top {
+		flex-wrap: wrap;
+	}
+
+	#edd-admin-tax-rates .edd-admin-tax-rates__tablenav--left {
+		margin-bottom: 16px;
+	}
+
+	#edd-admin-tax-rates .edd-admin-tax-rates__tablenav--left select {
+		margin-right: 6px;
 	}
 }

--- a/assets/css/edd-admin-tax-rates.css
+++ b/assets/css/edd-admin-tax-rates.css
@@ -2,7 +2,8 @@
 	margin: 1em 0 0;
 }
 
-#edd-admin-tax-rates th {
+#edd-admin-tax-rates th:not(.check-column) {
+	padding: 15px 10px;
 	width: unset;
 }
 
@@ -72,19 +73,16 @@
 	}
 
 	#edd-admin-tax-rates thead tr,
-	#edd-admin-tax-rates tfoot:not(.add-new) tr {
+	#edd-admin-tax-rates tfoot:not(.add-new) tr,
+	#edd-admin-tax-rates .edd-tax-rate-row {
 		display: grid;
 		grid-template-columns: 2.5em 1fr;
 		grid-template-rows: 1fr;
+		grid-gap: 0 16px;
 	}
 
 	#edd-admin-tax-rates th.edd-tax-rates-table-rate {
 		padding-left: 12px;
-	}
-
-	#edd-admin-tax-rates .edd-tax-rate-row {
-		display: grid;
-		grid-template-columns: 2.5em 1fr;
 	}
 
 	#edd-admin-tax-rates .edd-tax-rates-table-checkbox {

--- a/assets/css/edd-admin-tax-rates.css
+++ b/assets/css/edd-admin-tax-rates.css
@@ -2,6 +2,10 @@
 	margin: 1em 0 0;
 }
 
+#edd-admin-tax-rates th {
+	width: unset;
+}
+
 #edd-admin-tax-rates .chosen-container {
 	width: 100% !important;
 }
@@ -10,22 +14,13 @@
 	border-bottom: 1px solid #eee;
 }
 
-#edd-admin-tax-rates th {
-	vertical-align: middle;
-	padding: 8px;
-}
-
-#edd-admin-tax-rates td {
-	vertical-align: top;
-	padding: 10px;
-}
-
-#edd-admin-tax-rates tfoot th {
-	vertical-align: top;
-}
-
 #edd-admin-tax-rates tfoot.add-new th {
+	font-weight: normal;
 	padding: 12px 8px 10px 8px;
+}
+
+#edd-admin-tax-rates .edd-tax-rates-table-country {
+	padding-left: 12px;
 }
 
 .edd-tax-rate-table-add th select,
@@ -35,20 +30,6 @@
 	height: 28px;
 	margin: 0;
 	padding: 4px;
-}
-
-#edd-admin-tax-rates td.edd-tax-rates-table-checkbox,
-#edd-admin-tax-rates th.edd-tax-rates-table-checkbox {
-	width: 2.2em;
-}
-
-#edd-admin-tax-rates th.edd-tax-rates-table-rate,
-#edd-admin-tax-rates th.edd-tax-rates-table-actions {
-	width: 15%;
-}
-
-#edd-admin-tax-rates th.edd-tax-rates-table-checkbox input {
-	margin-left: 2px;
 }
 
 /**
@@ -84,6 +65,55 @@
 	background-color: #f9f9f9;
 }
 
-#edd-admin-tax-rates .edd-tax-rate-table-add th {
-	font-weight: normal;
+@media screen and (max-width: 782px) {
+	#edd-admin-tax-rates thead th:not(.edd-tax-rates-table-rate),
+	#edd-admin-tax-rates tfoot:not(.add-new) th:not(.edd-tax-rates-table-rate) {
+		display: none;
+	}
+
+	#edd-admin-tax-rates thead tr,
+	#edd-admin-tax-rates tfoot:not(.add-new) tr {
+		display: grid;
+		grid-template-columns: 2.5em 1fr;
+		grid-template-rows: 1fr;
+	}
+
+	#edd-admin-tax-rates th.edd-tax-rates-table-rate {
+		padding-left: 12px;
+	}
+
+	#edd-admin-tax-rates .edd-tax-rate-row {
+		display: grid;
+		grid-template-columns: 2.5em 1fr;
+	}
+
+	#edd-admin-tax-rates .edd-tax-rates-table-checkbox {
+		grid-row: 1 / 5;
+	}
+
+	#edd-admin-tax-rates tbody td {
+		padding-left: 35% !important;
+	}
+
+	#edd-admin-tax-rates td:before {
+		content: attr(data-colname);
+		display: block;
+		width: 32%;
+		position: absolute;
+	}
+
+	#edd-admin-tax-rates .edd-tax-rate-table-add,
+	#edd-admin-tax-rates .edd-tax-rate-table-add th {
+		display: block;
+	}
+
+	#edd-admin-tax-rates .edd-tax-rate-table-add .screen-reader-text {
+		display: block;
+		width: unset;
+		clip: unset;
+		height: unset;
+		clip-path: unset;
+		margin: 0 0 12px;
+		position: relative;
+	}
 }

--- a/assets/css/edd-admin-tax-rates.css
+++ b/assets/css/edd-admin-tax-rates.css
@@ -11,7 +11,7 @@
 	width: 100% !important;
 }
 
-#edd-admin-tax-rates tbody tr:not(:last-of-type) td {
+#edd-admin-tax-rates tbody tr:not(:last-of-type) {
 	border-bottom: 1px solid #eee;
 }
 

--- a/includes/admin/views/tmpl-tax-rates-table-add.php
+++ b/includes/admin/views/tmpl-tax-rates-table-add.php
@@ -13,9 +13,7 @@
 
 <tr class="edd-tax-rate-table-add">
 
-	<th>&nbsp;</th>
-
-	<th>
+	<th colspan="2">
 		<label for="tax_rate_country" class="screen-reader-text"><?php esc_html_e( 'Country', 'easy-digital-downloads' ); ?></label>
 		<?php
 		echo EDD()->html->select( array(
@@ -32,8 +30,8 @@
 	<th>
 		<label for="tax_rate_region" class="screen-reader-text"><?php esc_html_e( 'Region', 'easy-digital-downloads' ); ?></label>
 
-		<label style="margin: 5px 0; display: block;">
-			<input type="checkbox" checked style="margin-left: 0;" /> Apply to whole country
+		<label>
+			<input type="checkbox" checked /> Apply to whole country
 		</label>
 
 		<div id="tax_rate_region_wrapper"></div>

--- a/includes/admin/views/tmpl-tax-rates-table-bulk-actions.php
+++ b/includes/admin/views/tmpl-tax-rates-table-bulk-actions.php
@@ -13,7 +13,7 @@
 
 <div class="tablenav top">
 
-	<div class="alignleft">
+	<div class="edd-admin-tax-rates__tablenav--left">
 		<select id="edd-admin-tax-rates-table-bulk-actions">
 			<option><?php esc_html_e( 'Bulk Actions', 'easy-digital-downloads' ); ?></option>
 			<option value="active"><?php esc_html_e( 'Activate', 'easy-digital-downloads' ); ?></option>
@@ -23,7 +23,7 @@
 		<button class="button edd-admin-tax-rates-table-filter"><?php esc_html_e( 'Apply', 'easy-digital-downloads' ); ?></button>
 	</div>
 
-	<div class="alignright">
+	<div class="edd-admin-tax-rates__tablenav--right">
 		<label class="edd-toggle edd-admin-tax-rates-table-hide">
 			<span class="label"><?php esc_html_e( 'Show deactivated rates', 'easy-digital-downloads' ); ?></span>
 			<input type="checkbox" id="hide-deactivated" />

--- a/includes/admin/views/tmpl-tax-rates-table-meta.php
+++ b/includes/admin/views/tmpl-tax-rates-table-meta.php
@@ -12,8 +12,8 @@
 ?>
 
 <tr>
-	<th class="edd-tax-rates-table-checkbox"><input type="checkbox" /></th>
-	<th><?php esc_html_e( 'Country', 'easy-digital-downloads' ); ?></th>
+	<td class="edd-tax-rates-table-checkbox check-column"><input type="checkbox" /></td>
+	<th class="edd-tax-rates-table-country"><?php esc_html_e( 'Country', 'easy-digital-downloads' ); ?></th>
 	<th><?php esc_html_e( 'Region', 'easy-digital-downloads' ); ?></th>
 	<th class="edd-tax-rates-table-rate"><?php esc_html_e( 'Rate', 'easy-digital-downloads' ); ?></th>
 	<th class="edd-tax-rates-table-actions"><?php esc_html_e( 'Actions', 'easy-digital-downloads' ); ?></th>

--- a/includes/admin/views/tmpl-tax-rates-table-row.php
+++ b/includes/admin/views/tmpl-tax-rates-table-row.php
@@ -15,12 +15,12 @@
 	<input type="checkbox" <# if ( data.selected ) { #>checked<# } #> />
 </th>
 
-<td class="edd-tax-rates-table-country" data-colname="<?php esc_html_e( 'Country', 'easy-digital-downloads' ); ?>">
+<td class="edd-tax-rates-table-country" data-colname="<?php esc_attr_e( 'Country', 'easy-digital-downloads' ); ?>">
 	{{ data.country }}
 	<input type="hidden" name="tax_rates[{{ data.id }}][country]" value="{{ data.country }}" />
 </td>
 
-<td data-colname="<?php esc_html_e( 'Region', 'easy-digital-downloads' ); ?>">
+<td data-colname="<?php esc_attr_e( 'Region', 'easy-digital-downloads' ); ?>">
 	<# if ( data.global ) { #>
 	&mdash;
 	<input type="hidden" name="tax_rates[{{ data.id }}][global]" value="{{ data.global }}" />
@@ -30,12 +30,12 @@
 	<# } #>
 </td>
 
-<td data-colname="<?php esc_html_e( 'Rate', 'easy-digital-downloads' ); ?>">
+<td data-colname="<?php esc_attr_e( 'Rate', 'easy-digital-downloads' ); ?>">
 	{{ data.formattedAmount }}
 	<input type="hidden" name="tax_rates[{{ data.id }}][rate]" value="{{ data.amount }}" />
 </td>
 
-<td class="edd-tax-rates-table-actions" data-colname="<?php esc_html_e( 'Actions', 'easy-digital-downloads' ); ?>">
+<td class="edd-tax-rates-table-actions" data-colname="<?php esc_attr_e( 'Actions', 'easy-digital-downloads' ); ?>">
 	<# if ( data.unsaved ) { #>
 		<button class="button-link remove" data-cid="{{ data.id }}"><?php esc_html_e( 'Remove', 'easy-digital-downloads' ); ?></button>
 	<# } else if ( 'active' === data.status ) { #>

--- a/includes/admin/views/tmpl-tax-rates-table-row.php
+++ b/includes/admin/views/tmpl-tax-rates-table-row.php
@@ -11,16 +11,16 @@
  */
 ?>
 
-<td class="edd-tax-rates-table-checkbox">
+<th class="edd-tax-rates-table-checkbox check-column">
 	<input type="checkbox" <# if ( data.selected ) { #>checked<# } #> />
-</td>
+</th>
 
-<td>
+<td class="edd-tax-rates-table-country" data-colname="<?php esc_html_e( 'Country', 'easy-digital-downloads' ); ?>">
 	{{ data.country }}
 	<input type="hidden" name="tax_rates[{{ data.id }}][country]" value="{{ data.country }}" />
 </td>
 
-<td>
+<td data-colname="<?php esc_html_e( 'Region', 'easy-digital-downloads' ); ?>">
 	<# if ( data.global ) { #>
 	&mdash;
 	<input type="hidden" name="tax_rates[{{ data.id }}][global]" value="{{ data.global }}" />
@@ -30,12 +30,12 @@
 	<# } #>
 </td>
 
-<td>
+<td data-colname="<?php esc_html_e( 'Rate', 'easy-digital-downloads' ); ?>">
 	{{ data.formattedAmount }}
 	<input type="hidden" name="tax_rates[{{ data.id }}][rate]" value="{{ data.amount }}" />
 </td>
 
-<td class="edd-tax-rates-table-actions">
+<td class="edd-tax-rates-table-actions" data-colname="<?php esc_html_e( 'Actions', 'easy-digital-downloads' ); ?>">
 	<# if ( data.unsaved ) { #>
 		<button class="button-link remove" data-cid="{{ data.id }}"><?php esc_html_e( 'Remove', 'easy-digital-downloads' ); ?></button>
 	<# } else if ( 'active' === data.status ) { #>


### PR DESCRIPTION
Fixes #7957

Proposed Changes:
1. Update table markup for consistency with Core tables.
2. Add `data-colname` attributes to rows for managing small screen output.

The input labels for the "add new" row are currently hidden with `screen-reader-text`, which I'm currently overriding on mobile screens so they can be visible for all users. This is a good use case for the reusable "show on mobile" CSS class requested in #7946.