### PR TITLE
Check if download_id exists before using #8181

### DIFF
--- a/includes/cart/actions.php
+++ b/includes/cart/actions.php
@@ -64,7 +64,7 @@ add_action( 'template_redirect', 'edd_process_cart_endpoints', 100 );
  * @param $data
  */
 function edd_process_add_to_cart( $data ) {
-	$download_id = absint( $data['download_id'] );
+	$download_id = ! empty( $data['download_id'] ) ? absint( $data['download_id'] ) : false;
 	$options     = isset( $data['edd_options'] ) ? $data['edd_options'] : array();
 
 	if ( ! empty( $data['edd_download_quantity'] ) ) {
@@ -77,7 +77,9 @@ function edd_process_add_to_cart( $data ) {
 		}
 	}
 
-	$cart        = edd_add_to_cart( $download_id, $options );
+	if ( ! empty( $download_id ) ) {
+		edd_add_to_cart( $download_id, $options );
+	}
 
 	if ( edd_straight_to_checkout() && ! edd_is_checkout() ) {
 		$query_args 	= remove_query_arg( array( 'edd_action', 'download_id', 'edd_options' ) );


### PR DESCRIPTION
Fixes #8181  

Proposed Changes:
1. Check if `download_id` key exists before using.
2. Only add item to cart if `$download_id` isn't empty.
3. Don't save `edd_add_to_cart()` output to a variable, as the variable is never used.

I opted to continue the flow of the function instead of bailing immediately, because that way you'll still get redirected to checkout, even though your cart is empty. I thought this might make it easier to debug a broken URL.

To test:

1. Manually visit a malformed add to cart URL like this: `https://yoursite.com/checkout/?edd_action=add_to_cart` . Ensure you are redirected to checkout with no items in your cart. Ensure no PHP notices.
2. Manually visit a correctly formed add to cart URL like this: `https://yoursite.com/checkout/?edd_action=add_to_cart&download_id=123` (replace `123` with ID of a valid download). Ensure you are redirected to checkout with that item in your cart.