### PR TITLE
Fix tax rate conversion when importing settings

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1096,7 +1096,8 @@ function edd_tools_import_export_process_import() {
 
 	edd_redirect( edd_get_admin_url( array(
 		'page'        => 'edd-tools',
-		'edd-message' => 'settings-imported'
+		'edd-message' => 'settings-imported',
+		'tab'         => 'import_export',
 	) ) );
 }
 add_action( 'edd_import_settings', 'edd_tools_import_export_process_import' );

--- a/includes/compat/class-tax.php
+++ b/includes/compat/class-tax.php
@@ -70,6 +70,9 @@ class Tax extends Base {
 		$value = (array) $value;
 
 		foreach ( $value as $tax_rate ) {
+			if ( empty( $tax_rate ) ) {
+				continue;
+			}
 			$scope = isset( $tax_rate['global'] )
 				? 'country'
 				: 'region';


### PR DESCRIPTION
Fixes #8133

Proposed Changes:
1. Do not attempt to convert empty tax rates.
2. Fixes the redirect link after settings are imported.