### PR TITLE
Issue/8083 Reorder args to check PHP first

### DIFF
--- a/includes/process-download.php
+++ b/includes/process-download.php
@@ -182,8 +182,8 @@ function edd_process_download() {
 		if ( ! edd_is_func_disabled( 'set_time_limit' ) ) {
 			@set_time_limit(0);
 		}
-		if ( function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime() && version_compare( phpversion(), '5.4', '<' ) ) {
-			set_magic_quotes_runtime(0);
+		if ( version_compare( phpversion(), '5.4', '<' ) && function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime() ) {
+			set_magic_quotes_runtime( 0 );
 		}
 
 		// If we're using an attachment ID to get the file, even by path, we can ignore this check.


### PR DESCRIPTION
Fixes #8083 

Proposed Changes:
1. Reordered args in call for `get/set_magic_quotes_runtime` to check PHP version first

Steps to Duplicate

- Use PHP 7.4.
- Install All Access Pass and configure that.
- Purchase a pass.
- Visit the page with the [downloads] shortcode and click the "Download" link to download a file.

I wasn't able to replicate this issue with just EDD.  I had to use the instructions above from #7818 to trigger the error.