### PR TITLE
Ensure that a mislinked EDD settings page is an EDD admin screen

### DIFF
--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -447,6 +447,10 @@ function edd_is_admin_page( $passed_page = '', $passed_view = '' ) {
 			// Supported post types
 			} elseif ( edd_is_insertable_admin_page() ) {
 				$found = true;
+
+			// Mislinked EDD settings screen
+			} elseif ( 'admin.php' === $pagenow && 'edd-settings' === $page ) {
+				$found = true;
 			}
 			break;
 	}

--- a/includes/admin/admin-pages.php
+++ b/includes/admin/admin-pages.php
@@ -448,8 +448,8 @@ function edd_is_admin_page( $passed_page = '', $passed_view = '' ) {
 			} elseif ( edd_is_insertable_admin_page() ) {
 				$found = true;
 
-			// Mislinked EDD settings screen
-			} elseif ( 'admin.php' === $pagenow && 'edd-settings' === $page ) {
+			// The EDD settings screen (fallback if mislinked)
+			} elseif ( 'edd-settings' === $page ) {
 				$found = true;
 			}
 			break;

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -30,6 +30,8 @@ function edd_options_page_primary_nav( $active_tab = '' ) {
 			$tab_url = add_query_arg(
 				array(
 					'settings-updated' => false,
+					'post_type'        => 'download',
+					'page'             => 'edd-settings',
 					'tab'              => $tab_id,
 				),
 				edd_get_admin_base_url()

--- a/includes/admin/settings/display-settings.php
+++ b/includes/admin/settings/display-settings.php
@@ -27,10 +27,13 @@ function edd_options_page_primary_nav( $active_tab = '' ) {
 		<?php
 
 		foreach ( $tabs as $tab_id => $tab_name ) {
-			$tab_url = add_query_arg( array(
-				'settings-updated' => false,
-				'tab'              => $tab_id,
-			) );
+			$tab_url = add_query_arg(
+				array(
+					'settings-updated' => false,
+					'tab'              => $tab_id,
+				),
+				edd_get_admin_base_url()
+			);
 
 			// Remove the section from the tabs so we always end up at the main section
 			$tab_url = remove_query_arg( 'section', $tab_url );
@@ -77,12 +80,15 @@ function edd_options_page_secondary_nav( $active_tab = '', $section = '', $secti
 	foreach ( $sections as $section_id => $section_name ) {
 
 		// Tab & Section
-		$tab_url = add_query_arg( array(
-			'post_type' => 'download',
-			'page'      => 'edd-settings',
-			'tab'       => $active_tab,
-			'section'   => $section_id
-		) );
+		$tab_url = add_query_arg(
+			array(
+				'post_type' => 'download',
+				'page'      => 'edd-settings',
+				'tab'       => $active_tab,
+				'section'   => $section_id,
+			),
+			edd_get_admin_base_url()
+		);
 
 		// Settings not updated
 		$tab_url = remove_query_arg( 'settings-updated', $tab_url );


### PR DESCRIPTION
Fixes #8209

Proposed Changes:
1. Adds a check for `admin.php` and the EDD settings page to the `edd_is_admin_page()` function.

To test:
Navigate to `admin.php?page=edd-settings&tab=general` in your site. With this branch, the navigation tabs should be styled correctly and the script (Chosen) needed to change the country/region selector will load--that's the most visible thing to check.