### PR TITLE
fixed: edd_quantity_updated should trigger when add item to cart #8080

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -233,8 +233,10 @@ jQuery(document).ready(function ($) {
 
 					$('span.edd-cart-quantity').each(function() {
 						$(this).text(response.cart_quantity);
-						$(document.body).trigger('edd_quantity_updated', [ response.cart_quantity ]);
 					});
+
+					// Trigger the cart quantity
+					$(document.body).trigger('edd_quantity_updated', [ response.cart_quantity ]);
 
 					// Show the "number of items in cart" message
 					if ( $('.edd-cart-number-of-items').css('display') == 'none') {


### PR DESCRIPTION
Fixed: 'edd_quantity_updated' should trigger when add item to cart #8080

Proposed Changes:
1. `$(document.body).trigger('edd_quantity_updated', [ response.cart_quantity ]);` moved after 
```
$('span.edd-cart-quantity').each(function() {
	$(this).text(response.cart_quantity);	
});
```
so `$(document.body).trigger('edd_quantity_updated', [ response.cart_quantity ]);`  should be triggered after add any item to cart and no matter `span.edd-cart-quantity` DOM present or not.


