### PR TITLE
Check if 'key' exists before using #8174

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -750,22 +750,24 @@ class EDD_Payments_Query extends EDD_Stats {
 
 		if ( isset( $this->args['meta_query'] ) && is_array( $this->args['meta_query'] ) ) {
 			foreach ( $this->args['meta_query'] as $meta ) {
-				switch ( $meta['key'] ) {
-					case '_edd_payment_customer_id':
-						$arguments['customer_id'] = absint( $meta['value'] );
-						break;
+				if ( ! empty( $meta['key'] ) ) {
+					switch ( $meta['key'] ) {
+						case '_edd_payment_customer_id':
+							$arguments['customer_id'] = absint( $meta['value'] );
+							break;
 
-					case '_edd_payment_user_id':
-						$arguments['user_id'] = absint( $meta['value'] );
-						break;
+						case '_edd_payment_user_id':
+							$arguments['user_id'] = absint( $meta['value'] );
+							break;
 
-					case '_edd_payment_user_email':
-						$arguments['email'] = sanitize_email( $meta['value'] );
-						break;
+						case '_edd_payment_user_email':
+							$arguments['email'] = sanitize_email( $meta['value'] );
+							break;
 
-					case '_edd_payment_gateway':
-						$arguments['gateway'] = sanitize_text_field( $meta['value'] );
-						break;
+						case '_edd_payment_gateway':
+							$arguments['gateway'] = sanitize_text_field( $meta['value'] );
+							break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #8174

Proposed Changes:
1.Check if `$meta['key']` exists before switch statement.
