### PR TITLE
Reinstall custom tables prior to running unit tests #8210

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,30 @@ activate_plugin( 'easy-digital-downloads/easy-digital-downloads.php' );
 
 echo "Setting up Easy Digital Downloads...\n";
 
+$components = EDD()->components;
+
+foreach ( $components as $component ) {
+	$thing = $component->get_interface( 'table' );
+
+	if ( $thing instanceof \EDD\Database\Table ) {
+		if ( $thing->exists() ) {
+			$thing->uninstall();
+		}
+
+		$thing->install();
+	}
+
+	$thing = $component->get_interface( 'meta' );
+
+	if ( $thing instanceof \EDD\Database\Table ) {
+		if ( $thing->exists() ) {
+			$thing->uninstall();
+		}
+
+		$thing->install();
+	}
+}
+
 function _disable_reqs( $status = false, $args = array(), $url = '') {
 	return new WP_Error( 'no_reqs_in_unit_tests', __( 'HTTP Requests disabled for unit tests', 'easy-digital-downloads' ) );
 }


### PR DESCRIPTION
Fixes #8210 

Proposed Changes:
1. Prior to running tests, uninstall any custom tables, then reinstall.