### PR TITLE
Prevent negative fees from getting applied twice #6837

### DIFF
--- a/includes/gateways/paypal-standard.php
+++ b/includes/gateways/paypal-standard.php
@@ -289,12 +289,21 @@ function edd_process_paypal_purchase( $purchase_data ) {
 			}
 		}
 
+		$price_before_discount = $purchase_data['price'];
 		if ( $discounted_amount > '0' ) {
 			$paypal_args['discount_amount_cart'] = edd_sanitize_amount( $discounted_amount );
+
+			/*
+			 * Add the discounted amount back onto the price to get the "price before discount". We do this
+			 * to avoid double applying any discounts below.
+			 * @link https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6837
+			 */
+			$price_before_discount += $paypal_args['discount_amount_cart'];
 		}
 
-		if( $paypal_sum > $purchase_data['price'] ) {
-			$difference = round( $paypal_sum - $purchase_data['price'], 2 );
+		// Check if there are any additional discounts we need to add that we haven't already accounted for.
+		if( $paypal_sum > $price_before_discount ) {
+			$difference = round( $paypal_sum - $price_before_discount, 2 );
 			if( ! isset( $paypal_args['discount_amount_cart'] ) ) {
 				$paypal_args['discount_amount_cart'] = 0;
 			}


### PR DESCRIPTION
Fixes #6837

Proposed Changes:
1. Prevents negative fees from being applied twice.

---

This is going to need a bunch of testing because it touches payment amounts.

Testing steps for the original issue are outlined here: https://github.com/easydigitaldownloads/easy-digital-downloads/issues/6837#issuecomment-713580310

We should also test with:

1. Positive fees.
2. Actual discount codes (not negative fees, but proper coupons).
3. Anything else we can think of?