### PR TITLE
Use original customer argument in error message #8240

### DIFF
--- a/includes/api/class-edd-api-v2.php
+++ b/includes/api/class-edd-api-v2.php
@@ -338,7 +338,7 @@ class EDD_API_V2 extends EDD_API_V1 {
 
 		} elseif( $args['customer'] ) {
 
-			$error['error'] = sprintf( __( 'Customer %s not found!', 'easy-digital-downloads' ), $customer );
+			$error['error'] = sprintf( __( 'Customer %s not found!', 'easy-digital-downloads' ), $args['customer'] );
 			return $error;
 
 		} else {


### PR DESCRIPTION
Fixes #8240

Proposed Changes:
1.Use `$args['customer']` instead of an undefined `$customer` variable in the error message.