### PR TITLE
Add "doing it wrong" when -1 is used in a query which no longer supports it (#7748)

### DIFF
--- a/includes/admin/reporting/class-export-customers.php
+++ b/includes/admin/reporting/class-export-customers.php
@@ -134,7 +134,7 @@ class EDD_Customers_Export extends EDD_Export {
 
 			// Export all customers
 			$customers = edd_get_customers( array(
-				'limit' => -1
+				'limit' => 9999999,
 			) );
 
 			$i = 0;

--- a/includes/admin/reporting/class-export-payments.php
+++ b/includes/admin/reporting/class-export-payments.php
@@ -102,7 +102,7 @@ class EDD_Payments_Export extends EDD_Export {
 
 		$payments = edd_get_payments( array(
 			'offset' => 0,
-			'number' => -1,
+			'number' => 9999999,
 			'mode'   => edd_is_test_mode() ? 'test' : 'live',
 			'status' => isset( $_POST['edd_export_payment_status'] ) ? $_POST['edd_export_payment_status'] : 'any',
 			'month'  => isset( $_POST['month'] ) ? absint( $_POST['month'] ) : date( 'n' ),

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -679,7 +679,7 @@ function edd_v21_upgrade_customers_db() {
 				'user'    => $email,
 				'order'   => 'ASC',
 				'orderby' => 'ID',
-				'number'  => -1,
+				'number'  => 9999999,
 				'page'    => $step
 			) );
 

--- a/includes/class-edd-customer.php
+++ b/includes/class-edd-customer.php
@@ -345,7 +345,7 @@ class EDD_Customer extends \EDD\Database\Rows\Customer {
 			if ( intval( $previous_user_id ) !== intval( $this->user_id ) ) {
 
 				// Update some payment meta if we need to
-				$order_ids = edd_get_orders( array( 'customer_id' => $this->id, 'number' => 9999 ) );
+				$order_ids = edd_get_orders( array( 'customer_id' => $this->id, 'number' => 9999999 ) );
 
 				foreach ( $order_ids as $order_id ) {
 					edd_update_order( $order_id, array( 'user_id' => $this->user_id ) );

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -219,6 +219,7 @@ function edd_get_customers( $args = array() ) {
 
 	if ( -1 == $args['number'] ) {
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'Do not use -1 to retrieve all results.', 'easy-digital-downloads' ), '3.0' );
+		$args['number'] = 9999999;
 	}
 
 	// Instantiate a query object

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -217,9 +217,9 @@ function edd_get_customers( $args = array() ) {
 		'number' => 30
 	) );
 
-	if ( -1 == $args['number'] ) {
+	if ( -1 == $r['number'] ) {
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'Do not use -1 to retrieve all results.', 'easy-digital-downloads' ), '3.0' );
-		$args['number'] = 9999999;
+		$r['number'] = 9999999;
 	}
 
 	// Instantiate a query object

--- a/includes/customer-functions.php
+++ b/includes/customer-functions.php
@@ -217,6 +217,10 @@ function edd_get_customers( $args = array() ) {
 		'number' => 30
 	) );
 
+	if ( -1 == $args['number'] ) {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'Do not use -1 to retrieve all results.', 'easy-digital-downloads' ), '3.0' );
+	}
+
 	// Instantiate a query object
 	$customers = new EDD\Database\Queries\Customer();
 

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -322,7 +322,7 @@ function edd_update_old_payments_with_totals( $data ) {
 
 	$payments = edd_get_payments( array(
 		'offset' => 0,
-		'number' => -1,
+		'number' => 9999999,
 		'mode'   => 'all',
 	) );
 
@@ -358,7 +358,7 @@ function edd_mark_abandoned_orders() {
 
 	$args = array(
 		'status' => 'pending',
-		'number' => -1,
+		'number' => 9999999,
 		'output' => 'edd_payments',
 	);
 

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -621,6 +621,7 @@ class EDD_Payments_Query extends EDD_Stats {
 
 		if ( isset( $this->initial_args['number'] ) ) {
 			if ( -1 == $this->initial_args['number'] ) {
+				_doing_it_wrong( __FUNCTION__, esc_html__( 'Do not use -1 to retrieve all results.', 'easy-digital-downloads' ), '3.0' );
 				$this->args['nopaging'] = true;
 			} else {
 				$arguments['number'] = $this->initial_args['number'];
@@ -633,7 +634,6 @@ class EDD_Payments_Query extends EDD_Stats {
 
 		if ( isset( $this->args['nopaging'] ) && true === $this->args['nopaging'] ) {
 			// Setting to a really large number because we don't actually have a way to get all results.
-			// @todo Maybe trigger doing_it_wrong.
 			$arguments['number'] = 99999;
 		}
 

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -634,7 +634,7 @@ class EDD_Payments_Query extends EDD_Stats {
 
 		if ( isset( $this->args['nopaging'] ) && true === $this->args['nopaging'] ) {
 			// Setting to a really large number because we don't actually have a way to get all results.
-			$arguments['number'] = 99999;
+			$arguments['number'] = 9999999;
 		}
 
 		switch ( $this->args['orderby'] ) {

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -288,7 +288,7 @@ function _edd_anonymize_customer( $customer_id = 0 ) {
 	$payments = edd_get_payments( array(
 		'customer' => $customer->id,
 		'output'   => 'payments',
-		'number'   => -1,
+		'number'   => 9999999,
 	) );
 
 	foreach ( $payments as $payment ) {

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -130,7 +130,7 @@ function edd_get_users_purchased_products( $user = 0, $status = 'complete' ) {
 	}
 
 	// Fetch the order IDs
-	$number = apply_filters( 'edd_users_purchased_products_payments', 9999 );
+	$number = apply_filters( 'edd_users_purchased_products_payments', 9999999 );
 
 	$order_ids = edd_get_orders( array(
 		'customer_id' => $customer->id,
@@ -197,7 +197,7 @@ function edd_has_user_purchased( $user_id = 0, $downloads = array(), $variable_p
 		return false;
 	}
 
-	$number = apply_filters( 'edd_users_purchased_products_payments', 9999 );
+	$number = apply_filters( 'edd_users_purchased_products_payments', 9999999 );
 
 	$where_id   = "'" . implode( "', '", $wpdb->_escape( $downloads ) ) . "'";
 	$product_id = "oi.product_id IN ({$where_id})";


### PR DESCRIPTION
Fixes #7748

Proposed Changes:
1. Replace `-1` with `9999999` when using new database queries
2. Add `_doing_it_wrong` if `-1` is used in `edd_get_customers` or `EDD_Payments`

What this doesn't currently cover is if someone were to bypass a function such as `edd_get_customers` in favor of calling the class directly using something like (if `$args['number'] => -1`):

```php
$customers = new EDD\Database\Queries\Customer();

return $customers->query( $args );
```