### PR TITLE
Docblock: $downloads can be int edd_has_user_purchased()

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -199,7 +199,7 @@ function edd_get_users_purchased_products( $user = 0, $status = 'complete' ) {
  *
  * @since       1.0
  * @param       int $user_id - the ID of the user to check
- * @param       array $downloads - Array of IDs to check if purchased. If an int is passed, it will be converted to an array
+ * @param       array|int $downloads - Array of IDs to check if purchased. If an int is passed, it will be converted to an array
  * @param       int $variable_price_id - the variable price ID to check for
  * @return      boolean - true if has purchased, false otherwise
  */


### PR DESCRIPTION
This is supported functionality, but not reflected in the docBlocks.

Proposed Changes:
1. Fix the docblocks for edd_has_user_purchased()