### PR TITLE
Add edd_api_sales_payment_data filter

### DIFF
--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -455,6 +455,8 @@ class EDD_API_V2 extends EDD_API_V1 {
 				$sales['sales'][ $i ]['discounts'] = ( ! empty( $discount_values ) ? $discount_values : null );;
 				$sales['sales'][ $i ]['products']  = $cart_items;
 
+				$sales['sales'][ $i ] = apply_filters( 'edd_api_sales_payment_data', $sales['sales'][ $i ], $payment, $this );
+
 				$i++;
 			}
 		}

--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -455,6 +455,15 @@ class EDD_API_V2 extends EDD_API_V1 {
 				$sales['sales'][ $i ]['discounts'] = ( ! empty( $discount_values ) ? $discount_values : null );;
 				$sales['sales'][ $i ]['products']  = $cart_items;
 
+				/**
+				 * Filters the data for a single sale in the Recent Sales API response.
+				 *
+				 * @since 2.9.24
+				 *
+				 * @param array       $data    The sale data.
+				 * @param EDD_Payment $payment The `EDD_Payment` instance.
+				 * @param EDD_API_V2  $api     The `EDD_API_V2` instance.
+				 */
 				$sales['sales'][ $i ] = apply_filters( 'edd_api_sales_payment_data', $sales['sales'][ $i ], $payment, $this );
 
 				$i++;


### PR DESCRIPTION

Proposed Changes:
1. Add a `edd_api_sales_payment_data_filter` to `EDD_API_V2::get_recent_sales()` to allow third parties to modify the data for each one of the sales returned by the `/edd/sales` API endpoint.

We would like to have this filter in EDD to help fixing a bug in the Jilt for EDD plugin.

The Jilt for EDD plugin extends the `/edd/sales` endpoint to add information about associated Jilt orders. We recently noticed that when the sequential order numbers feature is enabled, Jilt for EDD is unable to find the payment instance associated with the entries in the sales data, because in that case `$sale['ID']` has the value from the `_edd_payment_number` meta, instead of the ID of the payment instance.

We can workaround that by finding the payment instance by it's key (`$sale['key']`). However, that approach introduces a potentially expensive query by having to check the payment key against the `meta_value` column of the `postmeta` table, which is not indexed. Most users shouldn't be affected, but we have seen performance issues from similar queries on websites with a large number of payments/orders and would like to avoid the query in this case if possible.

Thanks for taking a look!

---

What do you normally use as the value for the `since` tag during development? I used `2.9.24` because I think that's the next patch version, but I don't really know if or when this change will be added.
