### PR TITLE
Fix convert_object_to_array() method

### DIFF
--- a/includes/EDD_SL_Plugin_Updater.php
+++ b/includes/EDD_SL_Plugin_Updater.php
@@ -353,7 +353,7 @@ class EDD_SL_Plugin_Updater {
 	 */
 	private function convert_object_to_array( $data ) {
 		$new_data = array();
-		foreach ( $data as $key => $value ) {
+		foreach ( (array) $data as $key => $value ) {
 			$new_data[ $key ] = is_object( $value ) ? $this->convert_object_to_array( $value ) : $value;
 		}
 


### PR DESCRIPTION
This prevents from "PHP Warning: Invalid argument supplied for foreach() in .../EDD_SL_Plugin_Updater.php on line 356"

Probably will be a better idea to decode JSON directly to the array than converting it here
