### PR TITLE
Update dashboard widget, orders table, for sites which have not yet migrated (#7902)

### DIFF
--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -42,7 +42,19 @@ function edd_dashboard_sales_widget() {
 		global $wpdb;
 		$orders = $wpdb->get_var( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'edd_payment' LIMIT 1" );
 		if ( ! empty( $orders ) ) {
-			printf( '<p>%s</p>', esc_html__( 'Easy Digital Downloads needs to upgrade the database. This summary will be available when that has completed.', 'easy-digital-downloads' ) );
+			$url = add_query_arg(
+				array(
+					'page'        => 'edd-upgrades',
+					'edd-upgrade' => 'v30_migration',
+				),
+				admin_url( 'index.php' )
+			);
+			printf(
+				'<p>%1$s <a href="%2$s">%3$s</a></p>',
+				esc_html__( 'Easy Digital Downloads needs to upgrade the database. This summary will be available when that has completed.', 'easy-digital-downloads' ),
+				esc_url( $url ),
+				esc_html__( 'Begin the upgrade.', 'easy-digital-downloads' )
+			);
 			return;
 		}
 	}

--- a/includes/admin/dashboard-widgets.php
+++ b/includes/admin/dashboard-widgets.php
@@ -37,7 +37,15 @@ add_action('wp_dashboard_setup', 'edd_register_dashboard_widgets', 10 );
  * @since 1.2.2
  * @return void
  */
-function edd_dashboard_sales_widget( ) {
+function edd_dashboard_sales_widget() {
+	if ( ! edd_has_upgrade_completed( 'migrate_orders' ) ) {
+		global $wpdb;
+		$orders = $wpdb->get_var( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'edd_payment' LIMIT 1" );
+		if ( ! empty( $orders ) ) {
+			printf( '<p>%s</p>', esc_html__( 'Easy Digital Downloads needs to upgrade the database. This summary will be available when that has completed.', 'easy-digital-downloads' ) );
+			return;
+		}
+	}
 	wp_enqueue_script( 'edd-admin-dashboard' );
 	echo '<p><img src=" ' . esc_attr( set_url_scheme( EDD_PLUGIN_URL . 'assets/images/loading.gif', 'relative' ) ) . '"/></p>';
 }

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -366,6 +366,14 @@ class EDD_Payment_History_Table extends List_Table {
 	 * @since 3.0
 	 */
 	public function no_items() {
+		if ( ! edd_has_upgrade_completed( 'migrate_orders' ) ) {
+			global $wpdb;
+			$orders = $wpdb->get_var( "SELECT ID FROM {$wpdb->posts} WHERE post_type = 'edd_payment' LIMIT 1" );
+			if ( ! empty( $orders ) ) {
+				esc_html_e( 'Easy Digital Downloads needs to upgrade the database. Orders will be available when that has completed.', 'easy-digital-downloads' );
+				return;
+			}
+		}
 		esc_html_e( 'No orders found.', 'easy-digital-downloads' );
 	}
 


### PR DESCRIPTION
Fixes #7902

Proposed Changes:
If a storefront has has orders and hasn't done the migration process:
1. Changes the dashboard sales summary widget to explain that the information will be available once the migration is complete.
2. Updates the "no items" message for the orders table.

To test:
Update an existing 2.9 site to 3.0 but do not run the migration. Check the dashboard widget and the main orders table. The new messages should display.

Create a new 3.0 site with no orders. The new messages should not display.