### PR TITLE
Validate order country against global list during migration #8028

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -585,7 +585,9 @@ class Data_Migrator {
 			'address2'     => isset( $user_info['address']['line2'] )   ? $user_info['address']['line2']   : '',
 			'city'         => isset( $user_info['address']['city'] )    ? $user_info['address']['city']    : '',
 			'region'       => isset( $user_info['address']['state'] )   ? $user_info['address']['state']   : '',
-			'country'      => isset( $user_info['address']['country'] ) ? $user_info['address']['country'] : '',
+			'country'      => isset( $user_info['address']['country'] ) && array_key_exists( strtoupper( $user_info['address']['country'] ), edd_get_country_list() )
+				? $user_info['address']['country']
+				: '',
 			'postal_code'  => isset( $user_info['address']['zip'] )     ? $user_info['address']['zip']     : '',
 			'date_created' => $date_created_gmt,
 		);


### PR DESCRIPTION
Fixes #8028

Proposed Changes:
1. Only store the address country if it exists in `edd_get_country_list()`

To test:

1. Start on EDD 2.9.
2. Manually update the address on an order to be something invalid. Can be done by manually running this PHP:
```php
$order_id = 123; // Order/payment ID number
$meta = get_post_meta( $order_id, '_edd_payment_meta', true);
$meta['user_info']['address']['country'] = '*'; // Or set to something totally random
update_post_meta( $order_id, '_edd_payment_meta', $meta );
```
3. Upgrade to 3.0.
4. After upgrading, check the `wp_edd_order_addresses` value for that order ID. The `country` should be blank.