### PR TITLE
Return false for discount ID if discount object is not retrieved

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -910,7 +910,7 @@ function edd_is_discount_valid( $code = '', $user = '', $set_error = true ) {
 function edd_get_discount_id_by_code( $code = '' ) {
 	$discount = edd_get_discount_by_code( $code );
 
-	return is_object( $discount ) ? $discount->id : false;
+	return ( $discount instanceof EDD_Discount ) ? $discount->id : false;
 }
 
 /**

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -905,11 +905,12 @@ function edd_is_discount_valid( $code = '', $user = '', $set_error = true ) {
  * @since 3.0 Updated to call edd_get_discount_by_code()
  *
  * @param string $code Discount code.
- * @return int Discount ID.
+ * @return int|bool Discount ID, or false if discount does not exist.
  */
 function edd_get_discount_id_by_code( $code = '' ) {
 	$discount = edd_get_discount_by_code( $code );
-	return $discount->id;
+
+	return is_object( $discount ) ? $discount->id : false;
 }
 
 /**


### PR DESCRIPTION
Fixes #8002

To test:

Use `edd_get_discount_id_by_code()` (`var_dump` or `error_log` is enough) to retrieve a nonexistent discount code. Example:

```php
var_dump( edd_get_discount_id_by_code( 'adsrfd' ) );
```

In `release/3.0` this will throw a PHP notice, because a discount object is not returned. This adds a check for that situation.