### PR TITLE
Issue/8157 X Buttons Visible on All Screens

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -688,7 +688,11 @@ table.edd-order-overview-summary--refund {
 	color: #a00;
 }
 
-@media screen and (min-width: 782px) {
+@media screen and (min-width: 783px) {
+
+	.edd-order-overview-summary__adjustments .removable .delete {
+		margin-left: -40px;
+	}
 
 	.edd-order-overview-summary__totals .total {
 		font-size: 150%;
@@ -700,15 +704,6 @@ table.edd-order-overview-summary--refund {
 .edd-order-overview-summary__totals tr:last-child th,
 .edd-order-overview-summary__totals tr:last-child td:not(:first-of-type) {
 	border-top: 1px solid #e5e5e5;
-}
-
-.edd-order-overview-summary__adjustments .removable .delete {
-	position: absolute;
-	left:  -40px;
-	top: 50%;
-	margin-top: -15px;
-	padding-top: 5px;
-	padding-bottom: 5px;
 }
 
 .edd-order-overview-summary__totals .notice {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -691,7 +691,7 @@ table.edd-order-overview-summary--refund {
 @media screen and (min-width: 783px) {
 
 	.edd-order-overview-summary__adjustments .removable .delete {
-		margin-left: -40px;
+		margin-left: -50px;
 	}
 
 	.edd-order-overview-summary__totals .total {


### PR DESCRIPTION
Fixes #8157 

Proposed Changes:
1. Add media query to offset buttons only on larger screens
2. Tweak media query to match when table responds

I'm not crazy about this solution, but it works for now.  

In the future I'd love to see this screen styled differently for mobile, with tablet+ (782px) looking more like the larger screens.  IMO, the layout is too spread out, but that's a different issue having to do with when the table responds.