### PR TITLE
Check if edd-cart-downloads exists & is an array before using #8219

### DIFF
--- a/includes/cart/actions.php
+++ b/includes/cart/actions.php
@@ -161,10 +161,12 @@ add_action( 'edd_purchase_collection', 'edd_process_collection_purchase' );
  */
 function edd_process_cart_update( $data ) {
 
-	foreach( $data['edd-cart-downloads'] as $key => $cart_download_id ) {
-		$options  = json_decode( stripslashes( $data['edd-cart-download-' . $key . '-options'] ), true );
-		$quantity = absint( $data['edd-cart-download-' . $key . '-quantity'] );
-		edd_set_cart_item_quantity( $cart_download_id, $quantity, $options );
+	if ( ! empty( $data['edd-cart-downloads'] ) && is_array( $data['edd-cart-downloads'] ) ) {
+		foreach ( $data['edd-cart-downloads'] as $key => $cart_download_id ) {
+			$options  = json_decode( stripslashes( $data[ 'edd-cart-download-' . $key . '-options' ] ), true );
+			$quantity = absint( $data[ 'edd-cart-download-' . $key . '-quantity' ] );
+			edd_set_cart_item_quantity( $cart_download_id, $quantity, $options );
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes #8219

Proposed Changes:
1. Check if `$data['edd-cart-downloads']` exists and is an array before treating it like one.

I'm not sure how the original issue happened, but I think the main thing here is to ensure the process still works.

To test:

1. Enable quantities (Settings > Misc > Cart Item Quantities).
2. Add an item to your cart.
3. Once at checkout, **disable JavaScript**. JS needs to be disabled for the `Update Cart` button to appear.
4. Increase the quantity of the item in your cart and click `Update Cart`.
5. When the page refreshes, ensure you have the updated quantity.

![Screenshot from 2020-11-20 14-12-21](https://user-images.githubusercontent.com/6324272/99809593-6a830100-2b3a-11eb-8b53-16945a35cb73.png)
