### PR TITLE
Ensure values are floats before doing calculations #8183

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -137,6 +137,10 @@ class EDD_Notices {
 						break;
 					case 'discount_invalid_code':
 						$notices['error']['edd-discount-invalid-code'] = __( 'The discount code entered is invalid; only alphanumeric characters are allowed, please try again.', 'easy-digital-downloads' );
+						break;
+					case 'discount_invalid_amount' :
+						$notices['error']['edd-discount-invalid-amount'] = __( 'The discount amount must be a valid percentage or numeric flat amount. Please try again.', 'easy-digital-downloads' );
+						break;
 				}
 			}
 

--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -45,6 +45,11 @@ function edd_add_discount( $data ) {
 		edd_die();
 	}
 
+	if ( ! is_numeric( $data['amount'] ) ) {
+		wp_redirect( add_query_arg( 'edd-message', 'discount_invalid_amount' ) );
+		edd_die();
+	}
+
 	foreach ( $data as $key => $value ) {
 
 		if ( $key === 'products' || $key === 'excluded-products' ) {
@@ -110,6 +115,11 @@ function edd_edit_discount( $data ) {
 
 	if( ! current_user_can( 'manage_shop_discounts' ) ) {
 		wp_die( __( 'You do not have permission to edit discount codes', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+	}
+
+	if ( empty( $data['amount'] ) || ! is_numeric( $data['amount'] ) ) {
+		wp_redirect( add_query_arg( 'edd-message', 'discount_invalid_amount' ) );
+		edd_die();
 	}
 
 	// Setup the discount code details

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -1875,18 +1875,17 @@ class EDD_Discount {
 	 * @return float $discounted_price Amount after discount.
 	 */
 	public function get_discounted_amount( $base_price ) {
-		// Start off setting the amount as the base price.
-		$amount = $base_price;
+		$base_price = floatval( $base_price );
 
 		if ( 'flat' == $this->type ) {
-			$amount = $base_price - $this->amount;
+			$amount = $base_price - floatval( $this->amount );
 
 			if ( $amount < 0 ) {
 				$amount = 0;
 			}
 		} else {
 			// Percentage discount
-			$amount = $base_price - ( $base_price * ( $this->amount / 100 ) );
+			$amount = $base_price - ( $base_price * ( floatval( $this->amount ) / 100 ) );
 		}
 
 		/**


### PR DESCRIPTION
Fixes #8183

Proposed Changes:
1. Convert values to floats before doing calculations.

**Note:** For ease of testing, I'm doing this PR in two parts. This first part only fixes the calculations. This is to ensure you can still save a non-numeric discount for testing purposes. After this has been tested, I'll follow up with sanitizing amounts before saving.

## To test:

1. Create a new discount code. Type = percentage; amount = 50b. (Or any random letter thrown in.) Save.
2. After saving, it will appear in the UI as just 50, but in the database it's actually saved as 50b.
3. Add an item to your cart, proceed to checkout, and apply this discount code.
4. Ensure you don't get any PHP notices.
5. Ensure discount amount is correctly displayed on checkout.