### PR TITLE
Filter out empty query arguments #8262

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -813,7 +813,7 @@ class EDD_Payment_History_Table extends List_Table {
 			$mode = null;
 		}
 
-		$args = array(
+		$args = array_filter( array(
 			'user'        => $user,
 			'customer_id' => $customer,
 			'status'      => $status,
@@ -821,7 +821,7 @@ class EDD_Payment_History_Table extends List_Table {
 			'mode'        => $mode,
 			'type'        => $type,
 			'search'      => $search,
-		);
+		) );
 
 		// Search
 		if ( is_string( $search ) && ( false !== strpos( $search, 'txn:' ) ) ) {

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1570,8 +1570,8 @@ function edd_get_status_label( $status = '' ) {
  *
  * @since 3.0
  *
- * @param array  $counts
- * @param string $groupby
+ * @param EDD\Database\Query $counts
+ * @param string             $groupby
  * @return array
  */
 function edd_format_counts( $counts = array(), $groupby = '' ) {


### PR DESCRIPTION
Fixes #8262

Proposed Changes:
1. Filter out empty query arguments. The issue was that the count query had unnecessary clauses in it, checking for empty values (example: `where mode = ''`)
2. Change parameter type in docblock.