### PR TITLE
Fix labels on password input fields (profile editor)

### DIFF
--- a/templates/shortcode-profile-editor.php
+++ b/templates/shortcode-profile-editor.php
@@ -195,12 +195,12 @@ if ( is_user_logged_in() ):
 			<legend id="edd_profile_password_label"><?php _e( 'Change your Password', 'easy-digital-downloads' ); ?></legend>
 
 			<p id="edd_profile_password_wrap">
-				<label for="edd_user_pass"><?php _e( 'New Password', 'easy-digital-downloads' ); ?></label>
+				<label for="edd_new_user_pass1"><?php esc_html_e( 'New Password', 'easy-digital-downloads' ); ?></label>
 				<input name="edd_new_user_pass1" id="edd_new_user_pass1" class="password edd-input" type="password"/>
 			</p>
 
 			<p id="edd_profile_confirm_password_wrap">
-				<label for="edd_user_pass"><?php _e( 'Re-enter Password', 'easy-digital-downloads' ); ?></label>
+				<label for="edd_new_user_pass2"><?php esc_html_e( 'Re-enter Password', 'easy-digital-downloads' ); ?></label>
 				<input name="edd_new_user_pass2" id="edd_new_user_pass2" class="password edd-input" type="password"/>
 				<?php do_action( 'edd_profile_editor_password' ); ?>
 			</p>


### PR DESCRIPTION
Fixes #8232 

Proposed changes: update the `label` elements to associate them with the password `input` elements on the profile editor.