### PR TITLE
Support returning an integer when counting payments via EDD_Payments_Query #7056

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -155,7 +155,7 @@ class EDD_Payments_Query extends EDD_Stats {
 	 * @since 1.8
 	 * @since 3.0 Updated to use the new query classes and custom tables.
 	 *
-	 * @return EDD_Payment[]|EDD\Orders\Order[]
+	 * @return EDD_Payment[]|EDD\Orders\Order[]|int
 	 */
 	public function get_payments() {
 
@@ -194,6 +194,10 @@ class EDD_Payments_Query extends EDD_Stats {
 		}
 
 		$this->items = edd_get_orders( $this->args );
+
+		if ( ! empty( $this->args['count'] ) && is_numeric( $this->items ) ) {
+			return intval( $this->items );
+		}
 
 		if ( $should_output_order_objects ) {
 			return $this->items;

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -66,7 +66,7 @@ function edd_get_payment( $payment_or_txn_id = null, $by_txn = false ) {
  * @since 1.8 Refactored to be a wrapper for EDD_Payments_Query.
  *
  * @param array $args Arguments passed to get payments.
- * @return EDD_Payment[] $payments Payments retrieved from the database.
+ * @return EDD_Payment[]|int $payments Payments retrieved from the database.
  */
 function edd_get_payments( $args = array() ) {
 	$args     = apply_filters( 'edd_get_payments_args', $args );

--- a/tests/orders/tests-payments.php
+++ b/tests/orders/tests-payments.php
@@ -91,6 +91,14 @@ class Payment_Tests extends \EDD_UnitTestCase {
 		$this->assertEquals( 0, count( $out ) );
 	}
 
+	public function test_payments_query_count_payments() {
+		$payments = new \EDD_Payments_Query( array( 'count' => true ) );
+		$count    = $payments->get_payments();
+
+		$this->assertTrue( is_numeric( $count ) );
+		$this->assertEquals( 1, $count );
+	}
+
 	public function test_edd_get_payment_by() {
 		$payment = edd_get_payment_by( 'id', self::$payment->ID );
 		$this->assertObjectHasAttribute( 'ID', $payment );


### PR DESCRIPTION
Fixes #7056

Proposed Changes:
1. Support the `count` argument and return an integer when passed through.
2. Add unit test covering this scenario.