### PR TITLE
Adding notice to tax report if default tax rate is detected #6840

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2972,7 +2972,7 @@ add_action( 'admin_footer', 'edd_add_screen_options_nonces' );
  * that we cannot report on the default tax rate.
  *
  * @since 3.0
- * @param $report
+ * @param \EDD\Reports\Data\Report|\WP_Error $report The current report object, or WP_Error if invalid.
  */
 function edd_tax_report_notice( $report ) {
 	if ( 'taxes' === $report->object_id && false !== edd_get_option( 'tax_rate' ) ) {

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2966,3 +2966,21 @@ function edd_add_screen_options_nonces() {
 	wp_nonce_field( 'meta-box-order',  'meta-box-order-nonce', false );
 }
 add_action( 'admin_footer', 'edd_add_screen_options_nonces' );
+
+/**
+ * This function adds a notice to the bottom of the Tax reports screen if a default tax rate is detected, stating
+ * that we cannot report on the default tax rate.
+ *
+ * @param $report
+ */
+function edd_tax_report_notice( $report ) {
+	if ( 'taxes' === $report->object_id && false !== edd_get_option( 'tax_rate' ) ) {
+		?>
+		<div>
+			<strong><?php _e( 'Notice', 'easy-digital-downloads' ); ?>: </strong>
+			<?php _e( 'Tax reports are only generated for taxes associated with a location. The legacy default tax rate is unable to be reported on.', 'easy-digital-downloads' ); ?>
+		</div>
+		<?php
+	}
+}
+add_action( 'edd_reports_page_bottom', 'edd_tax_report_notice', 10, 1 );

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2971,15 +2971,16 @@ add_action( 'admin_footer', 'edd_add_screen_options_nonces' );
  * This function adds a notice to the bottom of the Tax reports screen if a default tax rate is detected, stating
  * that we cannot report on the default tax rate.
  *
+ * @since 3.0
  * @param $report
  */
 function edd_tax_report_notice( $report ) {
 	if ( 'taxes' === $report->object_id && false !== edd_get_option( 'tax_rate' ) ) {
 		?>
-		<div>
-			<strong><?php _e( 'Notice', 'easy-digital-downloads' ); ?>: </strong>
-			<?php _e( 'Tax reports are only generated for taxes associated with a location. The legacy default tax rate is unable to be reported on.', 'easy-digital-downloads' ); ?>
-		</div>
+		<p class="description">
+			<strong><?php esc_html_e( 'Notice', 'easy-digital-downloads' ); ?>: </strong>
+			<?php esc_html_e( 'Tax reports are only generated for taxes associated with a location. The legacy default tax rate is unable to be reported on.', 'easy-digital-downloads' ); ?>
+		</p>
 		<?php
 	}
 }

--- a/includes/reports/data/class-base-object.php
+++ b/includes/reports/data/class-base-object.php
@@ -25,7 +25,7 @@ abstract class Base_Object implements Error_Logger {
 	 * @since 3.0
 	 * @var   string
 	 */
-	private $object_id;
+	public $object_id;
 
 	/**
 	 * Object label.


### PR DESCRIPTION
Fixes #6840

Proposed Changes:
1. Changes the `object_id` of reports class to `public` so that it can be used in the hooks in the reports output. Everything was previously `private` so nothing could be used or filtered.
2. Adds a notice at the bottom of the tax reports if a default tax rate is detected.
