### PR TITLE
Remove type from empty address array

### DIFF
--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -640,7 +640,7 @@ function edd_maybe_add_customer_address( $customer_id = 0, $data = array() ) {
 		return false;
 	}
 	$address_to_check['customer_id'] = $customer_id;
-	$address_to_check['type']        = 'billing';
+	$address_to_check['type']        = empty( $data['type'] ) ? 'billing' : $data['type'];
 
 	// Instantiate a query object
 	$customer_addresses = new EDD\Database\Queries\Customer_Address();

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -643,6 +643,7 @@ function edd_maybe_add_customer_address( $customer_id = 0, $data = array() ) {
 		return false;
 	}
 	$address_to_check['customer_id'] = $customer_id;
+	$address_to_check['type']        = 'billing';
 
 	// Instantiate a query object
 	$customer_addresses = new EDD\Database\Queries\Customer_Address();

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -636,7 +636,6 @@ function edd_maybe_add_customer_address( $customer_id = 0, $data = array() ) {
 		'region'      => '',
 		'country'     => '',
 		'postal_code' => '',
-		'type'        => 'billing',
 	);
 	$address_to_check = array_intersect_key( $data, $empty_address );
 	$address_to_check = array_filter( $address_to_check );

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -625,10 +625,7 @@ function edd_maybe_add_customer_address( $customer_id = 0, $data = array() ) {
 		return false;
 	}
 
-	// Set the address type.
-	$data['type'] = 'billing';
-
-	// Set up an array with the whitelisted address keys.
+	// Set up an array with empty address keys. If all of these are empty in $data, the address should not be added.
 	$empty_address    = array(
 		'address'     => '',
 		'address2'    => '',


### PR DESCRIPTION
Fixes #7998

Proposed Changes:
1. Remove `type` from the `$empty_address` array
2. Add `type` to the `$address_to_check` array. Note that this is only for address comparison, and isn't part of the data added to the database (the `$data` variable in the code). Because the address table default type is `billing`, any address without a specific type registered will be added as a billing address.

To test: generate orders using WP-CLI. These orders do not have physical addresses, so no address rows should be created.