### PR TITLE
#7262 Remove Bulk Refund Action

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -631,10 +631,6 @@ function edd_orders_list_table_process_bulk_actions() {
 				edd_update_payment_status( $id, 'processing' );
 				break;
 
-			case 'set-status-refunded':
-				edd_update_payment_status( $id, 'refunded' );
-				break;
-
 			case 'set-status-revoked':
 				edd_update_payment_status( $id, 'revoked' );
 				break;

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -649,7 +649,6 @@ class EDD_Payment_History_Table extends List_Table {
 				'set-status-complete'     => __( 'Mark Completed',   'easy-digital-downloads' ),
 				'set-status-pending'     => __( 'Mark Pending',     'easy-digital-downloads' ),
 				'set-status-processing'  => __( 'Mark Processing',  'easy-digital-downloads' ),
-				'set-status-refunded'    => __( 'Mark Refunded',    'easy-digital-downloads' ),
 				'set-status-revoked'     => __( 'Mark Revoked',     'easy-digital-downloads' ),
 				'set-status-failed'      => __( 'Mark Failed',      'easy-digital-downloads' ),
 				'set-status-abandoned'   => __( 'Mark Abandoned',   'easy-digital-downloads' ),


### PR DESCRIPTION
Fixes #7262 

Proposed Changes:
1. Remove refund from Orders > bulk actions 
2. Remove refund from actions switch statement

