### PR TITLE
Check array keys exist before using & change empty dates to use null #8207

### DIFF
--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -98,7 +98,7 @@ function edd_admin_add_discount( $data = array() ) {
 		$end_date_hour   = isset( $data['end_date_hour'] ) && (int) $data['end_date_hour'] >= 0 && (int) $data['end_date_hour'] <= 23
 			? intval( $data['end_date_hour'] )
 			: '23';
-		$end_date_minute = isset( $data['end_date_hour'] ) && (int) $data['end_date_minute'] >= 0 && (int) $data['end_date_minute'] <= 59
+		$end_date_minute = isset( $data['end_date_minute'] ) && (int) $data['end_date_minute'] >= 0 && (int) $data['end_date_minute'] <= 59
 			? intval( $data['end_date_minute'] )
 			: '59';
 

--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -80,11 +80,11 @@ function edd_admin_add_discount( $data = array() ) {
 	// Start date.
 	if ( ! empty( $data['start_date'] ) ) {
 		$start_date        = sanitize_text_field( $data['start_date'] );
-		$start_date_hour   = (int) $data['start_date_hour'] >= 0 && (int) $data['start_date_hour'] <= 23
-			? sanitize_text_field( $data['start_date_hour'] )
+		$start_date_hour   = isset( $data['start_date_hour'] ) && (int) $data['start_date_hour'] >= 0 && (int) $data['start_date_hour'] <= 23
+			? intval( $data['start_date_hour'] )
 			: '00';
-		$start_date_minute = (int) $data['start_date_minute'] >= 0 && (int) $data['start_date_minute'] <= 59
-			? sanitize_text_field( $data['start_date_minute'] )
+		$start_date_minute = isset( $data['start_date_minute'] ) && (int) $data['start_date_minute'] >= 0 && (int) $data['start_date_minute'] <= 59
+			? intval( $data['start_date_minute'] )
 			: '00';
 
 		// The start date is entered in the user's WP timezone. We need to convert it to UTC prior to saving now.
@@ -95,11 +95,11 @@ function edd_admin_add_discount( $data = array() ) {
 	// End date.
 	if ( ! empty( $data['end_date'] ) ) {
 		$end_date        = sanitize_text_field( $data['end_date'] );
-		$end_date_hour   = (int) $data['end_date_hour'] >= 0 && (int) $data['end_date_hour'] <= 23
-			? sanitize_text_field( $data['end_date_hour'] )
+		$end_date_hour   = isset( $data['end_date_hour'] ) && (int) $data['end_date_hour'] >= 0 && (int) $data['end_date_hour'] <= 23
+			? intval( $data['end_date_hour'] )
 			: '23';
-		$end_date_minute = (int) $data['end_date_minute'] >= 0 && (int) $data['end_date_minute'] <= 59
-			? sanitize_text_field( $data['end_date_minute'] )
+		$end_date_minute = isset( $data['end_date_hour'] ) && (int) $data['end_date_minute'] >= 0 && (int) $data['end_date_minute'] <= 59
+			? intval( $data['end_date_minute'] )
 			: '59';
 
 		// The end date is entered in the user's WP timezone. We need to convert it to UTC prior to saving now.
@@ -204,35 +204,35 @@ function edd_admin_edit_discount( $data = array() ) {
 	// Start date.
 	if ( ! empty( $data['start_date'] ) ) {
 		$start_date        = sanitize_text_field( $data['start_date'] );
-		$start_date_hour   = (int) $data['start_date_hour'] >= 0 && (int) $data['start_date_hour'] <= 23
-			? sanitize_text_field( $data['start_date_hour'] )
+		$start_date_hour   = isset( $data['start_date_hour'] ) && (int) $data['start_date_hour'] >= 0 && (int) $data['start_date_hour'] <= 23
+			? intval( $data['start_date_hour'] )
 			: '00';
-		$start_date_minute = (int) $data['start_date_minute'] >= 0 && (int) $data['start_date_minute'] <= 59
-			? sanitize_text_field( $data['start_date_minute'] )
+		$start_date_minute = isset( $data['start_date_minute'] ) && (int) $data['start_date_minute'] >= 0 && (int) $data['start_date_minute'] <= 59
+			? intval( $data['start_date_minute'] )
 			: '00';
 
 		// The start date is entered in the user's WP timezone. We need to convert it to UTC prior to saving now.
 		$date                 = edd_get_utc_equivalent_date( EDD()->utils->date( $start_date . ' ' . $start_date_hour . ':' . $start_date_minute . ':00', edd_get_timezone_id(), false ) );
 		$to_update['start_date'] = $date->format( 'Y-m-d H:i:s' );
 	} else {
-		$to_update['start_date'] = '0000-00-00 00:00:00';
+		$to_update['start_date'] = null;
 	}
 
 	// End date.
 	if ( ! empty( $data['end_date'] ) ) {
 		$end_date        = sanitize_text_field( $data['end_date'] );
-		$end_date_hour   = (int) $data['end_date_hour'] >= 0 && (int) $data['end_date_hour'] <= 23
-			? sanitize_text_field( $data['end_date_hour'] )
+		$end_date_hour   = isset( $data['end_date_hour'] ) && (int) $data['end_date_hour'] >= 0 && (int) $data['end_date_hour'] <= 23
+			? intval( $data['end_date_hour'] )
 			: '23';
-		$end_date_minute = (int) $data['end_date_minute'] >= 0 && (int) $data['end_date_minute'] <= 59
-			? sanitize_text_field( $data['end_date_minute'] )
+		$end_date_minute = isset( $data['end_date_minute'] ) && (int) $data['end_date_minute'] >= 0 && (int) $data['end_date_minute'] <= 59
+			? intval( $data['end_date_minute'] )
 			: '59';
 
 		// The end date is entered in the user's WP timezone. We need to convert it to UTC prior to saving now.
 		$date               = edd_get_utc_equivalent_date( EDD()->utils->date( $end_date . ' ' . $end_date_hour . ':' . $end_date_minute . ':00', edd_get_timezone_id(), false ) );
 		$to_update['end_date'] = $date->format( 'Y-m-d H:i:s' );
 	} else {
-		$to_update['end_date'] = '0000-00-00 00:00:00';
+		$to_update['end_date'] = null;
 	}
 
 	// Known & accepted core discount meta


### PR DESCRIPTION
Fixes #8207 

Proposed Changes:
1. Add extra `isset()` conditional before using array keys.
2. Replace `sanitize_text_field()` with `intval()` because we're only interested in integers anyway.
3. When editing a discount, use `null` to represent no start/end date instead of `0000-00-00 00:00:00`. This was changed in a different PR and this instance clearly just got missed.

To test:

### Adding a discount

Create a brand new discount code with these steps:

1. Set a start date, but no start time.
2. Set an end date, but no end time.
3. Save.
4. Ensure you get no PHP errors/notices, that the start date is saved in the database with the time `00:00:00`, and that the end date is saved in the database with the time `23:59:59`.

Create a second discount code with these steps:

1. Set a start date and time. Set the time to anything other than `00:00`
2. Set an end date and time. Set the time to anything other than `23:59`
3. Save.
4. Ensure the times are saved correctly.

### Editing a discount

Edit an existing discount code with these steps:

1. Set a start date, but no time. If you're editing a discount code that already has a time filled out, then make sure you wipe out those values so they're completely empty.
2. Set an end date, but no time. If you're editing a discount code that already has a time filled out, then make sure you wipe out those values so they're completely empty.
3. Save.
4. Ensure you get no PHP errors/notices, that the start date is saved in the database with the time `00:00:00`, and that the end date is saved in the database with the time `23:59:59`.

After editing, edit again with these steps:

1. Set the start time to anything other than `00:00`
2. Set the end time to anything other than `23:59`
3. Save.
4. Ensure the times are saved correctly.

After editing, edit one more time with these steps:

1. Wipe out the start date and time completely. Both should be blank.
2. Wipe out the end date and time completely. Bot should be blank.
3. Save.
4. Ensure the `start_date` and `end_date` in the database is set to `null`.