### PR TITLE
3.0 - Orders - Ensure Taxes Are Needed on Individual Order Items

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -1485,10 +1485,11 @@ function edd_admin_order_get_item_amounts() {
 		$discount += $discount_amount;
 	}
 
-	$use_taxes = edd_use_taxes();
-	$tax_rate  = edd_get_tax_rate( $country, $region, $fallback = false );
-
-	if ( true === $use_taxes && floatval( 0 ) !== floatval( $tax_rate ) ) {
+	if (
+		true === edd_use_taxes() &&
+		false === edd_download_is_tax_exclusive( $product_id )
+	) {
+		$tax_rate = edd_get_tax_rate( $country, $region, $fallback = false );
 		$tax = edd_calculate_tax( floatval( $subtotal - $discount ), $country, $region );
 	} else {
 		$tax = 0;


### PR DESCRIPTION
Fixes #8029 

Proposed Changes:
1. Ensure taxes are enabled on individual Downloads before settings.