### PR TITLE
Show success message after manually creating order #8191

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -601,7 +601,7 @@ class EDD_Notices {
 				case 'payment_deleted' :
 					$this->add_notice( array(
 						'id'      => 'edd-payment-deleted',
-						'message' => __( 'The payment has been deleted.', 'easy-digital-downloads' )
+						'message' => __( 'The order has been deleted.', 'easy-digital-downloads' )
 					) );
 					break;
 				case 'email_sent' :

--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -610,12 +610,6 @@ class EDD_Notices {
 						'message' => __( 'The purchase receipt has been resent.', 'easy-digital-downloads' )
 					) );
 					break;
-				case 'refreshed-reports' :
-					$this->add_notice( array(
-						'id'      => 'edd-refreshed-reports',
-						'message' => __( 'The reports have been refreshed.', 'easy-digital-downloads' )
-					) );
-					break;
 				case 'payment-note-deleted' :
 					$this->add_notice( array(
 						'id'      => 'edd-note-deleted',

--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -514,40 +514,10 @@ class EDD_Notices {
 		// Shop reports errors
 		if ( current_user_can( 'view_shop_reports' ) ) {
 			switch( $notice ) {
-				case 'order_trashed' :
-					$this->add_notice( array(
-						'id'      => 'edd-order-trashed',
-						'message' => __( 'The order has been moved to the trash.', 'easy-digital-downloads' )
-					) );
-					break;
-				case 'order_restored' :
-					$this->add_notice( array(
-						'id'      => 'edd-order-restored',
-						'message' => __( 'The order has been restored.', 'easy-digital-downloads' )
-					) );
-					break;
-				case 'payment_deleted' :
-					$this->add_notice( array(
-						'id'      => 'edd-payment-deleted',
-						'message' => __( 'The payment has been deleted.', 'easy-digital-downloads' )
-					) );
-					break;
-				case 'email_sent' :
-					$this->add_notice( array(
-						'id'      => 'edd-payment-sent',
-						'message' => __( 'The purchase receipt has been resent.', 'easy-digital-downloads' )
-					) );
-					break;
 				case 'refreshed-reports' :
 					$this->add_notice( array(
 						'id'      => 'edd-refreshed-reports',
 						'message' => __( 'The reports have been refreshed.', 'easy-digital-downloads' )
-					) );
-					break;
-				case 'payment-note-deleted' :
-					$this->add_notice( array(
-						'id'      => 'edd-note-deleted',
-						'message' => __( 'The payment note has been deleted.', 'easy-digital-downloads' )
 					) );
 					break;
 			}
@@ -608,6 +578,48 @@ class EDD_Notices {
 					$this->add_notice( array(
 						'id'      => 'edd-payment-updated',
 						'message' => __( 'The order has been updated successfully.', 'easy-digital-downloads' )
+					) );
+					break;
+				case 'order_added' :
+					$this->add_notice( array(
+						'id'      => 'edd-order-added',
+						'message' => __( 'Order successfully created.', 'easy-digital-downloads' )
+					) );
+					break;
+				case 'order_trashed' :
+					$this->add_notice( array(
+						'id'      => 'edd-order-trashed',
+						'message' => __( 'The order has been moved to the trash.', 'easy-digital-downloads' )
+					) );
+					break;
+				case 'order_restored' :
+					$this->add_notice( array(
+						'id'      => 'edd-order-restored',
+						'message' => __( 'The order has been restored.', 'easy-digital-downloads' )
+					) );
+					break;
+				case 'payment_deleted' :
+					$this->add_notice( array(
+						'id'      => 'edd-payment-deleted',
+						'message' => __( 'The payment has been deleted.', 'easy-digital-downloads' )
+					) );
+					break;
+				case 'email_sent' :
+					$this->add_notice( array(
+						'id'      => 'edd-payment-sent',
+						'message' => __( 'The purchase receipt has been resent.', 'easy-digital-downloads' )
+					) );
+					break;
+				case 'refreshed-reports' :
+					$this->add_notice( array(
+						'id'      => 'edd-refreshed-reports',
+						'message' => __( 'The reports have been refreshed.', 'easy-digital-downloads' )
+					) );
+					break;
+				case 'payment-note-deleted' :
+					$this->add_notice( array(
+						'id'      => 'edd-note-deleted',
+						'message' => __( 'The payment note has been deleted.', 'easy-digital-downloads' )
 					) );
 					break;
 			}

--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -619,7 +619,7 @@ class EDD_Notices {
 				case 'payment-note-deleted' :
 					$this->add_notice( array(
 						'id'      => 'edd-note-deleted',
-						'message' => __( 'The payment note has been deleted.', 'easy-digital-downloads' )
+						'message' => __( 'The order note has been deleted.', 'easy-digital-downloads' )
 					) );
 					break;
 			}

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -18,12 +18,12 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0
  *
  * @param array $args Order form data.
- * @return int|bool Order ID if successful, false otherwise.
+ * @return void
  */
 function edd_add_manual_order( $args = array() ) {
 	// Bail if user cannot manage shop settings or no data was passed.
 	if ( empty( $args ) || ! current_user_can( 'manage_shop_settings' ) ) {
-		return false;
+		return;
 	}
 
 	// Set up parameters.
@@ -33,7 +33,7 @@ function edd_add_manual_order( $args = array() ) {
 
 	// Bail if nonce fails.
 	if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'edd_add_order_nonce' ) ) {
-		return false;
+		return;
 	}
 
 	// Get now one time to avoid microsecond issues
@@ -442,9 +442,10 @@ function edd_add_manual_order( $args = array() ) {
 
 	// Redirect to `Edit Order` page.
 	edd_redirect( edd_get_admin_url( array(
-		'page' => 'edd-payment-history',
-		'view' => 'view-order-details',
-		'id'   => $order_id,
+		'page'        => 'edd-payment-history',
+		'view'        => 'view-order-details',
+		'id'          => urlencode( $order_id ),
+		'edd-message' => 'order_added',
 	) ) );
 }
 add_action( 'edd_add_order', 'edd_add_manual_order' );


### PR DESCRIPTION
Fixes #8191

Proposed Changes:
1. Move all order related notices out of the "Shop reports errors" section and into the order-related notices. I think they were just in the wrong spot.
2. Create a new notice for `order_added` and include this notice in the page redirect after making an order.
3. Correct return type in PHPDocs for `edd_add_manual_order()`.

To test:

Manually create a new order and ensure you get a success message after doing so.