### PR TITLE
Fix array key checks on cart quantities, and force string on strpos #8088

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,12 @@ matrix:
     - php: 7.3
       env: WP_VERSION=4.4.23 WP_MULTISITE=0
     - php: 7.4
+      env: WP_VERSION=5.2.7 WP_MULTISITE=0
+    - php: 7.4
+      env: WP_VERSION=5.1.6 WP_MULTISITE=0
+    - php: 7.4
+      env: WP_VERSION=5.0.10 WP_MULTISITE=0
+    - php: 7.4
       env: WP_VERSION=4.9.15 WP_MULTISITE=0
     - php: 7.4
       env: WP_VERSION=4.8.14 WP_MULTISITE=0

--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -421,7 +421,7 @@ class EDD_Cart {
 					'options'      => array(
 						'price_id' => preg_replace( '/[^0-9\.-]/', '', $price )
 					),
-					'quantity'     => $quantity[ $key ],
+					'quantity'     => is_array( $quantity ) && isset( $quantity[ $key ] ) ? $quantity[ $key ] : $quantity,
 				);
 			}
 		} else {

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -1276,8 +1276,8 @@ function edd_get_next_payment_number() {
  */
 function edd_remove_payment_prefix_postfix( $number ) {
 
-	$prefix  = edd_get_option( 'sequential_prefix' );
-	$postfix = edd_get_option( 'sequential_postfix' );
+	$prefix  = (string) edd_get_option( 'sequential_prefix' );
+	$postfix = (string) edd_get_option( 'sequential_postfix' );
 
 	// Remove prefix
 	$number = preg_replace( '/' . $prefix . '/', '', $number, 1 );


### PR DESCRIPTION
Fixes #8088

Proposed Changes:
1. Forces pre/postfix items to be strings.
2. Make sure the the quantity of multi-price products is an array.