### PR TITLE
Add fallback parameter to edd_calculate_tax() function #8107

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -1498,8 +1498,7 @@ function edd_admin_order_get_item_amounts() {
 		true === edd_use_taxes() &&
 		false === edd_download_is_tax_exclusive( $product_id )
 	) {
-		$tax_rate = edd_get_tax_rate( $country, $region, $fallback = false );
-		$tax = edd_calculate_tax( floatval( $subtotal - $discount ), $country, $region );
+		$tax = edd_calculate_tax( floatval( $subtotal - $discount ), $country, $region, false );
 	} else {
 		$tax = 0;
 	}

--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -151,8 +151,9 @@ function edd_active_tax_rates_query_clauses( $clauses ) {
  *
  * @param string  $country Country.
  * @param string  $region  Region.
- * @param boolean $fallback Fall back to the current Customer's address information
- *                          or server $_POST data. Default true.
+ * @param boolean $fallback Fall back to (in order): server $_POST data, the current Customer's
+ *                          address information, then your store's Business Country setting.
+ *                          Default true.
  *
  * @return mixed|void
  */
@@ -264,8 +265,9 @@ function edd_get_formatted_tax_rate( $country = false, $state = false ) {
  * @param float  $amount  Amount.
  * @param string $country Country. Default base country.
  * @param string $region  Region. Default base region.
- * @param boolean $fallback Fall back to the current Customer's address information
- *                          or server $_POST data. Default true.
+ * @param boolean $fallback Fall back to (in order): server $_POST data, the current Customer's
+ *                          address information, then your store's Business Country setting.
+ *                          Default true.
  *
  * @return float $tax Taxed amount.
  */

--- a/includes/tax-functions.php
+++ b/includes/tax-functions.php
@@ -259,15 +259,18 @@ function edd_get_formatted_tax_rate( $country = false, $state = false ) {
  *
  * @since 1.3.3
  * @since 3.0 Renamed $state parameter to $region.
+ *            Added $fallback parameter.
  *
  * @param float  $amount  Amount.
  * @param string $country Country. Default base country.
  * @param string $region  Region. Default base region.
+ * @param boolean $fallback Fall back to the current Customer's address information
+ *                          or server $_POST data. Default true.
  *
  * @return float $tax Taxed amount.
  */
-function edd_calculate_tax( $amount = 0.00, $country = '', $region = '' ) {
-	$rate = edd_get_tax_rate( $country, $region );
+function edd_calculate_tax( $amount = 0.00, $country = '', $region = '', $fallback = true ) {
+	$rate = edd_get_tax_rate( $country, $region, $fallback );
 	$tax  = 0.00;
 
 	if ( edd_use_taxes() && $amount > 0 ) {


### PR DESCRIPTION
Fixes #8107

Proposed Changes:
1. Adds a `$fallback` parameter to the `edd_calculate_tax()` function. Set this to `false` when calling this function from inside `edd_admin_order_get_item_amounts()`.
2. Removes the `edd_get_tax_rate()` call (returned variable wasn't being used).

To test:

1. Make sure you have a `Business Country` set in Downloads > Settings > General.
2. Enable taxes and add a tax rate for your base country.
3. Manually create a new order via Downloads > Orders > Add New.
4. Add an item to your order, but do not set a customer/address, and ensure no tax is applied.

Also ensure that if you _do_ set a country that has a tax rate, tax is still applied. 