### PR TITLE
Add deprecation notices for variable pricing hooks

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -422,7 +422,7 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 	ob_end_clean();
 
 	ob_start();
-	if ( has_action( 'edd_download_price_table_row' ) ) {
+	if ( -1 !== has_action( 'edd_download_price_table_row', 'edd_hijack_edd_download_price_table_head' ) ) {
 		do_action_deprecated( 'edd_download_price_table_row', array( $post_id, $key, $args ), '2.8', 'edd_download_price_option_row' );
 	}
 	$show_advanced = ob_get_clean();

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -422,8 +422,13 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 	ob_end_clean();
 
 	ob_start();
-	if ( -1 !== has_action( 'edd_download_price_table_row', 'edd_hijack_edd_download_price_table_head' ) ) {
-		do_action_deprecated( 'edd_download_price_table_row', array( $post_id, $key, $args ), '2.8', 'edd_download_price_option_row' );
+	$found_fields = isset( $wp_filter['edd_download_price_table_row'] ) ? $wp_filter['edd_download_price_table_row'] : false;
+	if ( ! empty( $found_fields->callbacks ) ) {
+		if ( 1 !== count( $found_fields->callbacks ) ) {
+			do_action_deprecated( 'edd_download_price_table_row', array( $post_id, $key, $args ), '2.8', 'edd_download_price_option_row' );
+		} else {
+			do_action( 'edd_download_price_table_row', $post_id, $key, $args );
+		}
 	}
 	$show_advanced = ob_get_clean();
 ?>

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -417,7 +417,7 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 	// Output buffer so that the headers run, so we can log them and use them later
 	ob_start();
 	if ( has_action( 'edd_download_price_table_head' ) ) {
-		do_action_deprecated( 'edd_download_price_table_head', array( $post_id ), '2.8', 'edd_download_price_option_row' );
+		do_action_deprecated( 'edd_download_price_table_head', array( $post_id ), '2.10', 'edd_download_price_option_row' );
 	}
 	ob_end_clean();
 
@@ -425,7 +425,7 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 	$found_fields = isset( $wp_filter['edd_download_price_table_row'] ) ? $wp_filter['edd_download_price_table_row'] : false;
 	if ( ! empty( $found_fields->callbacks ) ) {
 		if ( 1 !== count( $found_fields->callbacks ) ) {
-			do_action_deprecated( 'edd_download_price_table_row', array( $post_id, $key, $args ), '2.8', 'edd_download_price_option_row' );
+			do_action_deprecated( 'edd_download_price_table_row', array( $post_id, $key, $args ), '2.10', 'edd_download_price_option_row' );
 		} else {
 			do_action( 'edd_download_price_table_row', $post_id, $key, $args );
 		}

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -416,11 +416,15 @@ function edd_render_price_row( $key, $args = array(), $post_id, $index ) {
 	// Run our advanced settings now, so we know if we need to display the settings.
 	// Output buffer so that the headers run, so we can log them and use them later
 	ob_start();
-	do_action( 'edd_download_price_table_head', $post_id );
+	if ( has_action( 'edd_download_price_table_head' ) ) {
+		do_action_deprecated( 'edd_download_price_table_head', array( $post_id ), '2.8', 'edd_download_price_option_row' );
+	}
 	ob_end_clean();
 
 	ob_start();
-	do_action( 'edd_download_price_table_row', $post_id, $key, $args );
+	if ( has_action( 'edd_download_price_table_row' ) ) {
+		do_action_deprecated( 'edd_download_price_table_row', array( $post_id, $key, $args ), '2.8', 'edd_download_price_option_row' );
+	}
 	$show_advanced = ob_get_clean();
 ?>
 	<?php


### PR DESCRIPTION
Fixes #8214

To test:
1. Activate this branch and an extension which adds options to the variable prices. Software Licensing may be easiest.
2. Make sure debugging is enabled.
3. Edit a download. PHP Notices should be logged.
4. Switch to the [SL branch 1182](https://github.com/easydigitaldownloads/EDD-Software-Licensing/pull/1182). Notices should be gone!