### PR TITLE
Fix busiest day tile

### DIFF
--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -385,7 +385,7 @@ class Stats {
 				FROM {$this->query_vars['table']}
 				WHERE 1=1 {$this->query_vars['status_sql']} {$this->query_vars['where_sql']} {$this->query_vars['date_query_sql']}
 				GROUP BY day
-				ORDER BY day DESC
+				ORDER BY total DESC
 				LIMIT 1";
 
 		$result = $this->get_db()->get_row( $sql );


### PR DESCRIPTION
Fixes #8006

The MySQL query should be ordered by `total` rather than `day`.

To test:
Generate a lot of orders for a specific day (ideally not a Saturday). I used:
```
wp edd payments create --number=50 --generate_users=1
```
which generated 50 orders for today (Thursday) in an otherwise fairly empty store. Visit Downloads > Reports and see what day is the busiest.

Alternatively, generate orders for a random set of dates, spanning maybe a year, and try changing the report date filter. Theoretically, the busiest day in a week could be different than the busiest day in a year.