### PR TITLE
Limit searchable to text based columns #8266

### DIFF
--- a/includes/database/schemas/class-adjustments.php
+++ b/includes/database/schemas/class-adjustments.php
@@ -48,7 +48,6 @@ final class Adjustments extends Schema {
 			'length'     => '20',
 			'unsigned'   => true,
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true,
 			'transition' => true
 		),
@@ -77,7 +76,6 @@ final class Adjustments extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'draft',
-			'searchable' => true,
 			'sortable'   => true,
 			'transition' => true
 		),
@@ -117,8 +115,7 @@ final class Adjustments extends Schema {
 			'name'       => 'amount',
 			'type'       => 'decimal',
 			'length'     => '18,9',
-			'default'    => '0',
-			'searchable' => true
+			'default'    => '0'
 		),
 
 		// description
@@ -170,7 +167,6 @@ final class Adjustments extends Schema {
 			'default'    => null,
 			'allow_null' => true,
 			'date_query' => true,
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -181,7 +177,6 @@ final class Adjustments extends Schema {
 			'default'    => null,
 			'allow_null' => true,
 			'date_query' => true,
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -192,7 +187,6 @@ final class Adjustments extends Schema {
 			'default'    => '', // Defaults to current time in query class
 			'created'    => true,
 			'date_query' => true,
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -203,7 +197,6 @@ final class Adjustments extends Schema {
 			'default'    => '', // Defaults to current time in query class
 			'modified'   => true,
 			'date_query' => true,
-			'searchable' => true,
 			'sortable'   => true
 		),
 

--- a/includes/database/schemas/class-customer-addresses.php
+++ b/includes/database/schemas/class-customer-addresses.php
@@ -60,7 +60,6 @@ class Customer_Addresses extends Schema {
 			'unsigned'   => false,
 			'default'    => '0',
 			'sortable'   => true,
-			'searchable' => false,
 			'transition' => true,
 		),
 
@@ -70,7 +69,6 @@ class Customer_Addresses extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'billing',
-			'searchable' => false,
 			'sortable'   => true,
 			'transition' => true
 		),
@@ -81,7 +79,6 @@ class Customer_Addresses extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'active',
-			'searchable' => false,
 			'sortable'   => true,
 			'transition' => true
 		),

--- a/includes/database/schemas/class-customer-email-addresses.php
+++ b/includes/database/schemas/class-customer-email-addresses.php
@@ -59,7 +59,6 @@ class Customer_Email_Addresses extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'secondary',
-			'searchable' => false,
 			'sortable'   => true,
 			'transition' => true
 		),
@@ -70,7 +69,6 @@ class Customer_Email_Addresses extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'active',
-			'searchable' => false,
 			'sortable'   => true,
 			'transition' => true
 		),

--- a/includes/database/schemas/class-customers.php
+++ b/includes/database/schemas/class-customers.php
@@ -77,7 +77,6 @@ class Customers extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'active',
-			'searchable' => true,
 			'sortable'   => true,
 			'transition' => true
 		),
@@ -88,8 +87,7 @@ class Customers extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true,
-			'searchable' => true
+			'sortable'   => true
 		),
 
 		// purchase_count

--- a/includes/database/schemas/class-logs-api-requests.php
+++ b/includes/database/schemas/class-logs-api-requests.php
@@ -39,7 +39,6 @@ class Logs_Api_Requests extends Schema {
 			'unsigned'   => true,
 			'extra'      => 'auto_increment',
 			'primary'    => true,
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -50,7 +49,6 @@ class Logs_Api_Requests extends Schema {
 			'length'     => '20',
 			'unsigned'   => true,
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -80,7 +78,6 @@ class Logs_Api_Requests extends Schema {
 			'type'       => 'varchar',
 			'length'     => '32',
 			'default'    => '',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -120,7 +117,6 @@ class Logs_Api_Requests extends Schema {
 			'type'       => 'varchar',
 			'length'     => '60',
 			'default'    => '',
-			'searchable' => true,
 			'sortable'   => true
 		),
 

--- a/includes/database/schemas/class-logs-file-downloads.php
+++ b/includes/database/schemas/class-logs-file-downloads.php
@@ -57,8 +57,7 @@ class Logs_File_Downloads extends Schema {
 			'type'       => 'bigint',
 			'length'     => '20',
 			'unsigned'   => true,
-			'default'    => '0',
-			'searchable' => true
+			'default'    => '0'
 		),
 
 		// order_id
@@ -85,8 +84,7 @@ class Logs_File_Downloads extends Schema {
 			'type'       => 'bigint',
 			'length'     => '20',
 			'unsigned'   => true,
-			'default'    => '0',
-			'searchable' => true
+			'default'    => '0'
 		),
 
 		// ip

--- a/includes/database/schemas/class-order-addresses.php
+++ b/includes/database/schemas/class-order-addresses.php
@@ -58,7 +58,6 @@ class Order_Addresses extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'billing',
-			'searchable' => false,
 			'sortable'   => true,
 			'transition' => true,
 		),

--- a/includes/database/schemas/class-order-adjustments.php
+++ b/includes/database/schemas/class-order-adjustments.php
@@ -49,7 +49,6 @@ class Order_Adjustments extends Schema {
 			'length'     => '20',
 			'unsigned'   => true,
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -59,7 +58,6 @@ class Order_Adjustments extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => '',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -70,7 +68,6 @@ class Order_Adjustments extends Schema {
 			'length'     => '20',
 			'unsigned'   => true,
 			'default'    => null,
-			'searchable' => true,
 			'sortable'   => true,
 			'allow_null' => true,
 		),
@@ -81,7 +78,6 @@ class Order_Adjustments extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => '',
-			'searchable' => true,
 			'sortable'   => true,
 			'transition' => true
 		),
@@ -93,7 +89,6 @@ class Order_Adjustments extends Schema {
 			'length'     => '255',
 			'default'    => null,
 			'allow_null' => true,
-			'searchable' => true,
 			'sortable'   => true,
 		),
 
@@ -113,7 +108,6 @@ class Order_Adjustments extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -123,7 +117,6 @@ class Order_Adjustments extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -133,7 +126,6 @@ class Order_Adjustments extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true
 		),
 

--- a/includes/database/schemas/class-order-transactions.php
+++ b/includes/database/schemas/class-order-transactions.php
@@ -66,7 +66,8 @@ class Order_Transactions extends Schema {
 			'name'       => 'transaction_id',
 			'type'       => 'varchar',
 			'length'     => '256',
-			'cache_key'  => true
+			'cache_key'  => true,
+			'searchable' => true
 		),
 
 		// gateway
@@ -83,7 +84,6 @@ class Order_Transactions extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'pending',
-			'searchable' => true,
 			'sortable'   => true,
 			'transition' => true
 		),


### PR DESCRIPTION
Fixes #8266 

Proposed Changes:
1. Remove all `'searchable' => false` parameters for consistency. The default is false, so omitting it completely is essentially already `false`. I did this to improve scanability so you can more easily search for `searchable` to see all the searchable fields.
2. In general, `searchable` has been removed for all non-text fields. This includes numeric columns (like `object_id` or `parent` etc. and amount fields like order totals) and date / datetime columns.

To clarify point 2, by removing searchable we can still query on those columns. We can still find all adjustments with `object_id` `4`; it just has to be done deliberately in the query arguments:

```php
array(
    'object_id' => 4
)
```

We can also still search orders for all orders with a total greater than $x. That remains unaffected.

What this change prevents is _arbitrary wildcard searching_ in those fields. So something like this will not search in `object_id` : 

```php
array(
    'search' => 4
)
```

## To test:

Perform searches in the following interfaces and ensure you still get results you expect:

- Orders
- Customers
    - Email Addresses
    - Physical Addresses
- Discounts - see #8230 
- Logs (Downloads > Tools > Logs)