### PR TITLE
Update filter bar markup, CSS

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -46,10 +46,6 @@ a.edd-delete:hover {
 	height: 29px;
 }
 
-.edd-from-to-wrapper {
-	margin-right: 4px;
-}
-
 .edd-from-to-wrapper input {
 	width: 105px;
 	margin: 0;
@@ -2383,7 +2379,7 @@ body.download_page_edd-reports {
 
 #edd-filters .filter-items .edd-date-range-options {
 	display: inline-block;
-	margin: 10px 4px 10px 0;
+	margin: 10px 0;
 }
 
 .edd-date-range-options .edd_datepicker {
@@ -2417,7 +2413,6 @@ body.download_page_edd-reports {
 
 .edd-admin--has-grid .edd-from-to-wrapper {
 	display: flex;
-	margin-right: 0;
 	margin-bottom: 16px;
 	width: 100%;
 }

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -1236,17 +1236,8 @@ textarea[name="edd-note"] {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
+	gap: 6px;
 }
-
-#edd-filters .filter-items > span:not(.edd-date-range-options) {
-	display: inline-block;
-	margin-right: 6px;
-}
-
-#edd-filters .filter-items > #edd-date-filters {
-	vertical-align: middle;
-}
-
 #edd-filters > p {
 	color: #777;
 }
@@ -2371,9 +2362,6 @@ body.download_page_edd-reports {
 }
 
 .download_page_edd-reports #edd-filters .filter-items {
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
 	flex: 1 1 75%;
 }
 

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -226,7 +226,7 @@ class EDD_Payment_History_Table extends List_Table {
 		<?php endif; ?>
 
 		<span id="edd-advanced-filters" class="<?php echo esc_attr( $maybe_show_filters ); ?>">
-			<input type="button" class="edd-advanced-filters-button button-secondary" value="<?php esc_html_e( 'More', 'easy-digital-downloads' ); ?>"/>
+			<input type="button" class="button edd-advanced-filters-button button-secondary" value="<?php esc_html_e( 'More', 'easy-digital-downloads' ); ?>"/>
 
 			<div class="inside">
 				<fieldset>
@@ -297,7 +297,7 @@ class EDD_Payment_History_Table extends List_Table {
 		</span>
 
 		<span id="edd-after-core-filters">
-			<input type="submit" class="button-secondary" value="<?php esc_html_e( 'Filter', 'easy-digital-downloads' ); ?>"/>
+			<input type="submit" class="button button-secondary" value="<?php esc_html_e( 'Filter', 'easy-digital-downloads' ); ?>"/>
 
 			<?php if ( ! empty( $start_date ) || ! empty( $end_date ) || ! empty( $order_total_filter_type ) || ( 'all' !== $gateway ) ) : ?>
 				<a href="<?php echo esc_url( $clear_url ); ?>" class="button-secondary">

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1262,7 +1262,7 @@ function filter_items( $report = false ) {
 	} ?>
 
 	<span class="edd-graph-filter-submit graph-option-section">
-		<input type="submit" class="button-secondary" value="<?php esc_html_e( 'Filter', 'easy-digital-downloads' ); ?>"/>
+		<input type="submit" class="button button-secondary" value="<?php esc_html_e( 'Filter', 'easy-digital-downloads' ); ?>"/>
 		<input type="hidden" name="edd_action" value="filter_reports" />
 		<input type="hidden" name="edd_redirect" value="<?php echo esc_url( $action ); ?>">
 		<input type="hidden" name="report_id" value="<?php echo esc_attr( $report_id ); ?>">


### PR DESCRIPTION
Fixes #7965

Proposed Changes:
1. Remove unneeded CSS for the filter bar.
2. Update filter bar button markup to include `button` class (`button-secondary` CSS is similar in many cases, but not mobile).
