### PR TITLE
Prevent empty discount rows showing in purchase confirmation (#8062)

### DIFF
--- a/templates/shortcode-receipt.php
+++ b/templates/shortcode-receipt.php
@@ -94,7 +94,7 @@ do_action( 'edd_payment_receipt_before_table', $payment, $edd_receipt_args );
 		</tr>
 		<?php endif; ?>
 
-		<?php if ( filter_var( $edd_receipt_args['discount'], FILTER_VALIDATE_BOOLEAN ) && isset( $user['discount'] ) && 'none' !== $user['discount'] ) : ?>
+		<?php if ( filter_var( $edd_receipt_args['discount'], FILTER_VALIDATE_BOOLEAN ) && ! empty( $user['discount'] ) && 'none' !== $user['discount'] ) : ?>
 			<tr>
 				<td><strong><?php esc_html_e( 'Discount(s)', 'easy-digital-downloads' ); ?>:</strong></td>
 				<td><?php echo esc_html( $user['discount'] ); ?></td>


### PR DESCRIPTION
Fixes #8062

Proposed Changes:
Update the check for discounts on a user's purchase.

To test: in `release/3.0`, create a front end purchase with no discounts applied. The "Discounts" row shows on the purchase confirmation screen, even though there are no discounts. Switch to this branch, reload, and the empty row will not display.