### PR TITLE
Prevent EDD sessions starting during Site Health loopback requests

### DIFF
--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -364,6 +364,10 @@ class EDD_Session {
 				$start_session = false;
 			}
 
+			// Do not start a session during the loopback request.
+			if ( false !== strpos( $uri, 'wp-site-health/v1/tests/loopback-requests' ) ) {
+				$start_session = false;
+			}
 		}
 
 		return apply_filters( 'edd_start_session', $start_session );

--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -339,6 +339,7 @@ class EDD_Session {
 	public function should_start_session() {
 
 		$start_session = true;
+		$uri           = '';
 
 		if( ! empty( $_SERVER[ 'REQUEST_URI' ] ) ) {
 
@@ -370,7 +371,13 @@ class EDD_Session {
 			}
 		}
 
-		return apply_filters( 'edd_start_session', $start_session );
+		/**
+		 * Filters the value for whether an EDD session should start or not.
+		 *
+		 * @param boolean $start_session Whether or not the EDD session should start.
+		 * @param string  $uri           The sanitized request URI.
+		 */
+		return apply_filters( 'edd_start_session', $start_session, $uri );
 
 	}
 


### PR DESCRIPTION
Fixes #8274

Proposed Changes:
1. Prevents the EDD session from starting during a loopback request.
2. Makes the sanitized `$uri` available to the `edd_start_session` filter.

To test:
1. Running WP 5.6, perform a Site Health check using the `master` branch. The loopback request will fail.
2. Switch to this branch and reload the Site Health screen. The loopback request should no longer fail.

Depending on your server configuration, this fix may not work--running LocalWP here on Windows and it still fails; I personally had to test on a "live" site. 