### PR TITLE
Update how discounts are displayed in the cart

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1288,7 +1288,7 @@ function edd_get_cart_discounts_html( $discounts = false ) {
 			}
 		}
 
-		$rate = edd_format_discount_rate( edd_get_discount_type( $discount_id ), $discount_amount );
+		$rate = edd_format_discount_rate( edd_get_discount_type( $discount_id ), edd_get_discount_amount( $discount_id ) );
 
 		$remove_url  = add_query_arg(
 			array(

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1275,7 +1275,7 @@ function edd_get_cart_discounts_html( $discounts = false ) {
 		return;
 	}
 
-	$html = '';
+	$html = _n( 'Discount', 'Discounts', count( $discounts ), 'easy-digital-downloads' ) . ':&nbsp;';
 
 	foreach ( $discounts as $discount ) {
 		$discount_id     = edd_get_discount_id_by_code( $discount );
@@ -1288,7 +1288,8 @@ function edd_get_cart_discounts_html( $discounts = false ) {
 			}
 		}
 
-		$rate = edd_format_discount_rate( edd_get_discount_type( $discount_id ), edd_get_discount_amount( $discount_id ) );
+		$type = edd_get_discount_type( $discount_id );
+		$rate = edd_format_discount_rate( $type, edd_get_discount_amount( $discount_id ) );
 
 		$remove_url  = add_query_arg(
 			array(
@@ -1299,10 +1300,19 @@ function edd_get_cart_discounts_html( $discounts = false ) {
 			edd_get_checkout_uri()
 		);
 
-		$discount_html = '';
-		$discount_html .= "<span class=\"edd_discount\">\n";
-			$discount_html .= "<span class=\"edd_discount_rate\">$discount&nbsp;&ndash;&nbsp;$rate</span>\n";
-			$discount_html .= "<a href=\"$remove_url\" data-code=\"$discount\" class=\"edd_discount_remove\"></a>\n";
+		$discount_html   = '';
+		$discount_html  .= "<span class=\"edd_discount\">\n";
+		$discount_amount = edd_currency_filter( edd_format_amount( $discount_amount ) );
+		$discount_html  .= "<span class=\"edd_discount_total\">{$discount}&nbsp;&ndash;&nbsp;{$discount_amount}</span>\n";
+		if ( 'percent' === $type ) {
+			$discount_html .= "<span class=\"edd_discount_rate\">($rate)</span>\n";
+		}
+		$discount_html .= sprintf(
+			'<a href="%s" data-code="%s" class="edd_discount_remove"><span class="screen-reader-text"%s</span></a>',
+			$remove_url,
+			$discount,
+			__( 'Remove discount', 'easy-digital-downloads' )
+		);
 		$discount_html .= "</span>\n";
 
 		$html .= apply_filters( 'edd_get_cart_discount_html', $discount_html, $discount, $rate, $remove_url );

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1309,9 +1309,9 @@ function edd_get_cart_discounts_html( $discounts = false ) {
 		}
 		$discount_html .= sprintf(
 			'<a href="%s" data-code="%s" class="edd_discount_remove"><span class="screen-reader-text"%s</span></a>',
-			$remove_url,
-			$discount,
-			__( 'Remove discount', 'easy-digital-downloads' )
+			esc_url( $remove_url ),
+			esc_attr( $discount ),
+			esc_attr__( 'Remove discount', 'easy-digital-downloads' )
 		);
 		$discount_html .= "</span>\n";
 


### PR DESCRIPTION
Fixes #8236

Proposed Changes: initially I was just going to fix the output to show the proper discount rate, but after reading through the code with changes from #7993, it seemed important to figure out how to show the calculated discount amount, as that appeared to be the goal of the updated code (2.9.x shows just the discount rate, not the calculated/applied amount):

1. Show the calculated discount amount after the discount code. This has been updated to honor the storefront currency placement settings.
2. Additionally, for percentage discounts, the percentage is also displayed.
3. Prefixed the row with "Discount(s):" to be consistent with Subtotal, Tax, and Total rows.
4. Added link text to the `edd_discount_remove` link (hidden with `screen-reader-text`) for accessibility.

To test:
- Create multiple discounts: one flat rate, one percentage rate.
- Add items to the cart and apply one or both discounts (you may have to enable multiple discounts in settings). The prefix should properly show Discount(s) as singular or plural.
- Check the discounts with the currency position set to "after".

This adjusts the display only of the discounts--the calculations were already handled by Spencer in the other issue.