### PR TITLE
Issue 7385 - Fixed modify_cart_item() when decreasing tax and updated…

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1441,7 +1441,7 @@ class EDD_Payment {
 		if ( $modified_download['tax'] > $current_args['tax'] ) {
 			$this->increase_tax( $modified_download['tax'] - $current_args['tax'] );
 		} else {
-			$this->increase_tax( $current_args['tax'] - $modified_download['tax'] );
+			$this->decrease_tax( $current_args['tax'] - $modified_download['tax'] );
 		}
 
 		return true;

--- a/tests/tests-payment-class.php
+++ b/tests/tests-payment-class.php
@@ -895,6 +895,14 @@ class Tests_Payment_Class extends EDD_UnitTestCase {
 		$payment = new EDD_Payment( $payment->ID );
 		$this->assertEquals( 2, $payment->cart_details[0]['tax'] );
 		$this->assertEquals( 2, $payment->tax );
+
+		$payment = new EDD_Payment( $payment->ID );
+		$payment->modify_cart_item( 0, array( 'tax' => 0 ) );
+		$payment->save();
+
+		$payment = new EDD_Payment( $payment->ID );
+		$this->assertEquals( 0, $payment->cart_details[0]['tax'] );
+		$this->assertEquals( 0, $payment->tax );
 	}
 
 	public function modify_cart_item_no_changes() {


### PR DESCRIPTION
Fixed Issue 7385 - https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7385

Proposed Changes:
1. When using modify_cart_item() to modify the tax value, fixed bug where increase_tax() was being used for both increases/decreases. Instead use decrease_tax() when new value is lower than existing value.
2. Updated modify_cart_item_tax() unit test to check for both tax increases and decreases.