### PR TITLE
Use city property when filling address city #8177

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -3147,7 +3147,7 @@ class EDD_Payment {
 			$user_info['address'] = array(
 				'line1'   => $order_address->address,
 				'line2'   => $order_address->address2,
-				'city'    => $order_address->address,
+				'city'    => $order_address->city,
 				'state'   => $order_address->region,
 				'country' => $country,
 				'zip'     => $order_address->postal_code,


### PR DESCRIPTION
Fixes #8177

Proposed Changes:
1. Use `city` property instead of `address`