### PR TITLE
Update admin screens tabbed navigation

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1334,10 +1334,6 @@ textarea[name="edd-note"] {
 	margin: .10px 20px -12px 2px;
 }
 
-h2.nav-tab-wrapper.edd-tab-clear {
-	margin: -19px 0 0 0;
-}
-
 .edit-tags-php.post-type-download .wrap > .wp-heading-inline,
 .edit-php.post-type-download .wrap .wp-heading-inline,
 .download_page_edd-payment-history .wrap .wp-heading-inline,
@@ -3105,11 +3101,6 @@ body.download_page_edd-reports {
 }
 
 @media screen and ( max-width: 782px ) {
-
-	.post-type-download .nav-tab-wrapper a {
-		font-size: 70%;
-		padding: 2px 4px;
-	}
 	.license-lifetime-notice,
 	.license-expiration-date-notice,
 	.license-null {

--- a/includes/admin/adjustments/adjustment-functions.php
+++ b/includes/admin/adjustments/adjustment-functions.php
@@ -39,12 +39,12 @@ function edd_adjustments_page() {
 	// Start the output buffer
 	ob_start(); ?>
 
-    <div class="wrap">
-        <h1 class="wp-heading-inline"><?php _e( 'Adjustments', 'easy-digital-downloads' ); ?></h1>
+	<div class="wrap">
+		<h1 class="wp-heading-inline"><?php esc_html_e( 'Adjustments', 'easy-digital-downloads' ); ?></h1>
 
 		<hr class="wp-header-end">
 
-        <h2 class="nav-tab-wrapper edd-nav-tab-wrapper">
+		<nav class="nav-tab-wrapper edd-nav-tab-wrapper" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>">
 			<?php
 
 			// Loop through all tabs
@@ -71,7 +71,7 @@ function edd_adjustments_page() {
 			<?php endforeach; ?>
 
 			<a href="<?php echo esc_url( $add_new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New', 'easy-digital-downloads' ); ?></a>
-        </h2>
+			</nav>
 		<br>
 
 		<?php do_action( 'edd_adjustments_page_' . $active_tab ); ?>

--- a/includes/admin/admin-actions.php
+++ b/includes/admin/admin-actions.php
@@ -207,23 +207,26 @@ function edd_display_product_tabs() {
 	ob_start() ?>
 
 	<div class="clear"></div>
-	<h2 class="nav-tab-wrapper edd-nav-tab-wrapper edd-tab-clear">
+	<nav class="nav-tab-wrapper wp-clearfix" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>">
 		<?php
 
 		foreach ( $tabs as $tab_id => $tab ) {
-			$active = ( $active_tab === $tab_id )
-				? ' nav-tab-active'
-				: '';
-
-			echo '<a href="' . esc_url( $tab['url'] ) . '" class="nav-tab' . esc_attr( $active ) . '">';
-			echo esc_html( $tab['name'] );
-			echo '</a>';
+			$class = 'nav-tab';
+			if ( $active_tab === $tab_id ) {
+				$class .= ' nav-tab-active';
+			}
+			printf(
+				'<a href="%s" class="%s">%s</a>',
+				esc_url( $tab['url'] ),
+				esc_attr( $class ),
+				esc_html( $tab['name'] )
+			);
 		} ?>
 
-		<a href="<?php echo admin_url( 'post-new.php?post_type=download' ); ?>" class="page-title-action">
-			<?php _e( 'Add New', 'easy-digital-downloads' ); ?>
+		<a href="<?php echo esc_url( edd_get_admin_url() ); ?>" class="page-title-action">
+			<?php esc_html_e( 'Add New', 'easy-digital-downloads' ); ?>
 		</a>
-	</h2>
+	</nav>
 	<br />
 
 	<?php

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -26,7 +26,7 @@ function edd_customers_page_primary_nav( $active_tab = '' ) {
 
 	ob_start();?>
 
-	<h2 class="nav-tab-wrapper edd-nav-tab-wrapper">
+	<nav class="nav-tab-wrapper edd-nav-tab-wrapper" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>">
 		<?php
 
 		// Get the pages
@@ -54,7 +54,7 @@ function edd_customers_page_primary_nav( $active_tab = '' ) {
 		}
 		?>
 		<!--<a href="<?php echo esc_url( $add_new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New', 'easy-digital-downloads' ); ?></a>-->
-	</h2>
+	</nav>
 
 	<?php
 

--- a/includes/admin/payments/payments-history.php
+++ b/includes/admin/payments/payments-history.php
@@ -26,7 +26,7 @@ function edd_orders_page_primary_nav( $active_tab = '' ) {
 
 	ob_start();?>
 
-	<h2 class="nav-tab-wrapper edd-nav-tab-wrapper">
+	<nav class="nav-tab-wrapper edd-nav-tab-wrapper" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>">
 		<?php
 
 		// Get the order pages
@@ -54,7 +54,7 @@ function edd_orders_page_primary_nav( $active_tab = '' ) {
 		}
 		?>
 		<a href="<?php echo esc_url( $add_new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New', 'easy-digital-downloads' ); ?></a>
-	</h2>
+	</nav>
 
 	<?php
 

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -23,7 +23,7 @@ function edd_options_page_primary_nav( $active_tab = '' ) {
 
 	ob_start();?>
 
-	<h2 class="nav-tab-wrapper edd-nav-tab-wrapper edd-settings-nav">
+	<nav class="nav-tab-wrapper edd-nav-tab-wrapper edd-settings-nav" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>">
 		<?php
 
 		foreach ( $tabs as $tab_id => $tab_name ) {
@@ -44,7 +44,7 @@ function edd_options_page_primary_nav( $active_tab = '' ) {
 			echo '</a>';
 		}
 		?>
-	</h2>
+	</nav>
 
 	<?php
 

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -39,34 +39,41 @@ function edd_tools_page() {
 		<h1><?php esc_html_e( 'Tools', 'easy-digital-downloads' ); ?></h1>
 		<hr class="wp-header-end">
 
-		<nav class="nav-tab-wrapper edd-nav-tab-wrapper" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>"><?php
+		<nav class="nav-tab-wrapper edd-nav-tab-wrapper" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>">
+		<?php
 
-			foreach ( $tabs as $tab_id => $tab_name ) {
+		foreach ( $tabs as $tab_id => $tab_name ) {
 
-				$tab_url = edd_get_admin_url( array(
+			$tab_url = edd_get_admin_url(
+				array(
 					'page' => 'edd-tools',
-					'tab'  => $tab_id
-				) );
+					'tab'  => $tab_id,
+				)
+			);
 
-				$tab_url = remove_query_arg( array(
+			$tab_url = remove_query_arg(
+				array(
 					'edd-message',
-				), $tab_url );
+				),
+				$tab_url
+			);
 
-				$active = ( $active_tab === $tab_id )
-					? ' nav-tab-active'
-					: '';
+			$active = ( $active_tab === $tab_id )
+				? ' nav-tab-active'
+				: '';
 
-				echo '<a href="' . esc_url( $tab_url ) . '" class="nav-tab' . esc_attr( $active ) . '">' . esc_html( $tab_name ) . '</a>';
-			}
+			echo '<a href="' . esc_url( $tab_url ) . '" class="nav-tab' . esc_attr( $active ) . '">' . esc_html( $tab_name ) . '</a>';
+		}
 
-		?></nav>
+		?>
+		</nav>
 
-        <div class="metabox-holder">
+		<div class="metabox-holder">
 			<?php
 			do_action( 'edd_tools_tab_' . $active_tab );
 			?>
-        </div><!-- .metabox-holder -->
-    </div><!-- .wrap -->
+		</div><!-- .metabox-holder -->
+	</div><!-- .wrap -->
 
 	<?php
 }

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -35,11 +35,11 @@ function edd_tools_page() {
 	}
 ?>
 
-    <div class="wrap">
-        <h1><?php _e( 'Tools', 'easy-digital-downloads' ); ?></h1>
+	<div class="wrap">
+		<h1><?php esc_html_e( 'Tools', 'easy-digital-downloads' ); ?></h1>
 		<hr class="wp-header-end">
 
-        <h2 class="nav-tab-wrapper edd-nav-tab-wrapper"><?php
+		<nav class="nav-tab-wrapper edd-nav-tab-wrapper" aria-label="<?php esc_attr_e( 'Secondary menu', 'easy-digital-downloads' ); ?>"><?php
 
 			foreach ( $tabs as $tab_id => $tab_name ) {
 
@@ -59,7 +59,7 @@ function edd_tools_page() {
 				echo '<a href="' . esc_url( $tab_url ) . '" class="nav-tab' . esc_attr( $active ) . '">' . esc_html( $tab_name ) . '</a>';
 			}
 
-		?></h2>
+		?></nav>
 
         <div class="metabox-holder">
 			<?php


### PR DESCRIPTION
Fixes #8055

Proposed Changes:
1. Change admin screens' tabbed navigation to use `nav` instead of `h2`
2. Adds `aria-label` to tabbed navigation
3. Removes unneeded CSS