### PR TITLE
Issue/8065 Data range styles 

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -3486,7 +3486,6 @@ body.download_page_edd-reports {
 	}
 
 	#edd-filters span {
-		display: block;
 		margin: 2px 0;
 	}
 

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -232,6 +232,11 @@ a.edd-delete:hover {
 	z-index: 9999 !important;
 }
 
+@media screen and (max-width: 782px) {
+	#edd-filters .filter-items > span:not(.edd-date-range-options) {
+		margin-bottom: 6px 6px 6px 0;
+	}
+}
 /* =Payment Icon Styling
 -------------------------------------------------------------- */
 

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -60,7 +60,6 @@ a.edd-delete:hover {
 .edd-from-to-wrapper input[name="start"],
 .edd-from-to-wrapper input[name="start-date"],
 .edd-from-to-wrapper input[name="filter_from"] {
-	border-right-color: #eee;
 	border-radius: 4px 0 0 4px;
 }
 
@@ -236,7 +235,7 @@ a.edd-delete:hover {
 }
 
 @media screen and (max-width: 782px) {
-	#edd-filters .filter-items > span:not(.edd-date-range-options) {
+	#edd-filters .filter-items {
 		margin: 6px 6px 6px 0;
 	}
 }

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -80,8 +80,8 @@ a.edd-delete:hover {
 .edd-from-to-wrapper input[name="start"]:focus,
 .edd-from-to-wrapper input[name="start-date"]:focus,
 .edd-from-to-wrapper input[name="filter_from"]:focus {
-	border-top-left-radius: 0;
-	border-bottom-left-radius: 0;
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
 }
 
 .edd-from-to-wrapper input[name="end"]:focus,

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -62,19 +62,21 @@ a.edd-delete:hover {
 	outline: auto 5px -webkit-focus-ring-color;
 	border-color: #eee;
 	box-shadow: none;
+	position: relative;
 }
 
 .edd-from-to-wrapper input[name="start"],
 .edd-from-to-wrapper input[name="start-date"],
 .edd-from-to-wrapper input[name="filter_from"] {
 	border-right-color: #eee;
+	border-radius: 4px 0 0 4px;
 }
 
 .edd-from-to-wrapper input[name="end"],
 .edd-from-to-wrapper input[name="end-date"],
 .edd-from-to-wrapper input[name="filter_to"] {
-	border-left-color: #eee;
 	margin-left: -1px;
+	border-radius: 0 4px 4px 0;
 }
 
 .edd-settings-sub-nav {
@@ -1250,7 +1252,6 @@ textarea[name="edd-note"] {
 #edd-filters input[type="text"].edd_datepicker,
 #edd-filters input[type="number"] {
 	max-width: 100px;
-	padding: 5px;
 }
 
 #edd-filters input[type="number"],

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -77,21 +77,6 @@ a.edd-delete:hover {
 	position: relative;
 }
 
-.edd-from-to-wrapper input[name="start"]:focus,
-.edd-from-to-wrapper input[name="start-date"]:focus,
-.edd-from-to-wrapper input[name="filter_from"]:focus {
-	border-top-right-radius: 0;
-	border-bottom-right-radius: 0;
-}
-
-.edd-from-to-wrapper input[name="end"]:focus,
-.edd-from-to-wrapper input[name="end-date"]:focus,
-.edd-from-to-wrapper input[name="filter_to"]:focus {
-	margin-left: -1px;
-	border-top-left-radius: 0;
-	border-bottom-left-radius: 0;
-}
-
 .edd-settings-sub-nav {
 	margin: 0 0px 10px 0;
 	width: 100%;

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -234,7 +234,7 @@ a.edd-delete:hover {
 
 @media screen and (max-width: 782px) {
 	#edd-filters .filter-items > span:not(.edd-date-range-options) {
-		margin-bottom: 6px 6px 6px 0;
+		margin: 6px 6px 6px 0;
 	}
 }
 /* =Payment Icon Styling

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -57,14 +57,6 @@ a.edd-delete:hover {
 	z-index: 1;
 }
 
-.edd-from-to-wrapper input:focus {
-	z-index: 2;
-	outline: auto 5px -webkit-focus-ring-color;
-	border-color: #eee;
-	box-shadow: none;
-	position: relative;
-}
-
 .edd-from-to-wrapper input[name="start"],
 .edd-from-to-wrapper input[name="start-date"],
 .edd-from-to-wrapper input[name="filter_from"] {
@@ -77,6 +69,17 @@ a.edd-delete:hover {
 .edd-from-to-wrapper input[name="filter_to"] {
 	margin-left: -1px;
 	border-radius: 0 4px 4px 0;
+}
+
+.edd-from-to-wrapper input:focus {
+	z-index: 2;
+	position: relative;
+}
+
+.edd-from-to-wrapper input[name="start"]:focus,
+.edd-from-to-wrapper input[name="start-date"]:focus,
+.edd-from-to-wrapper input[name="filter_from"]:focus {
+	border-radius: 4px 0 0 4px;
 }
 
 .edd-settings-sub-nav {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -60,14 +60,16 @@ a.edd-delete:hover {
 .edd-from-to-wrapper input[name="start"],
 .edd-from-to-wrapper input[name="start-date"],
 .edd-from-to-wrapper input[name="filter_from"] {
-	border-radius: 4px 0 0 4px;
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
 }
 
 .edd-from-to-wrapper input[name="end"],
 .edd-from-to-wrapper input[name="end-date"],
 .edd-from-to-wrapper input[name="filter_to"] {
 	margin-left: -1px;
-	border-radius: 0 4px 4px 0;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 .edd-from-to-wrapper input:focus {
@@ -78,7 +80,16 @@ a.edd-delete:hover {
 .edd-from-to-wrapper input[name="start"]:focus,
 .edd-from-to-wrapper input[name="start-date"]:focus,
 .edd-from-to-wrapper input[name="filter_from"]:focus {
-	border-radius: 4px 0 0 4px;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+}
+
+.edd-from-to-wrapper input[name="end"]:focus,
+.edd-from-to-wrapper input[name="end-date"]:focus,
+.edd-from-to-wrapper input[name="filter_to"]:focus {
+	margin-left: -1px;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
 }
 
 .edd-settings-sub-nav {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1236,7 +1236,6 @@ textarea[name="edd-note"] {
 #edd-filters .filter-items > span:not(.edd-date-range-options) {
 	display: inline-block;
 	margin-right: 6px;
-	/* max-width: 200px; */
 }
 
 #edd-filters .filter-items > #edd-date-filters {
@@ -1251,7 +1250,7 @@ textarea[name="edd-note"] {
 	margin-top: -30px;
 	margin-left: 2px;
 }
-/* Removed by Robin -- first selector only*/
+
 #edd-filters input[type="text"].edd_datepicker,
 #edd-filters input[type="number"] {
 	max-width: 105px;
@@ -2451,26 +2450,21 @@ body.download_page_edd-reports {
 .download_page_edd-reports #edd-item-wrapper {
 	margin: 0;
 }
+
 #edd-dashboard-widgets-wrap .postbox h2,
 #edd-dashboard-widgets-wrap .postbox h3 {
 	cursor: default;
 }
+
 #edd-filters .filter-items .edd-date-range-options {
-	/* Removed by Robin */
 	display: inline-block;
 	margin: 10px 4px 10px 0;
-	/* width: 200px; */
 }
 
 .edd-date-range-options .edd_datepicker {
-	width: 100px;
+	width: 105px;
 }
-.edd-date-range-options span span {
-	/* Removed by Robin */
-	/* float: left;
-	line-height: 29px;
-	height: 29px; */
-}
+
 .edd-report-wrap {
 	clear: both;
 }

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -51,7 +51,7 @@ a.edd-delete:hover {
 }
 
 .edd-from-to-wrapper input {
-	width: 100px;
+	width: 105px;
 	margin: 0;
 	position: relative;
 	z-index: 1;
@@ -1236,7 +1236,7 @@ textarea[name="edd-note"] {
 #edd-filters .filter-items > span:not(.edd-date-range-options) {
 	display: inline-block;
 	margin-right: 6px;
-	max-width: 200px;
+	/* max-width: 200px; */
 }
 
 #edd-filters .filter-items > #edd-date-filters {
@@ -1251,10 +1251,10 @@ textarea[name="edd-note"] {
 	margin-top: -30px;
 	margin-left: 2px;
 }
-
+/* Removed by Robin -- first selector only*/
 #edd-filters input[type="text"].edd_datepicker,
 #edd-filters input[type="number"] {
-	max-width: 100px;
+	max-width: 105px;
 }
 
 #edd-filters input[type="number"],
@@ -2456,19 +2456,20 @@ body.download_page_edd-reports {
 	cursor: default;
 }
 #edd-filters .filter-items .edd-date-range-options {
+	/* Removed by Robin */
 	display: inline-block;
 	margin: 10px 4px 10px 0;
-	width: 200px;
+	/* width: 200px; */
 }
 
 .edd-date-range-options .edd_datepicker {
 	width: 100px;
 }
-
 .edd-date-range-options span span {
-	float: left;
+	/* Removed by Robin */
+	/* float: left;
 	line-height: 29px;
-	height: 29px;
+	height: 29px; */
 }
 .edd-report-wrap {
 	clear: both;


### PR DESCRIPTION
Fixes #8065 

Proposed Changes:
1. Updated border-radius, border color, padding to more closely match core 
2. Removed display: block from `#edd-filters span` so that fields stay together when resized
3. Added media query to add margin under edd-filters on small screens

These changes work well in Chrome, but the heights of the the inputs and selects vary in Firefox.  Firefox loads correctly for a second and then the selects change height.  Maybe a Chosen side effect?
