### PR TITLE
Prevent errors when importing payments with non-existing discounts

### DIFF
--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -397,6 +397,7 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 	private function set_customer( $row ) {
 
 		global $wpdb;
+		$customer = false;
 
 		if( ! empty( $this->field_mapping['email'] ) && ! empty( $row[ $this->field_mapping['email'] ] ) ) {
 

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -1059,17 +1059,21 @@ function edd_build_order( $order_data = array() ) {
 		foreach ( $discounts as $discount ) {
 			$discount = edd_get_discount_by( 'code', $discount );
 
-			if ( $discount ) {
-				$discount_amount = 0;
-				$items           = $order_data['cart_details'];
+			if ( false === $discount ) {
+				continue;
+			}
 
-				if ( is_array( $items ) && ! empty( $items ) ) {
-					foreach ( $items as $key => $item ) {
-						$discount_amount += edd_get_item_discount_amount( $item, $items, array( $discount ) );
-					}
+			$discount_amount = 0;
+			$items           = $order_data['cart_details'];
+
+			if ( is_array( $items ) && ! empty( $items ) ) {
+				foreach ( $items as $key => $item ) {
+					$discount_amount += edd_get_item_discount_amount( $item, $items, array( $discount ) );
 				}
+			}
 
-				edd_add_order_adjustment( array(
+			edd_add_order_adjustment(
+				array(
 					'object_id'   => $order_id,
 					'object_type' => 'order',
 					'type_id'     => $discount->id,
@@ -1077,9 +1081,8 @@ function edd_build_order( $order_data = array() ) {
 					'description' => $discount->code,
 					'subtotal'    => $discount_amount,
 					'total'       => $discount_amount,
-				) );
-
-			}
+				)
+			);
 		}
 	}
 

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2198,6 +2198,10 @@ class EDD_Payment {
 							/** @var EDD_Discount $discount */
 							$discount = edd_get_discount_by( 'code', $discount );
 
+							if ( false === $discount ) {
+								continue;
+							}
+
 							$adjustments = $this->order->adjustments;
 
 							$found_discount = array_filter( $adjustments, function( $adjustment ) use ( $discount ) {
@@ -2216,9 +2220,12 @@ class EDD_Payment {
 									'amount' => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
 								) );
 
+								continue;
+							}
+
 							// Add the discount as an adjustment.
-							} else {
-								edd_add_order_adjustment( array(
+							edd_add_order_adjustment(
+								array(
 									'object_id'   => $this->ID,
 									'object_type' => 'order',
 									'type_id'     => $discount->id,
@@ -2226,8 +2233,8 @@ class EDD_Payment {
 									'description' => $discount->code,
 									'subtotal'    => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
 									'total'       => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
-								) );
-							}
+								)
+							);
 						}
 					}
 

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -658,7 +658,9 @@ class EDD_Payment {
 			);
 
 			foreach ( $order_meta as $key => $value ) {
-				edd_add_order_meta( $order_id, $key, $value );
+				if ( ! empty( $value ) ) {
+					edd_add_order_meta( $order_id, $key, $value );
+				}
 			}
 
 			$this->new = true;

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2224,22 +2224,20 @@ class EDD_Payment {
 								edd_update_order_adjustment( $found_discount->id, array(
 									'amount' => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
 								) );
-
-								continue;
+							} else {
+								// Add the discount as an adjustment.
+								edd_add_order_adjustment(
+									array(
+										'object_id'   => $this->ID,
+										'object_type' => 'order',
+										'type_id'     => $discount->id,
+										'type'        => 'discount',
+										'description' => $discount->code,
+										'subtotal'    => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
+										'total'       => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
+									)
+								);
 							}
-
-							// Add the discount as an adjustment.
-							edd_add_order_adjustment(
-								array(
-									'object_id'   => $this->ID,
-									'object_type' => 'order',
-									'type_id'     => $discount->id,
-									'type'        => 'discount',
-									'description' => $discount->code,
-									'subtotal'    => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
-									'total'       => $this->subtotal - $discount->get_discounted_amount( $this->subtotal ),
-								)
-							);
 						}
 					}
 

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -884,6 +884,10 @@ class EDD_Payment {
 							/** @var EDD_Discount $discount_obj */
 							$discount_obj = edd_get_discount_by( 'code', $discount );
 
+							if ( false === $discount_obj ) {
+								continue;
+							}
+
 							edd_add_order_adjustment( array(
 								'object_id'   => $this->ID,
 								'object_type' => 'order',

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -885,30 +885,23 @@ class EDD_Payment {
 						foreach ( $this->discounts as $discount ) {
 							/** @var EDD_Discount $discount_obj */
 							$discount_obj = edd_get_discount_by( 'code', $discount );
-
-							if ( false === $discount_obj ) {
-								edd_add_order_adjustment(
-									array(
-										'object_id'   => $this->ID,
-										'object_type' => 'order',
-										'type'        => 'fee',
-										'description' => $discount,
-										'subtotal'    => floatval( $this->total - $cart_subtotal - $this->tax ),
-										'total'       => floatval( $this->total - $cart_subtotal - $this->tax ),
-									)
-								);
-								continue;
-							}
-
-							edd_add_order_adjustment( array(
+							$args         = array(
 								'object_id'   => $this->ID,
 								'object_type' => 'order',
-								'type_id'     => $discount_obj->id,
-								'type'        => 'discount',
 								'description' => $discount,
-								'subtotal'    => floatval( $cart_subtotal - $discount_obj->get_discounted_amount( $cart_subtotal ) ),
-								'total'       => floatval( $cart_subtotal - $discount_obj->get_discounted_amount( $cart_subtotal ) ),
-							) );
+							);
+
+							if ( false === $discount_obj ) {
+								$args['type']     = 'fee';
+								$args['subtotal'] = floatval( $this->total - $cart_subtotal - $this->tax );
+								$args['total']    = floatval( $this->total - $cart_subtotal - $this->tax );
+							} else {
+								$args['type_id']  = $discount_obj->id;
+								$args['type']     = 'discount';
+								$args['subtotal'] = floatval( $cart_subtotal - $discount_obj->get_discounted_amount( $cart_subtotal ) );
+								$args['total']    = floatval( $cart_subtotal - $discount_obj->get_discounted_amount( $cart_subtotal ) );
+							}
+							edd_add_order_adjustment( $args );
 						}
 
 						$this->user_info['discount'] = implode( ',', $this->discounts );

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -893,8 +893,8 @@ class EDD_Payment {
 										'object_type' => 'order',
 										'type'        => 'fee',
 										'description' => $discount,
-										'subtotal'    => - floatval( $this->total - $cart_subtotal - $this->tax ),
-										'total'       => - floatval( $this->total - $cart_subtotal - $this->tax ),
+										'subtotal'    => floatval( $this->total - $cart_subtotal - $this->tax ),
+										'total'       => floatval( $this->total - $cart_subtotal - $this->tax ),
 									)
 								);
 								continue;

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -885,6 +885,16 @@ class EDD_Payment {
 							$discount_obj = edd_get_discount_by( 'code', $discount );
 
 							if ( false === $discount_obj ) {
+								edd_add_order_adjustment(
+									array(
+										'object_id'   => $this->ID,
+										'object_type' => 'order',
+										'type'        => 'fee',
+										'description' => $discount,
+										'subtotal'    => - floatval( $this->total - $cart_subtotal - $this->tax ),
+										'total'       => - floatval( $this->total - $cart_subtotal - $this->tax ),
+									)
+								);
 								continue;
 							}
 


### PR DESCRIPTION
Fixes #8145

Proposed Changes:
1. Make the early return logic consistent when `edd_get_discount_by` is used.
2. In `EDD_Payment`, if a discount object does not exist, but a discount does, add it as a fee instead (discounts are expected to exist in the `edd_adjusments` table).

<del>@ashleyfae although the checks for the discounts and taxes are happening in the `EDD_Payment` class, I feel uncomfortable automatically adding the fee/tax rate (haven't started on that one yet) there because of potential ripple effects. However, I'm not sure if I can duplicate the checks in the import class, or if that would be more appropriate at all. So setting this up as a draft to ask for feedback (the non-object error is resolved, at least, but imported orders don't feel correct).</del> Currently discounts and taxes are being added to the order (minimally) so going with this.

Note: if a fee is added to the order using the fees class, it does not appear to be accounted for at all in the CSV file, so I'm not sure how to account for that, but I'm not sure that's an issue specific to 3.0.

**To Test:**
1. This is best done with two different stores, an export store and an import store.
2. In the export store, generate some orders which include taxes.
3. Also generate some orders which use a discount code _which does not exist_ in the import store.
4. Export a CSV of orders.
5. Import the CSV into the store. If you want to see the breakage, do the import with `release/3.0` ... the import will error out because the discount code does not exist. Reset the store and then import using this branch; all orders should import, and the discounts/taxes should show on the orders.
