### PR TITLE
issue/7966 Active Vertical Tab Border

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -2366,7 +2366,6 @@ body.download_page_edd-reports {
 .download_page_edd-reports #edd-filters {
 	margin-bottom: -1px;
 	box-shadow: none;
-	z-index: 3;
 	justify-content: space-between;
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
Fixes #7966 

Proposed Changes:
1. Remove z-index for filters on reports screens

### Steps for Testing ###
Go to `Downloads > Reports > Downloads` and use the dropdown to select a product

You can also see the changes on `Taxes` and `File Downloads` under `Reports`.


