### PR TITLE
Get unit tests usable with PHPUnit 7.0

### DIFF
--- a/tests/orders/tests-trash.php
+++ b/tests/orders/tests-trash.php
@@ -125,8 +125,4 @@ class Trash_Tests extends \EDD_UnitTestCase {
 		$this->assertSame( 'trash', $refunds[0]->status );
 	}
 
-	public function test_restore_order_with_refunds() {
-
-	}
-
 }

--- a/tests/phpunit/class-edd-unittestcase.php
+++ b/tests/phpunit/class-edd-unittestcase.php
@@ -124,7 +124,11 @@ class EDD_UnitTestCase extends WP_UnitTestCase {
 		}
 
 		foreach ( $actual as $item ) {
-			\PHPUnit_Framework_Assert::assertThat( $item, $constraint );
+			if ( class_exists( '\PHPUnit\Framework\Assert' ) ) {
+				\PHPUnit\Framework\Assert::assertThat( $item, $constraint );
+			} else {
+				\PHPUnit_Framework_Assert::assertThat( $item, $constraint );
+			}
 		}
 	}
 

--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -293,9 +293,9 @@ class Tests_API extends EDD_UnitTestCase {
 		$this->assertArrayHasKey( 'earnings', $out['products'][0]['stats']['monthly_average'] );
 
 		$this->assertEquals( '60', $out['products'][0]['stats']['total']['sales'] );
-		$this->assertEquals( '229.43', $out['products'][0]['stats']['total']['earnings'] );
+		$this->assertEquals( '229.430000', $out['products'][0]['stats']['total']['earnings'] );
 		$this->assertEquals( '60', $out['products'][0]['stats']['monthly_average']['sales'] );
-		$this->assertEquals( '229.43', $out['products'][0]['stats']['monthly_average']['earnings'] );
+		$this->assertEquals( '229.430000', $out['products'][0]['stats']['monthly_average']['earnings'] );
 	}
 
 	public function test_get_products_pricing() {
@@ -304,8 +304,8 @@ class Tests_API extends EDD_UnitTestCase {
 		$this->assertArrayHasKey( 'simple', $out['products'][0]['pricing'] );
 		$this->assertArrayHasKey( 'advanced', $out['products'][0]['pricing'] );
 
-		$this->assertEquals( '20', $out['products'][0]['pricing']['simple'] );
-		$this->assertEquals( '100', $out['products'][0]['pricing']['advanced'] );
+		$this->assertEquals( '20.00', $out['products'][0]['pricing']['simple'] );
+		$this->assertEquals( '100.00', $out['products'][0]['pricing']['advanced'] );
 	}
 
 	public function test_get_products_files() {

--- a/tests/tests-api.php
+++ b/tests/tests-api.php
@@ -169,6 +169,8 @@ class Tests_API extends EDD_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		wp_set_current_user( self::$user_id );
+
 		add_filter( 'edd_api_output_format', function() {
 			return 'override';
 		} );
@@ -186,6 +188,9 @@ class Tests_API extends EDD_UnitTestCase {
 
 	public function tearDown() {
 		parent::tearDown();
+
+		// Revoke key to ensure `update_key()` will generate a new one.
+		EDD()->api->revoke_api_key( self::$user_id );
 
 		self::$api->flush_api_output();
 	}
@@ -253,12 +258,14 @@ class Tests_API extends EDD_UnitTestCase {
 
 		try {
 			self::$api->process_query();
-			$this->assertEquals( 'v1', self::$api->get_queried_version() );
+		} catch ( WPDieException $e ) {}
+		$this->assertEquals( 'v1', self::$api->get_queried_version() );
 
+		try {
 			$wp_query->query_vars['edd-api'] = 'v2/sales';
 			self::$api->process_query();
-			$this->assertEquals( 'v2', self::$api->get_queried_version() );
 		} catch ( WPDieException $e ) {}
+		$this->assertEquals( 'v2', self::$api->get_queried_version() );
 	}
 
 	public function test_get_products() {
@@ -421,30 +428,33 @@ class Tests_API extends EDD_UnitTestCase {
 
 		try {
 			self::$api->process_query();
-			$out = self::$api->get_output();
-
-			$this->assertArrayHasKey( 'error', $out );
-			$this->assertEquals( 'You must specify both a token and API key!', $out['error'] );
 		} catch ( WPDieException $e ) {}
+
+		$out = self::$api->get_output();
+
+		$this->assertArrayHasKey( 'error', $out );
+		$this->assertEquals( 'You must specify both a token and API key!', $out['error'] );
 	}
 
 	public function test_invalid_auth() {
+
 		global $wp_query;
 
 		$_POST['edd_set_api_key'] = 1;
 		EDD()->api->update_key( self::$user_id );
 
-		$wp_query->query_vars['key']     = get_user_meta( self::$user_id, 'edd_user_public_key', true );
+		$wp_query->query_vars['key']     = self::$api->get_user_public_key( self::$user_id );
 		$wp_query->query_vars['token']   = 'bad-token-val';
 		$wp_query->query_vars['edd-api'] = 'sales';
 
 		try {
 			self::$api->process_query();
-			$out = self::$api->get_output();
-
-			$this->assertArrayHasKey( 'error', $out );
-			$this->assertEquals( 'Your request could not be authenticated!', $out['error'] );
 		} catch ( WPDieException $e ) {}
+
+		$out = self::$api->get_output();
+
+		$this->assertArrayHasKey( 'error', $out );
+		$this->assertEquals( 'Your request could not be authenticated!', $out['error'] );
 	}
 
 	public function test_invalid_key() {
@@ -459,11 +469,12 @@ class Tests_API extends EDD_UnitTestCase {
 
 		try {
 			self::$api->process_query();
-			$out = self::$api->get_output();
-
-			$this->assertArrayHasKey( 'error', $out );
-			$this->assertEquals( 'Invalid API key!', $out['error'] );
 		} catch ( WPDieException $e ) {}
+
+		$out = self::$api->get_output();
+
+		$this->assertArrayHasKey( 'error', $out );
+		$this->assertEquals( 'Invalid API key!', $out['error'] );
 	}
 
 	public function test_info() {
@@ -496,58 +507,59 @@ class Tests_API extends EDD_UnitTestCase {
 
 		try {
 			self::$api->process_query();
-			$out = self::$api->get_output();
-
-			$this->assertArrayHasKey( 'info', $out['products'][0] );
-			$this->assertArrayHasKey( 'id', $out['products'][0]['info'] );
-			$this->assertArrayHasKey( 'slug', $out['products'][0]['info'] );
-			$this->assertEquals( 'test-download', $out['products'][0]['info']['slug'] );
-			$this->assertArrayHasKey( 'title', $out['products'][0]['info'] );
-			$this->assertEquals( 'Test Download', $out['products'][0]['info']['title'] );
-			$this->assertArrayHasKey( 'create_date', $out['products'][0]['info'] );
-			$this->assertArrayHasKey( 'modified_date', $out['products'][0]['info'] );
-			$this->assertArrayHasKey( 'status', $out['products'][0]['info'] );
-			$this->assertEquals( 'publish', $out['products'][0]['info']['status'] );
-			$this->assertArrayHasKey( 'link', $out['products'][0]['info'] );
-			$this->assertArrayHasKey( 'content', $out['products'][0]['info'] );
-			$this->assertEquals( self::$post->post_content, $out['products'][0]['info']['content'] );
-			$this->assertArrayHasKey( 'thumbnail', $out['products'][0]['info'] );
-
-			$this->assertArrayHasKey( 'stats', $out['products'][0] );
-			$this->assertArrayHasKey( 'total', $out['products'][0]['stats'] );
-			$this->assertArrayHasKey( 'sales', $out['products'][0]['stats']['total'] );
-			$this->assertEquals( 60, $out['products'][0]['stats']['total']['sales'] );
-			$this->assertArrayHasKey( 'earnings', $out['products'][0]['stats']['total'] );
-			$this->assertEquals( 229.43, $out['products'][0]['stats']['total']['earnings'] );
-			$this->assertArrayHasKey( 'monthly_average', $out['products'][0]['stats'] );
-			$this->assertArrayHasKey( 'sales', $out['products'][0]['stats']['monthly_average'] );
-			$this->assertEquals( 60, $out['products'][0]['stats']['monthly_average']['sales'] );
-			$this->assertArrayHasKey( 'earnings', $out['products'][0]['stats']['monthly_average'] );
-			$this->assertEquals( 229.43, $out['products'][0]['stats']['monthly_average']['earnings'] );
-
-			$this->assertArrayHasKey( 'pricing', $out['products'][0] );
-			$this->assertArrayHasKey( 'simple', $out['products'][0]['pricing'] );
-			$this->assertEquals( 20, $out['products'][0]['pricing']['simple'] );
-			$this->assertArrayHasKey( 'advanced', $out['products'][0]['pricing'] );
-			$this->assertEquals( 100, $out['products'][0]['pricing']['advanced'] );
-
-			$this->assertArrayHasKey( 'files', $out['products'][0] );
-			$this->assertArrayHasKey( 'name', $out['products'][0]['files'][0] );
-			$this->assertArrayHasKey( 'file', $out['products'][0]['files'][0] );
-			$this->assertArrayHasKey( 'condition', $out['products'][0]['files'][0] );
-			$this->assertArrayHasKey( 'name', $out['products'][0]['files'][1] );
-			$this->assertArrayHasKey( 'file', $out['products'][0]['files'][1] );
-			$this->assertArrayHasKey( 'condition', $out['products'][0]['files'][1] );
-			$this->assertEquals( 'File 1', $out['products'][0]['files'][0]['name'] );
-			$this->assertEquals( 'http://localhost/file1.jpg', $out['products'][0]['files'][0]['file'] );
-			$this->assertEquals( 0, $out['products'][0]['files'][0]['condition'] );
-			$this->assertEquals( 'File 2', $out['products'][0]['files'][1]['name'] );
-			$this->assertEquals( 'http://localhost/file2.jpg', $out['products'][0]['files'][1]['file'] );
-			$this->assertEquals( 'all', $out['products'][0]['files'][1]['condition'] );
-
-			$this->assertArrayHasKey( 'notes', $out['products'][0] );
-			$this->assertEquals( 'Purchase Notes', $out['products'][0]['notes'] );
 		} catch ( WPDieException $e ) {}
+
+		$out = self::$api->get_output();
+
+		$this->assertArrayHasKey( 'info', $out['products'][0] );
+		$this->assertArrayHasKey( 'id', $out['products'][0]['info'] );
+		$this->assertArrayHasKey( 'slug', $out['products'][0]['info'] );
+		$this->assertEquals( 'test-download', $out['products'][0]['info']['slug'] );
+		$this->assertArrayHasKey( 'title', $out['products'][0]['info'] );
+		$this->assertEquals( 'Test Download', $out['products'][0]['info']['title'] );
+		$this->assertArrayHasKey( 'create_date', $out['products'][0]['info'] );
+		$this->assertArrayHasKey( 'modified_date', $out['products'][0]['info'] );
+		$this->assertArrayHasKey( 'status', $out['products'][0]['info'] );
+		$this->assertEquals( 'publish', $out['products'][0]['info']['status'] );
+		$this->assertArrayHasKey( 'link', $out['products'][0]['info'] );
+		$this->assertArrayHasKey( 'content', $out['products'][0]['info'] );
+		$this->assertEquals( self::$post->post_content, $out['products'][0]['info']['content'] );
+		$this->assertArrayHasKey( 'thumbnail', $out['products'][0]['info'] );
+
+		$this->assertArrayHasKey( 'stats', $out['products'][0] );
+		$this->assertArrayHasKey( 'total', $out['products'][0]['stats'] );
+		$this->assertArrayHasKey( 'sales', $out['products'][0]['stats']['total'] );
+		$this->assertEquals( 60, $out['products'][0]['stats']['total']['sales'] );
+		$this->assertArrayHasKey( 'earnings', $out['products'][0]['stats']['total'] );
+		$this->assertEquals( 229.43, $out['products'][0]['stats']['total']['earnings'] );
+		$this->assertArrayHasKey( 'monthly_average', $out['products'][0]['stats'] );
+		$this->assertArrayHasKey( 'sales', $out['products'][0]['stats']['monthly_average'] );
+		$this->assertEquals( 60, $out['products'][0]['stats']['monthly_average']['sales'] );
+		$this->assertArrayHasKey( 'earnings', $out['products'][0]['stats']['monthly_average'] );
+		$this->assertEquals( 229.43, $out['products'][0]['stats']['monthly_average']['earnings'] );
+
+		$this->assertArrayHasKey( 'pricing', $out['products'][0] );
+		$this->assertArrayHasKey( 'simple', $out['products'][0]['pricing'] );
+		$this->assertEquals( 20, $out['products'][0]['pricing']['simple'] );
+		$this->assertArrayHasKey( 'advanced', $out['products'][0]['pricing'] );
+		$this->assertEquals( 100, $out['products'][0]['pricing']['advanced'] );
+
+		$this->assertArrayHasKey( 'files', $out['products'][0] );
+		$this->assertArrayHasKey( 'name', $out['products'][0]['files'][0] );
+		$this->assertArrayHasKey( 'file', $out['products'][0]['files'][0] );
+		$this->assertArrayHasKey( 'condition', $out['products'][0]['files'][0] );
+		$this->assertArrayHasKey( 'name', $out['products'][0]['files'][1] );
+		$this->assertArrayHasKey( 'file', $out['products'][0]['files'][1] );
+		$this->assertArrayHasKey( 'condition', $out['products'][0]['files'][1] );
+		$this->assertEquals( 'File 1', $out['products'][0]['files'][0]['name'] );
+		$this->assertEquals( 'http://localhost/file1.jpg', $out['products'][0]['files'][0]['file'] );
+		$this->assertEquals( 0, $out['products'][0]['files'][0]['condition'] );
+		$this->assertEquals( 'File 2', $out['products'][0]['files'][1]['name'] );
+		$this->assertEquals( 'http://localhost/file2.jpg', $out['products'][0]['files'][1]['file'] );
+		$this->assertEquals( 'all', $out['products'][0]['files'][1]['condition'] );
+
+		$this->assertArrayHasKey( 'notes', $out['products'][0] );
+		$this->assertEquals( 'Purchase Notes', $out['products'][0]['notes'] );
 	}
 
 }

--- a/tests/tests-cart.php
+++ b/tests/tests-cart.php
@@ -714,7 +714,7 @@ class Test_Cart extends EDD_UnitTestCase {
 		);
 		EDD()->fees->add_fee( $fee );
 
-		$this->assertEquals( "1", EDD()->cart->get_tax() );
+		$this->assertEquals( 1.00, EDD()->cart->get_tax() );
 
 		edd_update_option( 'enable_taxes', false );
 	}

--- a/tests/tests-formatting.php
+++ b/tests/tests-formatting.php
@@ -16,7 +16,7 @@ class Tests_Formatting extends EDD_UnitTestCase {
 
 	public function test_sanitize_amount() {
 
-		$this->assertEquals( '0', edd_sanitize_amount( '' ) );
+		$this->assertEquals( 0.00, edd_sanitize_amount( '' ) );
 		$this->assertEquals( '20000.20', edd_sanitize_amount( '20,000.20' ) );
 		$this->assertEquals( '22000.20', edd_sanitize_amount( '22 000.20' ) );
 		$this->assertEquals( '20.20', edd_sanitize_amount( '20.2' ) );

--- a/tests/tests-scripts.php
+++ b/tests/tests-scripts.php
@@ -101,6 +101,9 @@ class Tests_Scripts extends EDD_UnitTestCase {
 		edd_register_styles();
 
 		$this->go_to( '/' );
+
+		$this->assertTrue( wp_style_is( 'edd-styles', 'registered' ) );
+
 		unset( $_SERVER['HTTPS'] );
 	}
 

--- a/tests/tests-tax.php
+++ b/tests/tests-tax.php
@@ -242,16 +242,16 @@ class Tests_Taxes extends EDD_UnitTestCase {
 	}
 
 	public function test_get_payment_tax() {
-		$this->assertEquals( '11.0', edd_get_payment_tax( self::$order->ID ) );
+		$this->assertEquals( 11.000000000, edd_get_payment_tax( self::$order->ID ), 2 );
 	}
 
 	public function test_payment_tax_updates() {
 		// Test backwards compat bug in issue/3324
-		$this->assertEquals( '11.0', self::$order->tax );
+		$this->assertEquals( 11.000000000, self::$order->tax );
 		$current_meta = edd_get_payment_meta( self::$order->id );
 
 		edd_update_payment_meta( self::$order->id, '_edd_payment_meta', $current_meta );
-		$this->assertEquals( '11.0', edd_get_payment_tax( self::$order->id ) );
+		$this->assertEquals( 11.000000000, edd_get_payment_tax( self::$order->id ) );
 
 		// Test that when we update _edd_payment_tax, we update the _edd_payment_meta
 		edd_update_payment_meta( self::$order->id, '_edd_payment_tax', 10 );


### PR DESCRIPTION
The goal is to get the unit tests _mostly_ working with PHPUnit 5.x and 7.0.

Related: https://github.com/easydigitaldownloads/easy-digital-downloads/issues/7435

This PR doesn't entirely fix that issue; you still have to manually remove the speed trap listener. But the goal is to make it so if you _do_ remove that speed trap, the unit tests pass.

---

Update: With these changes the tests are now passing for me locally. I've added some notes throughout the code to explain why I made each change.

@robincornett Please run these tests on your end and let me know if there are any failures.