### PR TITLE
Relocate and rename order statuses functions

### DIFF
--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -1275,6 +1275,65 @@ function edd_clone_order( $order_id = 0, $clone_relationships = false, $args = a
 }
 
 /**
+ * Get the order status array keys that can be used to run reporting related to gross reporting.
+ *
+ * @since 3.0
+ *
+ * @return array An array of order status array keys that can be related to gross reporting.
+ */
+function edd_get_gross_order_statuses() {
+	$statuses = array(
+		'complete',
+		'refunded',
+		'partially_refunded',
+		'revoked',
+	);
+
+	/**
+	 * Statuses that affect gross order statistics.
+	 *
+	 * This filter allows extensions and developers to alter the statuses that can affect the reporting of gross
+	 * sales statistics.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $statuses {
+	 *     An array of order status array keys.
+	 *
+	 */
+	return apply_filters( 'edd_gross_order_statuses', $statuses );
+}
+
+/**
+ * Get the order status array keys that can be used to run reporting related to net reporting.
+ *
+ * @since 3.0
+ *
+ * @return array An array of order status array keys that can be related to net reporting.
+ */
+function edd_get_net_order_statuses() {
+	$statuses = array(
+		'complete',
+		'partially_refunded',
+		'revoked',
+	);
+
+	/**
+	 * Statuses that affect net order statistics.
+	 *
+	 * This filter allows extensions and developers to alter the statuses that can affect the reporting of net
+	 * sales statistics.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $statuses {
+	 *     An array of order status array keys.
+	 *
+	 */
+	return apply_filters( 'edd_net_order_statuses', $statuses );
+}
+
+/**
  * Generate unique payment key for orders.
  *
  * @since 3.0

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1278,65 +1278,6 @@ function filter_items( $report = false ) {
 }
 add_action( 'edd_admin_filter_bar_reports', 'EDD\Reports\filter_items' );
 
-/**
- * Get the order status array keys that can be used to run reporting related to gross reporting.
- *
- * @since 3.0
- *
- * @return array An array of order status array keys that can be related to gross reporting.
- */
-function edd_gross_order_statuses() {
-	$statuses = array(
-		'completed',
-		'refunded',
-		'partially_refunded',
-		'revoked',
-	);
-
-	/**
-	 * Statuses that affect gross order statistics.
-	 *
-	 * This filter allows extensions and developers to alter the statuses that can affect the reporting of gross
-	 * sales statistics.
-	 *
-	 * @since 3.0
-	 *
-	 * @param array $statuses {
-	 *     An array of order status array keys.
-	 *
-	 */
-	return apply_filters( 'edd_gross_order_statuses', $statuses );
-}
-
-/**
- * Get the order status array keys that can be used to run reporting related to net reporting.
- *
- * @since 3.0
- *
- * @return array An array of order status array keys that can be related to net reporting.
- */
-function edd_net_order_statuses() {
-	$statuses = array(
-		'completed',
-		'partially_refunded',
-		'revoked',
-	);
-
-	/**
-	 * Statuses that affect net order statistics.
-	 *
-	 * This filter allows extensions and developers to alter the statuses that can affect the reporting of net
-	 * sales statistics.
-	 *
-	 * @since 3.0
-	 *
-	 * @param array $statuses {
-	 *     An array of order status array keys.
-	 *
-	 */
-	return apply_filters( 'edd_net_order_statuses', $statuses );
-}
-
 /** Compat ********************************************************************/
 
 /**

--- a/tests/reports/tests-reports-functions.php
+++ b/tests/reports/tests-reports-functions.php
@@ -792,23 +792,23 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 
 	public function test_gross_order_status() {
 		$expected = array(
-			'completed',
+			'complete',
 			'refunded',
 			'partially_refunded',
 			'revoked',
 		);
 
-		$this->assertSame( $expected, edd_gross_order_statuses() );
+		$this->assertSame( $expected, edd_get_gross_order_statuses() );
 	}
 
 	public function test_net_order_status() {
 		$expected = array(
-			'completed',
+			'complete',
 			'partially_refunded',
 			'revoked',
 		);
 
-		$this->assertSame( $expected, edd_net_order_statuses() );
+		$this->assertSame( $expected, edd_get_net_order_statuses() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8030

Proposed Changes:
1. Moves get statuses functions out of a namespace
2. Fixes `completed` status to `complete`
3. Renames `edd_*_order_statuses` to `edd_get_*_order_statuses`