### PR TITLE
Fixing checkout registration form to set the current user #8098

### DIFF
--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -166,64 +166,66 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 */
 function edd_process_register_form( $data ) {
 
-	if( is_user_logged_in() ) {
+	if ( is_user_logged_in() ) {
 		return;
 	}
 
-	if( empty( $_POST['edd_register_submit'] ) ) {
+	if ( empty( $_POST['edd_register_submit'] ) ) {
 		return;
 	}
 
 	do_action( 'edd_pre_process_register_form' );
 
-	if( empty( $data['edd_user_login'] ) ) {
+	if ( empty( $data['edd_user_login'] ) ) {
 		edd_set_error( 'empty_username', __( 'Invalid username', 'easy-digital-downloads' ) );
 	}
 
-	if( username_exists( $data['edd_user_login'] ) ) {
+	if ( username_exists( $data['edd_user_login'] ) ) {
 		edd_set_error( 'username_unavailable', __( 'Username already taken', 'easy-digital-downloads' ) );
 	}
 
-	if( ! validate_username( $data['edd_user_login'] ) ) {
+	if ( ! validate_username( $data['edd_user_login'] ) ) {
 		edd_set_error( 'username_invalid', __( 'Invalid username', 'easy-digital-downloads' ) );
 	}
 
-	if( email_exists( $data['edd_user_email'] ) ) {
+	if ( email_exists( $data['edd_user_email'] ) ) {
 		edd_set_error( 'email_unavailable', __( 'Email address already taken', 'easy-digital-downloads' ) );
 	}
 
-	if( empty( $data['edd_user_email'] ) || ! is_email( $data['edd_user_email'] ) ) {
+	if ( empty( $data['edd_user_email'] ) || ! is_email( $data['edd_user_email'] ) ) {
 		edd_set_error( 'email_invalid', __( 'Invalid email', 'easy-digital-downloads' ) );
 	}
 
-	if( ! empty( $data['edd_payment_email'] ) && $data['edd_payment_email'] != $data['edd_user_email'] && ! is_email( $data['edd_payment_email'] ) ) {
+	if ( ! empty( $data['edd_payment_email'] ) && $data['edd_payment_email'] != $data['edd_user_email'] && ! is_email( $data['edd_payment_email'] ) ) {
 		edd_set_error( 'payment_email_invalid', __( 'Invalid payment email', 'easy-digital-downloads' ) );
 	}
 
-	if( empty( $_POST['edd_user_pass'] ) ) {
+	if ( empty( $_POST['edd_user_pass'] ) ) {
 		edd_set_error( 'empty_password', __( 'Please enter a password', 'easy-digital-downloads' ) );
 	}
 
-	if( ( ! empty( $_POST['edd_user_pass'] ) && empty( $_POST['edd_user_pass2'] ) ) || ( $_POST['edd_user_pass'] !== $_POST['edd_user_pass2'] ) ) {
+	if ( ( ! empty( $_POST['edd_user_pass'] ) && empty( $_POST['edd_user_pass2'] ) ) || ( $_POST['edd_user_pass'] !== $_POST['edd_user_pass2'] ) ) {
 		edd_set_error( 'password_mismatch', __( 'Passwords do not match', 'easy-digital-downloads' ) );
 	}
 
 	do_action( 'edd_process_register_form' );
 
-	// Check for errors and redirect if none present
+	// Check for errors and redirect if none present.
 	$errors = edd_get_errors();
 
-	if (  empty( $errors ) ) {
+	if ( empty( $errors ) ) {
 
 		$redirect = apply_filters( 'edd_register_redirect', $data['edd_redirect'] );
 
-		edd_register_and_login_new_user( array(
-			'user_login'      => $data['edd_user_login'],
-			'user_pass'       => $data['edd_user_pass'],
-			'user_email'      => $data['edd_user_email'],
-			'user_registered' => date( 'Y-m-d H:i:s' ),
-			'role'            => get_option( 'default_role' )
-		) );
+		edd_register_and_login_new_user(
+			array(
+				'user_login'      => $data['edd_user_login'],
+				'user_pass'       => $data['edd_user_pass'],
+				'user_email'      => $data['edd_user_email'],
+				'user_registered' => date( 'Y-m-d H:i:s' ),
+				'role'            => get_option( 'default_role' ),
+			)
+		);
 
 		wp_redirect( $redirect );
 		edd_die();

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -148,9 +148,12 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 				'</a>'
 			)
 		);
-	}
+	} else {
+		// Since wp_signon doesn't set the current user, we need to do this.
+		wp_set_current_user( $user->ID );
 
-	do_action( 'edd_log_user_in', $user_id, $user_login, $user_pass );
+		do_action( 'edd_log_user_in', $user_id, $user_login, $user_pass );
+	}
 
 	return $user;
 

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -800,13 +800,15 @@ function edd_register_and_login_new_user( $user_data = array() ) {
 	do_action( 'edd_insert_user', $user_id, $user_data );
 
 	// Login new user.
-	edd_log_user_in( $user_id, $user_data['user_login'], $user_data['user_pass'] );
+	$user = edd_log_user_in( $user_id, $user_data['user_login'], $user_data['user_pass'] );
 
-	// Since wp_signon doesn't set the current user, we need to do this.
-	wp_set_current_user( $user_id );
+	// If we have errors after trying to use wp_signon, return -1.
+	if ( edd_get_errors() ) {
+		return -1;
+	}
 
 	// Return user id.
-	return $user_id;
+	return $user->ID;
 }
 
 /**

--- a/includes/process-purchase.php
+++ b/includes/process-purchase.php
@@ -25,15 +25,15 @@ function edd_process_purchase_form() {
 
 	do_action( 'edd_pre_process_purchase' );
 
-	// Make sure the cart isn't empty
+	// Make sure the cart isn't empty.
 	if ( ! edd_get_cart_contents() && ! edd_cart_has_fees() ) {
 		$valid_data = false;
 		edd_set_error( 'empty_cart', __( 'Your cart is empty', 'easy-digital-downloads' ) );
 	} else {
-		// Validate the form $_POST data
+		// Validate the form $_POST data.
 		$valid_data = edd_purchase_form_validate_fields();
 
-		// Allow themes and plugins to hook to errors
+		// Allow themes and plugins to hook to errors.
 		do_action( 'edd_checkout_error_checks', $valid_data, $_POST );
 	}
 
@@ -52,15 +52,15 @@ function edd_process_purchase_form() {
 		}
 	}
 
-	// Process the login form
+	// Process the login form.
 	if ( isset( $_POST['edd_login_submit'] ) ) {
 		edd_process_purchase_login();
 	}
 
-	// Validate the user
+	// Validate the user.
 	$user = edd_get_purchase_form_user( $valid_data );
 
-	// Let extensions validate fields after user is logged in if user has used login/registration form
+	// Let extensions validate fields after user is logged in if user has used login/registration form.
 	do_action( 'edd_checkout_user_error_checks', $user, $valid_data, $_POST );
 
 	if ( false === $valid_data || edd_get_errors() || ! $user ) {
@@ -77,7 +77,7 @@ function edd_process_purchase_form() {
 		edd_die();
 	}
 
-	// Setup user information
+	// Setup user information.
 	$user_info = array(
 		'id'         => $user['user_id'],
 		'email'      => $user['user_email'],
@@ -87,7 +87,7 @@ function edd_process_purchase_form() {
 		'address'    => ! empty( $user['address'] ) ? $user['address'] : array(),
 	);
 
-	// Update a customer record if they have added/updated information
+	// Update a customer record if they have added/updated information.
 	$customer = new EDD_Customer( $user_info['email'] );
 
 	$name = $user_info['first_name'] . ' ' . $user_info['last_name'];
@@ -96,7 +96,7 @@ function edd_process_purchase_form() {
 			'name' => $name
 		);
 
-		// Update the customer's name and update the user record too
+		// Update the customer's name and update the user record too.
 		$customer->update( $update_data );
 		wp_update_user( array(
 			'ID'         => get_current_user_id(),
@@ -105,7 +105,7 @@ function edd_process_purchase_form() {
 		) );
 	}
 
-	// Update the customer's address if different to what's in the database
+	// Update the customer's address if different to what's in the database.
 	$address = get_user_meta( $customer->user_id, '_edd_user_address', true );
 	if ( ! is_array( $address ) ) {
 		$address = array();
@@ -127,20 +127,20 @@ function edd_process_purchase_form() {
 
 	if ( ! empty( $existing_payment ) ) {
 		$payment = new EDD_Payment( $existing_payment );
-		if( $payment->is_recoverable() && ! empty( $payment->key ) ) {
+		if ( $payment->is_recoverable() && ! empty( $payment->key ) ) {
 			$purchase_key = $payment->key;
 		}
 	}
 
-	// Setup purchase information
+	// Setup purchase information.
 	$purchase_data = array(
 		'downloads'    => edd_get_cart_contents(),
-		'fees'         => edd_get_cart_fees(),        // Any arbitrary fees that have been added to the cart
-		'subtotal'     => edd_get_cart_subtotal(),    // Amount before taxes and discounts
-		'discount'     => edd_get_cart_discounted_amount(), // Discounted amount
-		'tax'          => edd_get_cart_tax(),               // Taxed amount
-		'tax_rate'     => edd_use_taxes() ? edd_get_cart_tax_rate( $card_country, $card_state, $card_zip ) : 0, // Tax rate
-		'price'        => edd_get_cart_total(),    // Amount after taxes
+		'fees'         => edd_get_cart_fees(),        // Any arbitrary fees that have been added to the cart.
+		'subtotal'     => edd_get_cart_subtotal(),    // Amount before taxes and discounts.
+		'discount'     => edd_get_cart_discounted_amount(), // Discounted amount.
+		'tax'          => edd_get_cart_tax(),               // Taxed amount.
+		'tax_rate'     => edd_use_taxes() ? edd_get_cart_tax_rate( $card_country, $card_state, $card_zip ) : 0, // Tax rate.
+		'price'        => edd_get_cart_total(),    // Amount after taxes.
 		'purchase_key' => $purchase_key,
 		'user_email'   => $user['user_email'],
 		'date'         => date( 'Y-m-d H:i:s', current_time( 'timestamp' ) ),
@@ -151,36 +151,37 @@ function edd_process_purchase_form() {
 		'card_info'    => $valid_data['cc_info']
 	);
 
-	// Add the user data for hooks
+	// Add the user data for hooks.
 	$valid_data['user'] = $user;
 
-	// Allow themes and plugins to hook before the gateway
+	// Allow themes and plugins to hook before the gateway.
 	do_action( 'edd_checkout_before_gateway', $_POST, $user_info, $valid_data );
 
-	// If the total amount in the cart is 0, send to the manual gateway. This emulates a free download purchase
-	if ( !$purchase_data['price'] ) {
-		// Revert to manual
+	// If the total amount in the cart is 0, send to the manual gateway. This emulates a free download purchase.
+	if ( ! $purchase_data['price'] ) {
+
+		// Revert to manual.
 		$purchase_data['gateway'] = 'manual';
 		$_POST['edd-gateway'] = 'manual';
 	}
 
-	// Allow the purchase data to be modified before it is sent to the gateway
+	// Allow the purchase data to be modified before it is sent to the gateway.
 	$purchase_data = apply_filters(
 		'edd_purchase_data_before_gateway',
 		$purchase_data,
 		$valid_data
 	);
 
-	// Setup the data we're storing in the purchase session
+	// Setup the data we're storing in the purchase session.
 	$session_data = $purchase_data;
 
-	// Make sure credit card numbers are never stored in sessions
+	// Make sure credit card numbers are never stored in sessions.
 	unset( $session_data['card_info']['card_number'] );
 
 	// Used for showing download links to non logged-in users after purchase, and for other plugins needing purchase data.
 	edd_set_purchase_session( $session_data );
 
-	// Send info to the gateway for payment processing
+	// Send info to the gateway for payment processing.
 	edd_send_to_gateway( $purchase_data['gateway'], $purchase_data );
 	edd_die();
 }
@@ -277,54 +278,56 @@ add_action( 'wp_ajax_nopriv_edd_process_checkout_login', 'edd_process_purchase_l
  * @return      bool|array
  */
 function edd_purchase_form_validate_fields() {
-	// Check if there is $_POST
-	if ( empty( $_POST ) ) return false;
+	// Check if there is $_POST.
+	if ( empty( $_POST ) ) {
+		return false;
+	}
 
-	// Start an array to collect valid data
+	// Start an array to collect valid data.
 	$valid_data = array(
-		'gateway'          => edd_purchase_form_validate_gateway(), // Gateway fallback
-		'discount'         => edd_purchase_form_validate_discounts(),    // Set default discount
-		'need_new_user'    => false,     // New user flag
-		'need_user_login'  => false,     // Login user flag
-		'logged_user_data' => array(),   // Logged user collected data
-		'new_user_data'    => array(),   // New user collected data
-		'login_user_data'  => array(),   // Login user collected data
-		'guest_user_data'  => array(),   // Guest user collected data
-		'cc_info'          => edd_purchase_form_validate_cc()    // Credit card info
+		'gateway'          => edd_purchase_form_validate_gateway(), // Gateway fallback.
+		'discount'         => edd_purchase_form_validate_discounts(),    // Set default discount.
+		'need_new_user'    => false,     // New user flag.
+		'need_user_login'  => false,     // Login user flag.
+		'logged_user_data' => array(),   // Logged user collected data.
+		'new_user_data'    => array(),   // New user collected data.
+		'login_user_data'  => array(),   // Login user collected data.
+		'guest_user_data'  => array(),   // Guest user collected data.
+		'cc_info'          => edd_purchase_form_validate_cc(),    // Credit card info.
 	);
 
-	// Validate agree to terms
+	// Validate agree to terms.
 	if ( '1' === edd_get_option( 'show_agree_to_terms', false ) ) {
 		edd_purchase_form_validate_agree_to_terms();
 	}
 
-	// Validate agree to privacy policy
+	// Validate agree to privacy policy.
 	if ( '1' === edd_get_option( 'show_agree_to_privacy_policy', false ) ) {
 		edd_purchase_form_validate_agree_to_privacy_policy();
 	}
 
 	if ( is_user_logged_in() ) {
-		// Collect logged in user data
+		// Collect logged in user data.
 		$valid_data['logged_in_user'] = edd_purchase_form_validate_logged_in_user();
-	} else if ( isset( $_POST['edd-purchase-var'] ) && $_POST['edd-purchase-var'] == 'needs-to-register' ) {
-		// Set new user registration as required
+	} elseif ( isset( $_POST['edd-purchase-var'] ) && 'needs-to-register' === $_POST['edd-purchase-var'] ) {
+		// Set new user registration as required.
 		$valid_data['need_new_user'] = true;
 
-		// Validate new user data
+		// Validate new user data.
 		$valid_data['new_user_data'] = edd_purchase_form_validate_new_user();
-		// Check if login validation is needed
-	} else if ( isset( $_POST['edd-purchase-var'] ) && $_POST['edd-purchase-var'] == 'needs-to-login' ) {
-		// Set user login as required
+		// Check if login validation is needed.
+	} elseif ( isset( $_POST['edd-purchase-var'] ) && 'needs-to-login' === $_POST['edd-purchase-var'] ) {
+		// Set user login as required.
 		$valid_data['need_user_login'] = true;
 
-		// Validate users login info
+		// Validate users login info.
 		$valid_data['login_user_data'] = edd_purchase_form_validate_user_login();
 	} else {
-		// Not registering or logging in, so setup guest user data
+		// Not registering or logging in, so setup guest user data.
 		$valid_data['guest_user_data'] = edd_purchase_form_validate_guest_user();
 	}
 
-	// Return collected data
+	// Return collected data.
 	return $valid_data;
 }
 
@@ -562,47 +565,51 @@ function edd_purchase_form_validate_logged_in_user() {
 function edd_purchase_form_validate_new_user() {
 	$registering_new_user = false;
 
-	// Start an empty array to collect valid user data
+	// Start an empty array to collect valid user data.
 	$valid_user_data = array(
-		// Assume there will be errors
-		'user_id' => -1,
-		// Get first name
-		'user_first' => isset( $_POST["edd_first"] ) ? sanitize_text_field( $_POST["edd_first"] ) : '',
-		// Get last name
-		'user_last' => isset( $_POST["edd_last"] ) ? sanitize_text_field( $_POST["edd_last"] ) : '',
+		'user_id'    => -1, // Assume there will be errors.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
+		'user_first' => isset( $_POST['edd_first'] ) ? sanitize_text_field( $_POST['edd_first'] ) : '', // Get first name.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
+		'user_last'  => isset( $_POST['edd_last'] ) ? sanitize_text_field( $_POST['edd_last'] ) : '', // Get last name.
 	);
 
-	// Check the new user's credentials against existing ones
-	$user_login   = isset( $_POST["edd_user_login"] ) ? trim( $_POST["edd_user_login"] ) : false;
+	// Check the new user's credentials against existing ones.
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
+	$user_login   = isset( $_POST['edd_user_login'] ) ? trim( $_POST['edd_user_login'] ) : false;
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 	$user_email   = isset( $_POST['edd_email'] ) ? trim( $_POST['edd_email'] ) : false;
-	$user_pass    = isset( $_POST["edd_user_pass"] ) ? trim( $_POST["edd_user_pass"] ) : false;
-	$pass_confirm = isset( $_POST["edd_user_pass_confirm"] ) ? trim( $_POST["edd_user_pass_confirm"] ) : false;
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
+	$user_pass    = isset( $_POST['edd_user_pass'] ) ? trim( $_POST['edd_user_pass'] ) : false;
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
+	$pass_confirm = isset( $_POST['edd_user_pass_confirm'] ) ? trim( $_POST['edd_user_pass_confirm'] ) : false;
 
-	// Loop through required fields and show error messages
+	// Loop through required fields and show error messages.
 	foreach ( edd_purchase_form_required_fields() as $field_name => $value ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce check happens earlier.
 		if ( in_array( $value, edd_purchase_form_required_fields() ) && empty( $_POST[ $field_name ] ) ) {
 			edd_set_error( $value['error_id'], $value['error_message'] );
 		}
 	}
 
-	// Check if we have an username to register
+	// Check if we have an username to register.
 	if ( $user_login && strlen( $user_login ) > 0 ) {
 		$registering_new_user = true;
 
-		// We have an user name, check if it already exists
+		// We have an user name, check if it already exists.
 		if ( username_exists( $user_login ) ) {
-			// Username already registered
+			// Username already registered.
 			edd_set_error( 'username_unavailable', __( 'Username already taken', 'easy-digital-downloads' ) );
-			// Check if it's valid
-		} else if ( ! edd_validate_username( $user_login ) ) {
-			// Invalid username
+			// Check if it's valid.
+		} elseif ( ! edd_validate_username( $user_login ) ) {
+			// Invalid username.
 			if ( is_multisite() ) {
 				edd_set_error( 'username_invalid', __( 'Invalid username. Only lowercase letters (a-z) and numbers are allowed', 'easy-digital-downloads' ) );
 			} else {
 				edd_set_error( 'username_invalid', __( 'Invalid username', 'easy-digital-downloads' ) );
 			}
 		} else {
-			// All the checks have run and it's good to go
+			// All the checks have run and it's good to go.
 			$valid_user_data['user_login'] = $user_login;
 		}
 	} else {
@@ -611,43 +618,43 @@ function edd_purchase_form_validate_new_user() {
 		}
 	}
 
-	// Check if we have an email to verify
+	// Check if we have an email to verify.
 	if ( $user_email && strlen( $user_email ) > 0 ) {
-		// Validate email
+		// Validate email.
 		if ( ! is_email( $user_email ) ) {
 			edd_set_error( 'email_invalid', __( 'Invalid email', 'easy-digital-downloads' ) );
-			// Check if email exists
+			// Check if email exists.
 		} else {
 			$customer = new EDD_Customer( $user_email );
 			if ( $registering_new_user && email_exists( $user_email ) ) {
 				edd_set_error( 'email_used', __( 'Email already used. Login or use a different email to complete your purchase.', 'easy-digital-downloads' ) );
 			} else {
-				// All the checks have run and it's good to go
+				// All the checks have run and it's good to go.
 				$valid_user_data['user_email'] = $user_email;
 			}
 		}
 	} else {
-		// No email
+		// No email.
 		edd_set_error( 'email_empty', __( 'Enter an email', 'easy-digital-downloads' ) );
 	}
 
-	// Check password
+	// Check password.
 	if ( $user_pass && $pass_confirm ) {
-		// Verify confirmation matches
-		if ( $user_pass != $pass_confirm ) {
-			// Passwords do not match
+		// Verify confirmation matches.
+		if ( $user_pass !== $pass_confirm ) {
+			// Passwords do not match.
 			edd_set_error( 'password_mismatch', __( 'Passwords don\'t match', 'easy-digital-downloads' ) );
 		} else {
-			// All is good to go
+			// All is good to go.
 			$valid_user_data['user_pass'] = $user_pass;
 		}
 	} else {
-		// Password or confirmation missing
+		// Password or confirmation missing.
 		if ( ! $user_pass && $registering_new_user ) {
-			// The password is invalid
+			// The password is invalid.
 			edd_set_error( 'password_empty', __( 'Enter a password', 'easy-digital-downloads' ) );
 		} else if ( ! $pass_confirm && $registering_new_user ) {
-			// Confirmation password is invalid
+			// Confirmation password is invalid.
 			edd_set_error( 'confirmation_empty', __( 'Enter the password confirmation', 'easy-digital-downloads' ) );
 		}
 	}
@@ -746,81 +753,99 @@ function edd_purchase_form_validate_guest_user() {
 }
 
 /**
- * Register And Login New User
+ * Register And Login New User.
  *
- * @param array   $user_data
+ * @since 1.0.8.1
  *
- * @access  private
- * @since  1.0.8.1
- * @return  integer
+ * @param array $user_data The data provided by the checkout page's registration form.
+ * @return integer
  */
 function edd_register_and_login_new_user( $user_data = array() ) {
-	// Verify the array
-	if ( empty( $user_data ) )
+
+	// Verify the array.
+	if ( empty( $user_data ) ) {
 		return -1;
+	}
 
-	if ( edd_get_errors() )
+	if ( edd_get_errors() ) {
 		return -1;
+	}
 
-	$user_args = apply_filters( 'edd_insert_user_args', array(
-		'user_login'      => isset( $user_data['user_login'] ) ? $user_data['user_login'] : '',
-		'user_pass'       => isset( $user_data['user_pass'] )  ? $user_data['user_pass']  : '',
-		'user_email'      => isset( $user_data['user_email'] ) ? $user_data['user_email'] : '',
-		'first_name'      => isset( $user_data['user_first'] ) ? $user_data['user_first'] : '',
-		'last_name'       => isset( $user_data['user_last'] )  ? $user_data['user_last']  : '',
-		'user_registered' => date( 'Y-m-d H:i:s' ),
-		'role'            => get_option( 'default_role' )
-	), $user_data );
+	$user_args = apply_filters(
+		'edd_insert_user_args',
+		array(
+			'user_login'      => isset( $user_data['user_login'] ) ? $user_data['user_login'] : '',
+			'user_pass'       => isset( $user_data['user_pass'] ) ? $user_data['user_pass'] : '',
+			'user_email'      => isset( $user_data['user_email'] ) ? $user_data['user_email'] : '',
+			'first_name'      => isset( $user_data['user_first'] ) ? $user_data['user_first'] : '',
+			'last_name'       => isset( $user_data['user_last'] ) ? $user_data['user_last'] : '',
+			'user_registered' => date( 'Y-m-d H:i:s' ),
+			'role'            => get_option( 'default_role' ),
+		),
+		$user_data
+	);
 
-	// Insert new user
+	// Insert new user.
 	$user_id = wp_insert_user( $user_args );
 
-	// Validate inserted user
-	if ( is_wp_error( $user_id ) )
+	// Validate inserted user.
+	if ( is_wp_error( $user_id ) ) {
 		return -1;
+	}
 
-	// Allow themes and plugins to filter the user data
+	// Allow themes and plugins to filter the user data.
 	$user_data = apply_filters( 'edd_insert_user_data', $user_data, $user_args );
 
-	// Allow themes and plugins to hook
+	// Allow themes and plugins to hook.
 	do_action( 'edd_insert_user', $user_id, $user_data );
 
-	// Login new user
+	// Login new user.
 	edd_log_user_in( $user_id, $user_data['user_login'], $user_data['user_pass'] );
 
-	// Return user id
+	// Since wp_signon doesn't set the current user, we need to do this.
+	wp_set_current_user( $user_id );
+
+	// Return user id.
 	return $user_id;
 }
 
 /**
  * Get Purchase Form User
  *
- * @param array   $valid_data
- *
  * @access  private
  * @since  1.0.8.1
+ *
+ * @param   array $valid_data The validated data from the checkout form validation.
  * @return  array
  */
 function edd_get_purchase_form_user( $valid_data = array() ) {
-	// Initialize user
+	// Initialize user.
 	$user    = false;
 	$is_ajax = defined( 'DOING_AJAX' ) && DOING_AJAX;
 
 	if ( $is_ajax ) {
-		// Do not create or login the user during the ajax submission (check for errors only)
+
+		// Do not create or login the user during the ajax submission (check for errors only).
 		return true;
-	} else if ( is_user_logged_in() ) {
-		// Set the valid user as the logged in collected data
+
+	} elseif ( is_user_logged_in() ) {
+
+		// Set the valid user as the logged in collected data.
 		$user = $valid_data['logged_in_user'];
-	} else if ( $valid_data['need_new_user'] === true || $valid_data['need_user_login'] === true  ) {
-		// New user registration
-		if ( $valid_data['need_new_user'] === true ) {
-			// Set user
+
+	} elseif ( true === $valid_data['need_new_user'] || true === $valid_data['need_user_login'] ) {
+
+		// New user registration.
+		if ( true === $valid_data['need_new_user'] ) {
+
+			// Set user.
 			$user = $valid_data['new_user_data'];
-			// Register and login new user
+
+			// Register and login new user.
 			$user['user_id'] = edd_register_and_login_new_user( $user );
-			// User login
-		} else if ( $valid_data['need_user_login'] === true  && ! $is_ajax ) {
+
+		} elseif ( true === $valid_data['need_user_login'] && ! $is_ajax ) { // User login.
+
 			/*
 			 * The login form is now processed in the edd_process_purchase_login() function.
 			 * This is still here for backwards compatibility.
@@ -831,11 +856,11 @@ function edd_get_purchase_form_user( $valid_data = array() ) {
 			 * instead of submitting the login form, meaning the customer is logged in during the purchase process.
 			 */
 
-			// Set user
+			// Set user.
 			$user = $valid_data['login_user_data'];
 
-			// Login user
-			if ( empty( $user ) || $user['user_id'] == -1 ) {
+			// Login user.
+			if ( empty( $user ) || -1 === $user['user_id'] ) {
 				edd_set_error( 'invalid_user', __( 'The user information is invalid', 'easy-digital-downloads' ) );
 				return false;
 			} else {
@@ -844,29 +869,28 @@ function edd_get_purchase_form_user( $valid_data = array() ) {
 		}
 	}
 
-	// Check guest checkout
+	// Check guest checkout.
 	if ( false === $user && false === edd_no_guest_checkout() ) {
-		// Set user
+		// Set user.
 		$user = $valid_data['guest_user_data'];
 	}
 
-	// Verify we have an user
+	// Verify we have an user.
 	if ( false === $user || empty( $user ) ) {
-		// Return false
 		return false;
 	}
 
-	// Get user first name
+	// Get user first name.
 	if ( ! isset( $user['user_first'] ) || strlen( trim( $user['user_first'] ) ) < 1 ) {
 		$user['user_first'] = isset( $_POST["edd_first"] ) ? strip_tags( trim( $_POST["edd_first"] ) ) : '';
 	}
 
-	// Get user last name
+	// Get user last name.
 	if ( ! isset( $user['user_last'] ) || strlen( trim( $user['user_last'] ) ) < 1 ) {
 		$user['user_last'] = isset( $_POST["edd_last"] ) ? strip_tags( trim( $_POST["edd_last"] ) ) : '';
 	}
 
-	// Get the user's billing address details
+	// Get the user's billing address details.
 	$user['address'] = array();
 	$user['address']['line1']   = ! empty( $_POST['card_address']    ) ? sanitize_text_field( $_POST['card_address']    ) : '';
 	$user['address']['line2']   = ! empty( $_POST['card_address_2']  ) ? sanitize_text_field( $_POST['card_address_2']  ) : '';
@@ -875,15 +899,16 @@ function edd_get_purchase_form_user( $valid_data = array() ) {
 	$user['address']['country'] = ! empty( $_POST['billing_country'] ) ? sanitize_text_field( $_POST['billing_country'] ) : '';
 	$user['address']['zip']     = ! empty( $_POST['card_zip']        ) ? sanitize_text_field( $_POST['card_zip']        ) : '';
 
-	if ( empty( $user['address']['country'] ) )
-		$user['address'] = false; // Country will always be set if address fields are present
+	if ( empty( $user['address']['country'] ) ) {
+		$user['address'] = false; // Country will always be set if address fields are present.
+	}
 
 	if ( ! empty( $user['user_id'] ) && $user['user_id'] > 0 && ! empty( $user['address'] ) ) {
-		// Store the address in the user's meta so the cart can be pre-populated with it on return purchases
+		// Store the address in the user's meta so the cart can be pre-populated with it on return purchases.
 		update_user_meta( $user['user_id'], '_edd_user_address', $user['address'] );
 	}
 
-	// Return valid user
+	// Return valid user.
 	return $user;
 }
 


### PR DESCRIPTION
Fixes #8098

Proposed Changes:
1. Boat-load of PHPCS fixes
2. In the `edd_register_and_login_new_user` function, we're now setting the WordPress user if logged in successfully.