### PR TITLE
Fix order comparison query #8260

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -229,9 +229,9 @@ class EDD_Payment_History_Table extends List_Table {
 					<legend for="order-amount-filter-type"><?php esc_html_e( 'Total is', 'easy-digital-downloads' ); ?></legend>
 					<?php
 					$options = array(
-						'=' => __( 'equal to', 'easy-digital-downloads' ),
-						'>' => __( 'greater than', 'easy-digital-downloads' ),
-						'<' => __( 'less than', 'easy-digital-downloads' ),
+						'eq' => __( 'equal to', 'easy-digital-downloads' ),
+						'gt' => __( 'greater than', 'easy-digital-downloads' ),
+						'lt' => __( 'less than', 'easy-digital-downloads' ),
 					);
 
 					echo EDD()->html->select( array(
@@ -857,10 +857,21 @@ class EDD_Payment_History_Table extends List_Table {
 		// Maybe filter by order amount.
 		if ( isset( $_GET['order-amount-filter-type'] ) && isset( $_GET['order-amount-filter-value'] ) ) {
 			if ( ! is_null( $_GET['order-amount-filter-value'] ) && '' !== $_GET['order-amount-filter-value'] ) {
-				$filter_type   = sanitize_text_field( $_GET['order-amount-filter-type'] );
 				$filter_amount = floatval( sanitize_text_field( $_GET['order-amount-filter-value'] ) );
 
-				$args['compare'] = array(
+				switch( $_GET['order-amount-filter-type'] ) {
+					case 'lt' :
+						$filter_type = '<';
+						break;
+					case 'gt' :
+						$filter_type = '>';
+						break;
+					default :
+						$filter_type = '=';
+						break;
+				}
+
+				$args['compare_query'] = array(
 					array(
 						'key'     => 'total',
 						'value'   => $filter_amount,

--- a/includes/database/queries/class-order.php
+++ b/includes/database/queries/class-order.php
@@ -273,6 +273,10 @@ class Order extends Query {
 	 */
 	public function query_by_country( $clauses ) {
 
+		if ( empty( $this->query_vars['country'] ) || 'all' === $this->query_vars['country'] ) {
+			return $clauses;
+		}
+
 		global $wpdb;
 
 		$primary_alias  = $this->table_alias;
@@ -287,34 +291,30 @@ class Order extends Query {
 			$where_clause = '';
 		}
 
-		// Filter by the order address's country.
-		if ( ! empty( $this->query_vars['country'] ) && 'all' !== $this->query_vars['country'] ) {
-			// Filter by the order address's region (state/province/etc)..
-			if ( ! empty( $this->query_vars['region'] ) && 'all' !== $this->query_vars['region'] ) {
+		// Filter by the order address's region (state/province/etc)..
+		if ( ! empty( $this->query_vars['region'] ) && 'all' !== $this->query_vars['region'] ) {
+			$location_join = $wpdb->prepare(
+				" LEFT JOIN {$order_addresses_query->table_name} {$join_alias} ON {$primary_alias}.{$primary_column} = {$join_alias}.order_id WHERE {$join_alias}.country = %s AND {$join_alias}.region = %s {$where_clause}",
+				$this->query_vars['country'],
+				$this->query_vars['region']
+			);
+
+			// Add the region to the query var defaults.
+			$this->query_var_defaults['region'] = $this->query_vars['region'];
+
+			// Filter only by the country, not by region.
+		} else {
 				$location_join = $wpdb->prepare(
-					" LEFT JOIN {$order_addresses_query->table_name} {$join_alias} ON {$primary_alias}.{$primary_column} = {$join_alias}.order_id WHERE {$join_alias}.country = %s AND {$join_alias}.region = %s {$where_clause}",
-					$this->query_vars['country'],
-					$this->query_vars['region']
+					" LEFT JOIN {$order_addresses_query->table_name} {$join_alias} ON {$primary_alias}.{$primary_column} = {$join_alias}.order_id WHERE {$join_alias}.country = %s {$where_clause}",
+					$this->query_vars['country']
 				);
 
-				// Add the region to the query var defaults.
-				$this->query_var_defaults['region'] = $this->query_vars['region'];
-
-				// Filter only by the country, not by region.
-			} else {
-					$location_join = $wpdb->prepare(
-						" LEFT JOIN {$order_addresses_query->table_name} {$join_alias} ON {$primary_alias}.{$primary_column} = {$join_alias}.order_id WHERE {$join_alias}.country = %s {$where_clause}",
-						$this->query_vars['country']
-					);
-
-					// Add the country to the query var defaults.
-					$this->query_var_defaults['country'] = $this->query_vars['country'];
-			}
-
-			// Add the customized join to the query.
-			$clauses['join'] .= ' ' . $location_join;
-
+				// Add the country to the query var defaults.
+				$this->query_var_defaults['country'] = $this->query_vars['country'];
 		}
+
+		// Add the customized join to the query.
+		$clauses['join'] .= ' ' . $location_join;
 
 		// We have added the wheres to the join calls so we don't need it to be here anymore.
 		unset( $clauses['where'] );


### PR DESCRIPTION
Fixes #8260

Proposed Changes:
1. Change select values to `eq`, `gt`, and `lt` instead of angle brackets.
2. Use `compare_query` argument instead of `compare` for comparison array. I suspect this was a change in BerlinDB at some point. :shrug: 
3. Exit early out of `query_by_country()` method if there is no country query.

To test:

Try filtering by all "Total is" options to ensure each of them work.

Try combining a "Total is" option with a country filter and ensure it still works.