### PR TITLE
Update migration for orders created with Manual Purchases extension

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -485,6 +485,10 @@ class Data_Migrator {
 			$parent = $wpdb->get_var( $wpdb->prepare( "SELECT edd_order_id FROM {$wpdb->edd_ordermeta} WHERE meta_key = %s AND meta_value = %d", esc_sql( 'legacy_order_id' ), $data->ID ) );
 		}
 
+		if ( 'manual_purchases' === $gateway && isset( $meta['_edd_payment_total'][0] ) ) {
+			$total = $meta['_edd_payment_total'][0];
+		}
+
 		// Build the order data before inserting.
 		$order_data = array(
 			'id'             => $data->ID,

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -486,7 +486,8 @@ class Data_Migrator {
 		}
 
 		if ( 'manual_purchases' === $gateway && isset( $meta['_edd_payment_total'][0] ) ) {
-			$total = $meta['_edd_payment_total'][0];
+			$gateway = 'manual';
+			$total   = $meta['_edd_payment_total'][0];
 		}
 
 		// Build the order data before inserting.

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -191,10 +191,6 @@ function edd_get_gateway_admin_label( $gateway ) {
 		? absint( $_GET['id'] )
 		: false;
 
-	if ( 'manual_purchases' === $gateway ) {
-		$label = __( 'Manual Payment', 'easy-digital-downloads' );
-	}
-
 	if ( 'manual' === $gateway && $payment ) {
 		if ( ! edd_get_payment_amount( $payment ) ) {
 			$label = __( 'Free Purchase', 'easy-digital-downloads' );
@@ -215,10 +211,6 @@ function edd_get_gateway_admin_label( $gateway ) {
 function edd_get_gateway_checkout_label( $gateway ) {
 	$gateways = edd_get_payment_gateways();
 	$label    = isset( $gateways[ $gateway ] ) ? $gateways[ $gateway ]['checkout_label'] : $gateway;
-
-	if ( 'manual_purchases' === $gateway ) {
-		$label = __( 'Manual Payment', 'easy-digital-downloads' );
-	}
 
 	if ( 'manual' === $gateway ) {
 		$label = __( 'Free Purchase', 'easy-digital-downloads' );

--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -191,6 +191,10 @@ function edd_get_gateway_admin_label( $gateway ) {
 		? absint( $_GET['id'] )
 		: false;
 
+	if ( 'manual_purchases' === $gateway ) {
+		$label = __( 'Manual Payment', 'easy-digital-downloads' );
+	}
+
 	if ( 'manual' === $gateway && $payment ) {
 		if ( ! edd_get_payment_amount( $payment ) ) {
 			$label = __( 'Free Purchase', 'easy-digital-downloads' );
@@ -211,6 +215,10 @@ function edd_get_gateway_admin_label( $gateway ) {
 function edd_get_gateway_checkout_label( $gateway ) {
 	$gateways = edd_get_payment_gateways();
 	$label    = isset( $gateways[ $gateway ] ) ? $gateways[ $gateway ]['checkout_label'] : $gateway;
+
+	if ( 'manual_purchases' === $gateway ) {
+		$label = __( 'Manual Payment', 'easy-digital-downloads' );
+	}
 
 	if ( 'manual' === $gateway ) {
 		$label = __( 'Free Purchase', 'easy-digital-downloads' );


### PR DESCRIPTION
Fixes #8033

Proposed Changes:
1. Since the Manual Purchases extension allows users to override the purchase total, use that if it is set.
2. Add a fallback label for orders with the `manual_purchases` gateway. This is currently set to "Manual Payment", which is what the extension uses, but could be changed.

**To Test:**
1. In a 2.9 storefront, use the Manual Purchases extension to create some orders. Make sure to override the purchase total on some.
2. Check out the `issue/8033` branch and migrate the payments. The order totals should reflect the manually set total, instead of the calculated total. (In `release/3.0`, the orders will use a calculated total, and will override the `_edd_payment_total` amount.