### PR TITLE
Release/2.9.26

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -5,7 +5,7 @@
  * Description: The easiest way to sell digital products with WordPress.
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
- * Version: 2.9.25
+ * Version: 2.9.26
  * Text Domain: easy-digital-downloads
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EDD
  * @category Core
  * @author Pippin Williamson
- * @version 2.9.25
+ * @version 2.9.26
  */
 
 // Exit if accessed directly.
@@ -206,7 +206,7 @@ final class Easy_Digital_Downloads {
 
 		// Plugin version.
 		if ( ! defined( 'EDD_VERSION' ) ) {
-			define( 'EDD_VERSION', '2.9.25' );
+			define( 'EDD_VERSION', '2.9.26' );
 		}
 
 		// Plugin Folder Path.

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -2254,7 +2254,7 @@ function edd_jilt_callback( $args ) {
 
 		<?php endif; ?>
 
-	<?php else : ?>
+	<?php elseif( current_user_can( 'install_plugins' ) ) : ?>
 
 		<p>
 			<button id="edd-jilt-connect" class="button button-primary">

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -384,7 +384,7 @@ add_action( 'wp_ajax_edd_sendwp_disconnect', 'edd_sendwp_disconnect' );
  */
 function edd_jilt_remote_install_handler() {
 
-	if ( ! current_user_can( 'manage_shop_settings' ) ) {
+	if ( ! current_user_can( 'manage_shop_settings' ) || ! current_user_can( 'install_plugins' ) ) {
 		wp_send_json_error(
 			array(
 				'error' => __( 'You do not have permission to do this.', 'easy-digital-downloads' ),

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -199,7 +199,7 @@ function edd_get_users_purchased_products( $user = 0, $status = 'complete' ) {
  *
  * @since       1.0
  * @param       int $user_id - the ID of the user to check
- * @param       array $downloads - Array of IDs to check if purchased. If an int is passed, it will be converted to an array
+ * @param       array|int $downloads - Array of IDs to check if purchased. If an int is passed, it will be converted to an array
  * @param       int $variable_price_id - the variable price ID to check for
  * @return      boolean - true if has purchased, false otherwise
  */

--- a/languages/easy-digital-downloads.pot
+++ b/languages/easy-digital-downloads.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Easy Digital Downloads package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Easy Digital Downloads 2.9.25\n"
+"Project-Id-Version: Easy Digital Downloads 2.9.26\n"
 "Report-Msgid-Bugs-To: https://easydigitaldownloads.com/\n"
-"POT-Creation-Date: 2020-09-03 16:33:19+00:00\n"
+"POT-Creation-Date: 2020-10-02 06:35:46+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-digital-downloads",
-  "version": "2.9.25",
+  "version": "2.9.26",
   "private": true,
   "devDependencies": {
     "grunt": "^1.0.4",

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Contributors: easydigitaldownloads, mordauk, sunnyratilal, chriscct7, section214
 Donate link: https://easydigitaldownloads.com/donate/
 Tags: ecommerce, sell, checkout, payments, stripe
 Requires at least: 4.4
-Tested up to: 5.5
+Tested up to: 5.5.1
 Requires PHP: 5.3
-Stable Tag: 2.9.25
+Stable Tag: 2.9.26
 License: GNU Version 2 or Any Later Version
 
 Sell your digital products the simple way. Easily build an online store complete with a cart system, checkout forms, reports, coupons, and more!
@@ -253,6 +253,10 @@ For most stores, we recommend using the Stripe Payment Gateway.
 9. Checkout screen
 
 == Changelog ==
+= 2.9.26, October 1, 2020 =
+* Fix: Installation of the Jilt extension was allowed for non-super admins on multisite installs.
+* Dev: Improved DocBloc for edd_has_user_purchased() function.
+
 = 2.9.25, September 3, 2020 =
 * Fix: Using the registration form on checkout with guest checkout disabled, could result in errors when attempting to purchase.
 


### PR DESCRIPTION
| Issue # | Description |
|---------|-------------|
| #8122 | Docblock: $downloads can be int edd_has_user_purchased() |
| #8115 | Allow Jilt installation to super admins only when in MU |