### PR TITLE
Fix user fallback if user is not in initial batch for user_dropdown

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -339,21 +339,21 @@ class EDD_HTML_Elements {
 			$options[0] = __( 'No users found', 'easy-digital-downloads' );
 		}
 
+		$selected = $args['selected'];
+		if ( ! is_array( $selected ) ) {
+			$selected = array( $selected );
+		}
 		// If a selected user has been specified, we need to ensure it's in the initial list of user displayed
-		if( ! empty( $args['selected'] ) ) {
+		if ( ! empty( $selected ) ) {
+			foreach ( $selected as $selected_user ) {
+				if ( ! array_key_exists( $selected_user, $options ) ) {
+					$user = get_userdata( $selected_user );
 
-			if( ! array_key_exists( $args['selected'], $options ) ) {
-
-				$user = get_userdata( $args['selected'] );
-
-				if( $user ) {
-
-					$options[ absint( $args['selected'] ) ] = esc_html( $user->display_name );
-
+					if ( $user ) {
+						$options[ absint( $args['selected'] ) ] = esc_html( $user->display_name );
+					}
 				}
-
 			}
-
 		}
 
 		$output = $this->select( array(

--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -350,7 +350,7 @@ class EDD_HTML_Elements {
 					$user = get_userdata( $selected_user );
 
 					if ( $user ) {
-						$options[ absint( $args['selected'] ) ] = esc_html( $user->display_name );
+						$options[ absint( $user->ID ) ] = esc_html( $user->display_name );
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #8224

Proposed Changes:
1. Updates the user dropdown function to accept an array of selected users when making sure that a selected user will appear in the initial batch.

To test:
1. Check out the [1.5-master-merge branch](https://github.com/easydigitaldownloads/edd-discounts-pro/tree/release/1.5-master-merge) for Discounts Pro (the issue is not present in `master`).
2. With `release/2.10`, create a discount for a specific user and see the error indicated in the related issue.
3. Switch to this branch and the error should be resolved.

Notes: I referred to the `product_dropdown` method to set up the logic for this, as it also can be set to single/multiple.