### PR TITLE
Validate discount amount is numeric before saving #8183

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -137,6 +137,10 @@ class EDD_Notices {
 						break;
 					case 'discount_invalid_code':
 						$notices['error']['edd-discount-invalid-code'] = __( 'The discount code entered is invalid; only alphanumeric characters are allowed, please try again.', 'easy-digital-downloads' );
+						break;
+					case 'discount_invalid_amount' :
+						$notices['error']['edd-discount-invalid-amount'] = __( 'The discount amount must be a valid percentage or numeric flat amount. Please try again.', 'easy-digital-downloads' );
+						break;
 				}
 			}
 

--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -45,6 +45,11 @@ function edd_add_discount( $data ) {
 		edd_die();
 	}
 
+	if ( ! is_numeric( $data['amount'] ) ) {
+		wp_redirect( add_query_arg( 'edd-message', 'discount_invalid_amount' ) );
+		edd_die();
+	}
+
 	foreach ( $data as $key => $value ) {
 
 		if ( $key === 'products' || $key === 'excluded-products' ) {
@@ -110,6 +115,11 @@ function edd_edit_discount( $data ) {
 
 	if( ! current_user_can( 'manage_shop_discounts' ) ) {
 		wp_die( __( 'You do not have permission to edit discount codes', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+	}
+
+	if ( empty( $data['amount'] ) || ! is_numeric( $data['amount'] ) ) {
+		wp_redirect( add_query_arg( 'edd-message', 'discount_invalid_amount' ) );
+		edd_die();
 	}
 
 	// Setup the discount code details


### PR DESCRIPTION
Fixes #8183 

Proposed Changes:
1. Validate discount code is numeric prior to saving.

To test:

1. Attempt to create a new discount code with an invalid amount (such as `10abcd`). Ensure you get an error message.
2. Attempt to edit an existing discount code with an invalid amount. Ensure you get an error message.
3. Ensure you can still successfully add/update discounts with valid amounts.