### PR TITLE
Return 401 response on failed login and use wp_signon #6647

### DIFF
--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -135,7 +135,8 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 		edd_set_error(
 			'edd_invalid_login',
 			sprintf(
-				__( 'Invalid username or password. %sReset Password%s', 'easy-digital-downloads' ),
+				/* translators: %1$s Opening anchor tag, do not translate. %2$s Closing anchor tag, do not translate. */
+				__( 'Invalid username or password. %1$sReset Password%2$s', 'easy-digital-downloads' ),
 				'<a href="' . wp_lostpassword_url( edd_get_checkout_uri() ) . '">',
 				'</a>'
 			)

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -92,11 +92,19 @@ function edd_register_form( $redirect = '' ) {
 function edd_process_login_form( $data ) {
 
 	if ( ! empty( $data['edd_login_nonce'] ) && wp_verify_nonce( $data['edd_login_nonce'], 'edd-login-nonce' ) ) {
+		$login      = isset( $data['edd_user_login'] ) ? $data['edd_user_login'] : '';
+		$pass       = isset( $data['edd_user_pass'] ) ? $data['edd_user_pass'] : '';
 		$rememberme = isset( $data['rememberme'] );
 
-		$user = edd_log_user_in( 0, $data['edd_user_login'], $data['edd_user_pass'], $rememberme );
+		$user = edd_log_user_in( 0, $login, $pass, $rememberme );
 
-		// Check for errors and redirect if none present
+		// Wipe these variables so they aren't anywhere in the submitted format any longer.
+		$login = null;
+		$pass  = null;
+		$data['edd_user_login'] = null;
+		$data['edd_user_pass']  = null;
+
+		// Check for errors and redirect if none present.
 		$errors = edd_get_errors();
 		if ( ! $errors ) {
 			$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], 0 );

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -91,19 +91,18 @@ function edd_register_form( $redirect = '' ) {
 */
 function edd_process_login_form( $data ) {
 
-	if ( wp_verify_nonce( $data['edd_login_nonce'], 'edd-login-nonce' ) ) {
+	if ( ! empty( $data['edd_login_nonce'] ) && wp_verify_nonce( $data['edd_login_nonce'], 'edd-login-nonce' ) ) {
+		$rememberme = isset( $data['rememberme'] ) ? (bool) $data['rememberme'] : false;
 
-			$rememberme = isset( $data['rememberme'] ) ? (bool) $data['rememberme'] : false;
+		$user = edd_log_user_in( 0, $data['edd_user_login'], $data['edd_user_pass'], $rememberme );
 
-			$user = edd_log_user_in( 0, $data['edd_user_login'], $data['edd_user_pass'], $rememberme );
-
-			// Check for errors and redirect if none present
-			$errors = edd_get_errors();
-			if ( ! $errors ) {
-					$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], 0 );
-					wp_redirect( $redirect );
-					edd_die();
-			}
+		// Check for errors and redirect if none present
+		$errors = edd_get_errors();
+		if ( ! $errors ) {
+				$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], 0 );
+				wp_redirect( $redirect );
+				edd_die();
+		}
 	}
 }
 add_action( 'edd_user_login', 'edd_process_login_form' );

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -92,7 +92,7 @@ function edd_register_form( $redirect = '' ) {
 function edd_process_login_form( $data ) {
 
 	if ( ! empty( $data['edd_login_nonce'] ) && wp_verify_nonce( $data['edd_login_nonce'], 'edd-login-nonce' ) ) {
-		$rememberme = isset( $data['rememberme'] ) ? (bool) $data['rememberme'] : false;
+		$rememberme = isset( $data['rememberme'] );
 
 		$user = edd_log_user_in( 0, $data['edd_user_login'], $data['edd_user_pass'], $rememberme );
 

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -136,7 +136,7 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 			sprintf(
 				/* translators: %1$s Opening anchor tag, do not translate. %2$s Closing anchor tag, do not translate. */
 				__( 'Invalid username or password. %1$sReset Password%2$s', 'easy-digital-downloads' ),
-				'<a href="' . wp_lostpassword_url( edd_get_checkout_uri() ) . '">',
+				'<a href="' . esc_url( wp_lostpassword_url( edd_get_checkout_uri() ) ) . '">',
 				'</a>'
 			)
 		);

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -99,9 +99,9 @@ function edd_process_login_form( $data ) {
 		// Check for errors and redirect if none present
 		$errors = edd_get_errors();
 		if ( ! $errors ) {
-				$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], 0 );
-				wp_redirect( $redirect );
-				edd_die();
+			$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], 0 );
+			wp_redirect( $redirect );
+			edd_die();
 		}
 	}
 }

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -124,9 +124,9 @@ add_action( 'edd_user_login', 'edd_process_login_form' );
 function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false ) {
 
 	$credentials = array(
-			'user_login'    => $user_login,
-			'user_password' => $user_pass,
-			'remember'      => $remember,
+		'user_login'    => $user_login,
+		'user_password' => $user_pass,
+		'remember'      => $remember,
 	);
 
 	$user = wp_signon( $credentials );

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -31,8 +31,9 @@ function edd_login_form( $redirect = '' ) {
 
 	ob_start();
 
-	if ( ! empty( edd_get_errors() ) ) {
-		if ( array_key_exists( 'edd_invalid_login', edd_get_errors() ) ) {
+	$errors = edd_get_errors();
+	if ( ! empty( $errors ) ) {
+		if ( array_key_exists( 'edd_invalid_login', $errors ) ) {
 				status_header( 401 );
 		}
 	}
@@ -79,7 +80,9 @@ function edd_process_login_form( $data ) {
 
 	if ( wp_verify_nonce( $data['edd_login_nonce'], 'edd-login-nonce' ) ) {
 
-			$user = edd_log_user_in( 0, $data['edd_user_login'], $data['edd_user_pass'], $data['rememberme'] );
+			$rememberme = isset( $data['rememberme'] ) ? (bool) $data['rememberme'] : false;
+
+			$user = edd_log_user_in( 0, $data['edd_user_login'], $data['edd_user_pass'], $rememberme );
 
 			if ( ! $user instanceof WP_User ) {
 					edd_set_error( 'edd_invalid_login', __( 'Invalid username or password.', 'easy-digital-downloads' ) );
@@ -88,7 +91,7 @@ function edd_process_login_form( $data ) {
 			// Check for errors and redirect if none present
 			$errors = edd_get_errors();
 			if ( ! $errors ) {
-					$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], $user_ID );
+					$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], 0 );
 					wp_redirect( $redirect );
 					edd_die();
 			}

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -31,6 +31,12 @@ function edd_login_form( $redirect = '' ) {
 
 	ob_start();
 
+	if ( ! empty( edd_get_errors() ) ) {
+		if ( array_key_exists( 'edd_invalid_login', edd_get_errors() ) ) {
+				status_header( 401 );
+		}
+	}
+
 	edd_get_template_part( 'shortcode', 'login' );
 
 	return apply_filters( 'edd_login_form', ob_get_clean() );
@@ -64,49 +70,39 @@ function edd_register_form( $redirect = '' ) {
  * Process Login Form
  *
  * @since 1.0
+ * @since 2.9.24 No longer does validation which would prevent bruteforce detection plugins to be able to integrate.
+ *
  * @param array $data Data sent from the login form
  * @return void
 */
 function edd_process_login_form( $data ) {
+
 	if ( wp_verify_nonce( $data['edd_login_nonce'], 'edd-login-nonce' ) ) {
-		$user_data = get_user_by( 'login', $data['edd_user_login'] );
-		if ( ! $user_data ) {
-			$user_data = get_user_by( 'email', $data['edd_user_login'] );
-		}
-		if ( $user_data ) {
-			$user_ID = $user_data->ID;
-			$user_email = $user_data->user_email;
 
-			if ( wp_check_password( $data['edd_user_pass'], $user_data->user_pass, $user_data->ID ) ) {
+			$user = edd_log_user_in( 0, $data['edd_user_login'], $data['edd_user_pass'], $data['rememberme'] );
 
-				if ( isset( $data['rememberme'] ) ) {
-					$data['rememberme'] = true;
-				} else {
-					$data['rememberme'] = false;
-				}
-
-				edd_log_user_in( $user_data->ID, $data['edd_user_login'], $data['edd_user_pass'], $data['rememberme'] );
-			} else {
-				edd_set_error( 'password_incorrect', __( 'The password you entered is incorrect', 'easy-digital-downloads' ) );
+			if ( ! $user instanceof WP_User ) {
+					edd_set_error( 'edd_invalid_login', __( 'Invalid username or password.', 'easy-digital-downloads' ) );
 			}
-		} else {
-			edd_set_error( 'username_incorrect', __( 'The username you entered does not exist', 'easy-digital-downloads' ) );
-		}
-		// Check for errors and redirect if none present
-		$errors = edd_get_errors();
-		if ( ! $errors ) {
-			$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], $user_ID );
-			wp_redirect( $redirect );
-			edd_die();
-		}
+
+			// Check for errors and redirect if none present
+			$errors = edd_get_errors();
+			if ( ! $errors ) {
+					$redirect = apply_filters( 'edd_login_redirect', $data['edd_redirect'], $user_ID );
+					wp_redirect( $redirect );
+					edd_die();
+			}
 	}
 }
 add_action( 'edd_user_login', 'edd_process_login_form' );
+
 
 /**
  * Log User In
  *
  * @since 1.0
+ * @since 2.9.24 Uses the wp_signon function instead of all the additional checks which can bypass hooks in core.
+ *
  * @param int $user_id User ID
  * @param string $user_login Username
  * @param string $user_pass Password
@@ -114,13 +110,18 @@ add_action( 'edd_user_login', 'edd_process_login_form' );
  * @return void
 */
 function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false ) {
-	if ( $user_id < 1 )
-		return;
 
-	wp_set_auth_cookie( $user_id, $remember );
-	wp_set_current_user( $user_id, $user_login );
-	do_action( 'wp_login', $user_login, get_userdata( $user_id ) );
+	$credentials = array(
+			'user_login'    => $user_login,
+			'user_password' => $user_pass,
+			'remember'      => $remember,
+	);
+
+	$user = wp_signon( $credentials );
 	do_action( 'edd_log_user_in', $user_id, $user_login, $user_pass );
+
+	return $user;
+
 }
 
 

--- a/tests/tests-login-register.php
+++ b/tests/tests-login-register.php
@@ -37,8 +37,9 @@ class Tests_Login_Register extends EDD_UnitTestCase {
 			'edd_user_login'  => 'wrong_username',
 		) );
 
-		$this->assertArrayHasKey( 'username_incorrect', edd_get_errors() );
-		$this->assertContains( 'The username you entered does not exist', edd_get_errors() );
+		$errors = edd_get_errors();
+		$this->assertArrayHasKey( 'edd_invalid_login', $errors );
+		$this->assertContains( 'Invalid username or password', $errors['edd_invalid_login'] );
 
 		// Clear errors for other test
 		edd_clear_errors();
@@ -58,8 +59,9 @@ class Tests_Login_Register extends EDD_UnitTestCase {
 			'edd_user_pass'   => 'falsepass',
 		) );
 
-		$this->assertArrayHasKey( 'password_incorrect', edd_get_errors() );
-		$this->assertContains( 'The password you entered is incorrect', edd_get_errors() );
+		$errors = edd_get_errors();
+		$this->assertArrayHasKey( 'edd_invalid_login', $errors );
+		$this->assertContains( 'Invalid username or password', $errors['edd_invalid_login'] );
 
 		// Clear errors for other test
 		edd_clear_errors();
@@ -93,7 +95,7 @@ class Tests_Login_Register extends EDD_UnitTestCase {
 	 * @since 2.2.3
 	 */
 	public function test_log_user_in_return() {
-		$this->assertNull( edd_log_user_in( 0, '', '' ) );
+		$this->assertTrue( edd_log_user_in( 0, '', '' ) instanceof WP_Error );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #6647

Proposed Changes:
1. Adds a 401 status header when a login is failed.
2. Remove validation done by EDD so that core actions can run
3. Modify `edd_log_user_in` to use `wp_signon` instead of just setting cookies and doing actions, so that core actions can run.