### PR TITLE
Allow used discounts to be selected for bulk actions (#7596)

### DIFF
--- a/includes/admin/discounts/class-discount-codes-table.php
+++ b/includes/admin/discounts/class-discount-codes-table.php
@@ -250,13 +250,11 @@ class EDD_Discount_Codes_Table extends List_Table {
 	 * @return string Checkbox HTML.
 	 */
 	public function column_cb( $discount ) {
-		return 0 < $discount->use_count
-			? '<input type="checkbox" title="' . esc_html__( 'This discount code cannot be deleted as it has already been used.', 'easy-digital-downloads' ) . '" disabled="disabled" />'
-			: sprintf(
-				'<input type="checkbox" name="%1$s[]" value="%2$s" />',
-				/*$1%s*/ 'discount',
-				/*$2%s*/ $discount->id
-			);
+		return sprintf(
+			'<input type="checkbox" name="%1$s[]" value="%2$s" />',
+			/*$1%s*/ 'discount',
+			/*$2%s*/ $discount->id
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #7596

Proposed Changes:
Change the checkbox column on the discounts list table to allow used discounts to be selected for bulk actions.

To test:
1. Create some discounts.
2. Use a discount.
3. Select multiple discounts, including the used one, and Deactivate them. Even the used discount should be deactivated (note: you may need to refresh the page again as the new discount state does not show on the initial refresh for me).
4. Select multiple discounts, including the used one, and Delete them. The used discount will not be deleted, but the others will.