### PR TITLE
Update product dropdown placeholders for exports (#8046)

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2602,7 +2602,8 @@ function display_export_report() {
 									'name'        => 'download_id',
 									'id'          => 'edd_orders_export_download',
 									'chosen'      => true,
-									'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
+									/* translators: the plural post type label */
+									'placeholder' => sprintf( __( 'All %s', 'easy-digital-downloads' ), edd_get_label_plural() ),
 								) );
 
 				                echo EDD()->html->customer_dropdown( array(
@@ -2774,7 +2775,8 @@ function display_export_report() {
 									'name'        => 'download',
 									'id'          => 'edd_customer_export_download',
 									'chosen'      => true,
-									'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
+									/* translators: the plural post type label */
+									'placeholder' => sprintf( __( 'All %s', 'easy-digital-downloads' ), edd_get_label_plural() ),
 				                ) );
 
 				                wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' );
@@ -2829,7 +2831,8 @@ function display_export_report() {
 										'name'        => 'download_id',
 										'id'          => 'edd_download_export_download',
 										'chosen'      => true,
-										'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
+										/* translators: the plural post type label */
+										'placeholder' => sprintf( __( 'All %s', 'easy-digital-downloads' ), edd_get_label_plural() ),
 									)
 								); ?>
 								<?php wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' ); ?>
@@ -2880,7 +2883,8 @@ function display_export_report() {
 										'name'        => 'download_id',
 										'id'          => 'edd_file_download_export_download',
 										'chosen'      => true,
-										'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
+										/* translators: the plural post type label */
+										'placeholder' => sprintf( __( 'All %s', 'easy-digital-downloads' ), edd_get_label_plural() ),
 									)
 								); ?>
 								<span class="edd-from-to-wrapper">

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2598,11 +2598,12 @@ function display_export_report() {
 
 								?></span><?php
 
-				                echo EDD()->html->product_dropdown( array(
-					                'name'   => 'download_id',
-					                'id'     => 'edd_orders_export_download',
-					                'chosen' => true,
-				                ) );
+								echo EDD()->html->product_dropdown( array(
+									'name'        => 'download_id',
+									'id'          => 'edd_orders_export_download',
+									'chosen'      => true,
+									'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
+								) );
 
 				                echo EDD()->html->customer_dropdown( array(
 					                'name'          => 'customer_id',
@@ -2770,9 +2771,10 @@ function display_export_report() {
 				                ) );
 
 				                echo EDD()->html->product_dropdown( array(
-					                'name'   => 'download',
-					                'id'     => 'edd_customer_export_download',
-					                'chosen' => true,
+									'name'        => 'download',
+									'id'          => 'edd_customer_export_download',
+									'chosen'      => true,
+									'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
 				                ) );
 
 				                wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' );
@@ -2820,9 +2822,16 @@ function display_export_report() {
                     <div class="postbox edd-export-downloads">
                         <h3 class="hndle"><span><?php esc_html_e( sprintf( __( 'Export %s','easy-digital-downloads' ), edd_get_label_plural() ) ); ?></span></h3>
                         <div class="inside">
-                            <p><?php esc_html_e( sprintf( __( 'Download a CSV of %1$s. To download a CSV for all %1$s, leave "Choose a %2$s" as it is.', 'easy-digital-downloads' ), edd_get_label_plural( true ), edd_get_label_singular() ) ); ?></p>
+							<p><?php esc_html_e( sprintf( __( 'Download a CSV of %1$s.', 'easy-digital-downloads' ), edd_get_label_plural( true ) ) ); ?></p>
                             <form id="edd-export-file-downloads" class="edd-export-form edd-import-export-form" method="post">
-								<?php echo EDD()->html->product_dropdown( array( 'name' => 'download_id', 'id' => 'edd_download_export_download', 'chosen' => true ) ); ?>
+								<?php echo EDD()->html->product_dropdown(
+									array(
+										'name'        => 'download_id',
+										'id'          => 'edd_download_export_download',
+										'chosen'      => true,
+										'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
+									)
+								); ?>
 								<?php wp_nonce_field( 'edd_ajax_export', 'edd_ajax_export' ); ?>
                                 <input type="hidden" name="edd-export-class" value="EDD_Batch_Downloads_Export"/>
                                 <input type="submit" value="<?php esc_html_e( 'Generate CSV', 'easy-digital-downloads' ); ?>" class="button-secondary"/>
@@ -2864,9 +2873,16 @@ function display_export_report() {
                     <div class="postbox edd-export-download-history">
                         <h3 class="hndle"><span><?php esc_html_e('Export File Download Logs','easy-digital-downloads' ); ?></span></h3>
                         <div class="inside">
-                            <p><?php esc_html_e( 'Download a CSV of file downloads. To download a CSV for all file downloads, leave "Choose a Download" as it is.', 'easy-digital-downloads' ); ?></p>
+                            <p><?php esc_html_e( 'Download a CSV of file download logs.', 'easy-digital-downloads' ); ?></p>
                             <form id="edd-export-file-downloads" class="edd-export-form edd-import-export-form" method="post">
-								<?php echo EDD()->html->product_dropdown( array( 'name' => 'download_id', 'id' => 'edd_file_download_export_download', 'chosen' => true ) ); ?>
+								<?php echo EDD()->html->product_dropdown(
+									array(
+										'name'        => 'download_id',
+										'id'          => 'edd_file_download_export_download',
+										'chosen'      => true,
+										'placeholder' => __( 'All Downloads', 'easy-digital-downloads' ),
+									)
+								); ?>
 								<span class="edd-from-to-wrapper">
 									<?php
 


### PR DESCRIPTION
Fixes #8046

Proposed Changes:
1. Change the placeholder (default/`0` value) for the product dropdowns on Downloads > Reports > Export to say "All Downloads" (use `edd_get_label_plural` for storefronts which have modified the labels) instead of "Choose a Download".
2. Remove explanatory text which is no longer needed.