### PR TITLE
check that inputs have lengths before checking them on remove download #8092

### DIFF
--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -453,11 +453,11 @@ jQuery(document).ready(function ($) {
 					var quantity    = $('input[name="edd-payment-details-downloads['+key+'][quantity]"]').val();
 					var amount      = $('input[name="edd-payment-details-downloads['+key+'][amount]"]').val();
 
-					if ( $('input[name="edd-payment-details-downloads['+key+'][tax]"]') ) {
+					if ( $('input[name="edd-payment-details-downloads['+key+'][tax]"]').length ) {
 						var fees = $('input[name="edd-payment-details-downloads['+key+'][tax]"]').val();
 					}
 
-					if ( $('input[name="edd-payment-details-downloads['+key+'][fees]"]') ) {
+					if ( $('input[name="edd-payment-details-downloads['+key+'][fees]"]').length ) {
 						var fees = $.parseJSON( $('input[name="edd-payment-details-downloads['+key+'][fees]"]').val() );
 					}
 

--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -71,7 +71,7 @@ jQuery(document).ready(function ($) {
 						$('.edd-cart').each( function() {
 
 							var cart_wrapper = $(this).parent();
-							if ( cart_wrapper ) {
+							if ( cart_wrapper.length ) {
 								cart_wrapper.addClass('cart-empty')
 								cart_wrapper.removeClass('cart-not-empty');
 							}
@@ -213,7 +213,7 @@ jQuery(document).ready(function ($) {
 						$(response.cart_item).insertBefore(target);
 
 						var cart_wrapper = $(this).parent();
-						if ( cart_wrapper ) {
+						if ( cart_wrapper.length ) {
 							cart_wrapper.addClass('cart-not-empty')
 							cart_wrapper.removeClass('cart-empty');
 						}


### PR DESCRIPTION
Fixes #8092

Proposed Changes:
1. Adds `.length` attributes to the checks on the presense of the tax and fees inputs when removing a download from a payment in the admin.