### PR TITLE
Update redirect when directing to lost password URL

### DIFF
--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -171,7 +171,7 @@ add_filter( 'wp_login_errors', 'edd_login_register_error_message', 10, 2 );
 function edd_login_register_error_message( $errors, $redirect ) {
 	$action_is_confirm   = ! empty( $_GET['checkemail'] ) && 'confirm' === sanitize_text_field( $_GET['checkemail'] );
 	$edd_action_is_reset = ! empty( $_GET['edd_reset_password'] ) && 'confirm' === sanitize_text_field( $_GET['checkemail'] );
-	$redirect_url        = ! empty( $_GET['edd_redirect'] ) ? esc_url( $_GET['edd_redirect'] ) : false;
+	$redirect_url        = ! empty( $_GET['edd_redirect'] ) ? $_GET['edd_redirect'] : false;
 	if ( $action_is_confirm && $edd_action_is_reset && $redirect_url ) {
 		$errors->remove( 'confirm' );
 		$errors->add(

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -181,14 +181,17 @@ add_filter( 'wp_login_errors', 'edd_login_register_error_message', 10, 2 );
  * @return void
  */
 function edd_login_register_error_message( $errors, $redirect ) {
-	if ( 'confirm' === filter_input( INPUT_GET, 'edd_reset_password', FILTER_SANITIZE_STRING ) ) {
+	$action_is_confirm   = 'confirm' === filter_input( INPUT_GET, 'checkemail', FILTER_SANITIZE_STRING );
+	$edd_action_is_reset = 'confirm' === filter_input( INPUT_GET, 'edd_reset_password', FILTER_SANITIZE_STRING );
+	$redirect_url        = filter_input( INPUT_GET, 'edd_redirect', FILTER_SANITIZE_URL );
+	if ( $action_is_confirm && $edd_action_is_reset ) {
 		$errors->remove( 'confirm' );
 		$errors->add(
 			'confirm',
 			sprintf(
 				/* translators: %s: Link to the referring page. */
 				__( 'Check your email for the confirmation link, then <a href="%s">return to what you were doing</a>.', 'easy-digital-downloads' ),
-				filter_input( INPUT_GET, 'edd_redirect', FILTER_SANITIZE_URL )
+				$redirect_url
 			),
 			'message'
 		);

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -147,7 +147,7 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 			'edd_reset_password' => 'confirm',
 			'edd_redirect'       => $url,
 		),
-		'wp-login.php'
+		wp_login_url()
 	);
 
 	if ( ! $user instanceof WP_User ) {

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -137,18 +137,6 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 	);
 
 	$user = wp_signon( $credentials );
-	$url  = wp_get_raw_referer();
-	if ( empty( $url ) ) {
-		$url = edd_get_checkout_uri();
-	}
-	$redirect = add_query_arg(
-		array(
-			'checkemail'         => 'confirm',
-			'edd_reset_password' => 'confirm',
-			'edd_redirect'       => esc_url_raw( $url ),
-		),
-		wp_login_url()
-	);
 
 	if ( ! $user instanceof WP_User ) {
 		edd_set_error(
@@ -156,7 +144,7 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 			sprintf(
 				/* translators: %1$s Opening anchor tag, do not translate. %2$s Closing anchor tag, do not translate. */
 				__( 'Invalid username or password. %1$sReset Password%2$s', 'easy-digital-downloads' ),
-				'<a href="' . esc_url( wp_lostpassword_url( $redirect ) ) . '">',
+				'<a href="' . esc_url( edd_get_lostpassword_url() ) . '">',
 				'</a>'
 			)
 		);
@@ -198,6 +186,30 @@ function edd_login_register_error_message( $errors, $redirect ) {
 	}
 
 	return $errors;
+}
+
+/**
+ * Gets the lost password URL, customized for EDD. Using this allows the password
+ * reset form to redirect to the login screen with the EDD custom confirmation message.
+ *
+ * @since 2.10
+ * @return string
+ */
+function edd_get_lostpassword_url() {
+	$url = wp_get_raw_referer();
+	if ( empty( $url ) ) {
+		$url = edd_get_checkout_uri();
+	}
+	$redirect = add_query_arg(
+		array(
+			'checkemail'         => 'confirm',
+			'edd_reset_password' => 'confirm',
+			'edd_redirect'       => esc_url_raw( $url ),
+		),
+		wp_login_url()
+	);
+
+	return wp_lostpassword_url( $redirect );
 }
 
 /**

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -200,10 +200,21 @@ function edd_login_register_error_message( $errors, $redirect ) {
  * @return string
  */
 function edd_get_lostpassword_url() {
-	$url = wp_get_raw_referer();
+	$url = false;
+	// `wp_get_raw_referer` was added in WP 4.5; this check is required as we still support 4.4.
+	if ( function_exists( 'wp_get_raw_referer' ) ) {
+		$url = wp_get_raw_referer();
+	} else {
+		if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
+			$url = wp_unslash( $_REQUEST['_wp_http_referer'] );
+		} elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
+			$url = wp_unslash( $_SERVER['HTTP_REFERER'] );
+		}
+	}
 	if ( empty( $url ) ) {
 		$url = edd_get_checkout_uri();
 	}
+	$url      = wp_validate_redirect( $url );
 	$redirect = add_query_arg(
 		array(
 			'checkemail'         => 'confirm',

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -200,8 +200,7 @@ function edd_login_register_error_message( $errors, $redirect ) {
  * @return string
  */
 function edd_get_lostpassword_url() {
-	$url      = edd_get_current_page_url();
-	$url      = wp_validate_redirect( $url, edd_get_checkout_uri() );
+	$url      = wp_validate_redirect( edd_get_current_page_url(), edd_get_checkout_uri() );
 	$redirect = add_query_arg(
 		array(
 			'checkemail'         => 'confirm',

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -200,17 +200,7 @@ function edd_login_register_error_message( $errors, $redirect ) {
  * @return string
  */
 function edd_get_lostpassword_url() {
-	$url = false;
-	// `wp_get_raw_referer` was added in WP 4.5; this check is required as we still support 4.4.
-	if ( function_exists( 'wp_get_raw_referer' ) ) {
-		$url = wp_get_raw_referer();
-	} else {
-		if ( ! empty( $_REQUEST['_wp_http_referer'] ) ) {
-			$url = wp_unslash( $_REQUEST['_wp_http_referer'] );
-		} elseif ( ! empty( $_SERVER['HTTP_REFERER'] ) ) {
-			$url = wp_unslash( $_SERVER['HTTP_REFERER'] );
-		}
-	}
+	$url      = edd_get_current_page_url();
 	$url      = wp_validate_redirect( $url, edd_get_checkout_uri() );
 	$redirect = add_query_arg(
 		array(

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -176,9 +176,13 @@ function edd_login_register_error_message( $errors, $redirect ) {
 		$errors->remove( 'confirm' );
 		$errors->add(
 			'confirm',
-			sprintf(
-				/* translators: %s: Link to the referring page. */
-				__( 'Check your email for the confirmation link, then <a href="%s">return to what you were doing</a>.', 'easy-digital-downloads' ),
+			apply_filters(
+				'edd_login_register_error_message',
+				sprintf(
+					/* translators: %s: Link to the referring page. */
+					__( 'Follow the instructions in the confirmation email you just received, then <a href="%s">return to what you were doing</a>.', 'easy-digital-downloads' ),
+					$redirect_url
+				),
 				$redirect_url
 			),
 			'message'

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -212,7 +212,12 @@ function edd_get_lostpassword_url() {
 		}
 	}
 	if ( empty( $url ) ) {
-		$url = edd_get_checkout_uri();
+		$login_redirect_page = edd_get_option( 'login_redirect_page', '' );
+		if ( ! empty( $login_redirect_page ) ) {
+			$url = get_permalink( $login_redirect_page );
+		} else {
+			$url = edd_get_checkout_uri();
+		}
 	}
 	$url      = wp_validate_redirect( $url );
 	$redirect = add_query_arg(

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -137,7 +137,10 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 	);
 
 	$user     = wp_signon( $credentials );
-	$redirect = $_SERVER['HTTP_REFERER'];
+	$redirect = wp_get_referer();
+	if ( empty( $redirect ) ) {
+		$redirect = edd_get_checkout_uri();
+	}
 
 	if ( ! $user instanceof WP_User ) {
 		edd_set_error(

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -172,7 +172,7 @@ function edd_login_register_error_message( $errors, $redirect ) {
 	$action_is_confirm   = 'confirm' === filter_input( INPUT_GET, 'checkemail', FILTER_SANITIZE_STRING );
 	$edd_action_is_reset = 'confirm' === filter_input( INPUT_GET, 'edd_reset_password', FILTER_SANITIZE_STRING );
 	$redirect_url        = filter_input( INPUT_GET, 'edd_redirect', FILTER_SANITIZE_URL );
-	if ( $action_is_confirm && $edd_action_is_reset ) {
+	if ( $action_is_confirm && $edd_action_is_reset && $redirect_url ) {
 		$errors->remove( 'confirm' );
 		$errors->add(
 			'confirm',
@@ -181,7 +181,7 @@ function edd_login_register_error_message( $errors, $redirect ) {
 				sprintf(
 					/* translators: %s: Link to the referring page. */
 					__( 'Follow the instructions in the confirmation email you just received, then <a href="%s">return to what you were doing</a>.', 'easy-digital-downloads' ),
-					$redirect_url
+					esc_url( $redirect_url )
 				),
 				$redirect_url
 			),

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -171,7 +171,7 @@ add_filter( 'wp_login_errors', 'edd_login_register_error_message', 10, 2 );
 function edd_login_register_error_message( $errors, $redirect ) {
 	$action_is_confirm   = ! empty( $_GET['checkemail'] ) && 'confirm' === sanitize_text_field( $_GET['checkemail'] );
 	$edd_action_is_reset = ! empty( $_GET['edd_reset_password'] ) && 'confirm' === sanitize_text_field( $_GET['checkemail'] );
-	$redirect_url        = ! empty( $_GET['edd_redirect'] ) ? $_GET['edd_redirect'] : false;
+	$redirect_url        = ! empty( $_GET['edd_redirect'] ) ? urldecode( $_GET['edd_redirect'] ) : false;
 	if ( $action_is_confirm && $edd_action_is_reset && $redirect_url ) {
 		$errors->remove( 'confirm' );
 		$errors->add(
@@ -216,7 +216,7 @@ function edd_get_lostpassword_url() {
 		array(
 			'checkemail'         => 'confirm',
 			'edd_reset_password' => 'confirm',
-			'edd_redirect'       => esc_url_raw( $url ),
+			'edd_redirect'       => urlencode( $url ),
 		),
 		wp_login_url()
 	);

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -137,7 +137,7 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 	);
 
 	$user = wp_signon( $credentials );
-	$url  = wp_get_referer();
+	$url  = wp_get_raw_referer();
 	if ( empty( $url ) ) {
 		$url = edd_get_checkout_uri();
 	}
@@ -145,7 +145,7 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 		array(
 			'checkemail'         => 'confirm',
 			'edd_reset_password' => 'confirm',
-			'edd_redirect'       => $url,
+			'edd_redirect'       => esc_url_raw( $url ),
 		),
 		wp_login_url()
 	);

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -211,15 +211,7 @@ function edd_get_lostpassword_url() {
 			$url = wp_unslash( $_SERVER['HTTP_REFERER'] );
 		}
 	}
-	if ( empty( $url ) ) {
-		$login_redirect_page = edd_get_option( 'login_redirect_page', '' );
-		if ( ! empty( $login_redirect_page ) ) {
-			$url = get_permalink( $login_redirect_page );
-		} else {
-			$url = edd_get_checkout_uri();
-		}
-	}
-	$url      = wp_validate_redirect( $url );
+	$url      = wp_validate_redirect( $url, edd_get_checkout_uri() );
 	$redirect = add_query_arg(
 		array(
 			'checkemail'         => 'confirm',

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -136,7 +136,8 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 		'remember'      => $remember,
 	);
 
-	$user = wp_signon( $credentials );
+	$user     = wp_signon( $credentials );
+	$redirect = $_SERVER['HTTP_REFERER'];
 
 	if ( ! $user instanceof WP_User ) {
 		edd_set_error(
@@ -144,7 +145,7 @@ function edd_log_user_in( $user_id, $user_login, $user_pass, $remember = false )
 			sprintf(
 				/* translators: %1$s Opening anchor tag, do not translate. %2$s Closing anchor tag, do not translate. */
 				__( 'Invalid username or password. %1$sReset Password%2$s', 'easy-digital-downloads' ),
-				'<a href="' . esc_url( wp_lostpassword_url( edd_get_checkout_uri() ) ) . '">',
+				'<a href="' . esc_url( wp_lostpassword_url( $redirect ) ) . '">',
 				'</a>'
 			)
 		);

--- a/includes/login-register.php
+++ b/includes/login-register.php
@@ -169,9 +169,9 @@ add_filter( 'wp_login_errors', 'edd_login_register_error_message', 10, 2 );
  * @return void
  */
 function edd_login_register_error_message( $errors, $redirect ) {
-	$action_is_confirm   = 'confirm' === filter_input( INPUT_GET, 'checkemail', FILTER_SANITIZE_STRING );
-	$edd_action_is_reset = 'confirm' === filter_input( INPUT_GET, 'edd_reset_password', FILTER_SANITIZE_STRING );
-	$redirect_url        = filter_input( INPUT_GET, 'edd_redirect', FILTER_SANITIZE_URL );
+	$action_is_confirm   = ! empty( $_GET['checkemail'] ) && 'confirm' === sanitize_text_field( $_GET['checkemail'] );
+	$edd_action_is_reset = ! empty( $_GET['edd_reset_password'] ) && 'confirm' === sanitize_text_field( $_GET['checkemail'] );
+	$redirect_url        = ! empty( $_GET['edd_redirect'] ) ? esc_url( $_GET['edd_redirect'] ) : false;
 	if ( $action_is_confirm && $edd_action_is_reset && $redirect_url ) {
 		$errors->remove( 'confirm' );
 		$errors->add(

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -534,7 +534,7 @@ function edd_recovery_force_login_fields() {
 			<div class="edd-alert edd-alert-info">
 				<p><?php _e( 'To complete this payment, please login to your account.', 'easy-digital-downloads' ); ?></p>
 				<p>
-					<a href="<?php echo edd_get_lostpassword_url(); ?>" title="<?php _e( 'Lost Password', 'easy-digital-downloads' ); ?>">
+					<a href="<?php echo esc_url( edd_get_lostpassword_url() ); ?>" title="<?php esc_attr_e( 'Lost Password', 'easy-digital-downloads' ); ?>">
 						<?php _e( 'Lost Password?', 'easy-digital-downloads' ); ?>
 					</a>
 				</p>

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -534,7 +534,7 @@ function edd_recovery_force_login_fields() {
 			<div class="edd-alert edd-alert-info">
 				<p><?php _e( 'To complete this payment, please login to your account.', 'easy-digital-downloads' ); ?></p>
 				<p>
-					<a href="<?php echo wp_lostpassword_url(); ?>" title="<?php _e( 'Lost Password', 'easy-digital-downloads' ); ?>">
+					<a href="<?php echo edd_get_lostpassword_url(); ?>" title="<?php _e( 'Lost Password', 'easy-digital-downloads' ); ?>">
 						<?php _e( 'Lost Password?', 'easy-digital-downloads' ); ?>
 					</a>
 				</p>

--- a/templates/shortcode-login.php
+++ b/templates/shortcode-login.php
@@ -29,7 +29,7 @@ if ( ! is_user_logged_in() ) :
 				<input id="edd_login_submit" type="submit" class="edd-submit" value="<?php _e( 'Log In', 'easy-digital-downloads' ); ?>"/>
 			</p>
 			<p class="edd-lost-password">
-				<a href="<?php echo edd_get_lostpassword_url(); ?>">
+				<a href="<?php echo esc_url( edd_get_lostpassword_url() ); ?>">
 					<?php _e( 'Lost Password?', 'easy-digital-downloads' ); ?>
 				</a>
 			</p>

--- a/templates/shortcode-login.php
+++ b/templates/shortcode-login.php
@@ -29,7 +29,7 @@ if ( ! is_user_logged_in() ) :
 				<input id="edd_login_submit" type="submit" class="edd-submit" value="<?php _e( 'Log In', 'easy-digital-downloads' ); ?>"/>
 			</p>
 			<p class="edd-lost-password">
-				<a href="<?php echo wp_lostpassword_url(); ?>">
+				<a href="<?php echo edd_get_lostpassword_url(); ?>">
 					<?php _e( 'Lost Password?', 'easy-digital-downloads' ); ?>
 				</a>
 			</p>


### PR DESCRIPTION
Fixes #8100

Proposed Changes:
1. Because the EDD login process isn't always part of the checkout process, the current referer is set as the redirect instead of hard coding in the checkout page.

Base set to 2.10.