### PR TITLE
Change selector of upload field on admin download page to take precedence over WordPress CSS

### DIFF
--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -468,7 +468,7 @@ label.edd_prices_shipping { /* remove once Simple Shipping markup is improved */
 	top: 3px;
 	right: 7px;
 }
-.edd_upload_field {
+input[type="text"].edd_upload_field {
 	padding-right: 8em;
 }
 textarea#edd-payment-note {

--- a/assets/css/edd-admin.css
+++ b/assets/css/edd-admin.css
@@ -468,8 +468,8 @@ label.edd_prices_shipping { /* remove once Simple Shipping markup is improved */
 	top: 3px;
 	right: 7px;
 }
-input[type="text"].edd_upload_field {
-	padding-right: 8em;
+.edd_upload_field {
+	padding-right: 8em !important;
 }
 textarea#edd-payment-note {
 	width: 100%;


### PR DESCRIPTION
# Fixes

1. I think the CSS selector in EDD needs to be changed like this:
from: .edd_upload_field
to: input[type="text"].edd_upload_field

Then it will work just fine as it takes precedence over WordPress CSS.