### PR TITLE
Update WP versions for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ php:
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=5.2.5 WP_MULTISITE=0
-  - WP_VERSION=5.1.4 WP_MULTISITE=0
-  - WP_VERSION=5.0.8 WP_MULTISITE=0
-  - WP_VERSION=4.9.13 WP_MULTISITE=0
+  - WP_VERSION=5.4.2 WP_MULTISITE=0
+  - WP_VERSION=5.3.4 WP_MULTISITE=0
+  - WP_VERSION=5.2.7 WP_MULTISITE=0
+  - WP_VERSION=5.1.6 WP_MULTISITE=0
+  - WP_VERSION=5.0.10 WP_MULTISITE=0
+  - WP_VERSION=4.9.15 WP_MULTISITE=0
 
 matrix:
   include:
@@ -24,15 +26,15 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
   exclude:
     - php: 7.4
-      env: WP_VERSION=4.9.13 WP_MULTISITE=0
+      env: WP_VERSION=4.9.15 WP_MULTISITE=0
     - php: 7.4
-      env: WP_VERSION=5.0.8 WP_MULTISITE=0
+      env: WP_VERSION=5.0.10 WP_MULTISITE=0
     - php: 7.4
-      env: WP_VERSION=5.1.4 WP_MULTISITE=0
+      env: WP_VERSION=5.1.6 WP_MULTISITE=0
     - php: 7.4
-      env: WP_VERSION=5.2.5 WP_MULTISITE=0
+      env: WP_VERSION=5.2.7 WP_MULTISITE=0
     - php: 7.3
-      env: WP_VERSION=4.9.13 WP_MULTISITE=0
+      env: WP_VERSION=4.9.15 WP_MULTISITE=0
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
Fixes #8032

Proposed Changes:
1. Updates WordPress versions used for unit tests.

Include/exclude are not added/removed at this time.
