### PR TITLE
Remove unnecessary meta query & fix email search #8272

### DIFF
--- a/includes/admin/reporting/class-api-requests-logs-list-table.php
+++ b/includes/admin/reporting/class-api-requests-logs-list-table.php
@@ -21,6 +21,13 @@ defined( 'ABSPATH' ) || exit;
 class EDD_API_Request_Log_Table extends EDD_Base_Log_List_Table {
 
 	/**
+	 * Log type
+	 *
+	 * @var string
+	 */
+	protected $log_type = 'api_requests';
+
+	/**
 	 * Get things started
 	 *
 	 * @since 1.5

--- a/includes/admin/reporting/class-api-requests-logs-list-table.php
+++ b/includes/admin/reporting/class-api-requests-logs-list-table.php
@@ -111,61 +111,6 @@ class EDD_API_Request_Log_Table extends EDD_Base_Log_List_Table {
 	}
 
 	/**
-	 * Gets the meta query for the log query
-	 *
-	 * This is used to return log entries that match our search query
-	 *
-	 * @since 1.5
-	 * @return array $meta_query
-	 */
-	function get_meta_query() {
-		$meta_query = array();
-
-		$search = $this->get_search();
-
-		if ( $search ) {
-			if ( filter_var( $search, FILTER_VALIDATE_IP ) ) {
-				// This is an IP address search
-				$key = '_edd_log_request_ip';
-			} else if ( is_email( $search ) ) {
-				// This is an email search
-				$userdata = get_user_by( 'email', $search );
-
-				if( $userdata ) {
-					$search = $userdata->ID;
-				}
-
-				$key = '_edd_log_user';
-			} elseif( strlen( $search ) == 32 ) {
-				// Look for an API key
-				$key = '_edd_log_key';
-			} elseif( stristr( $search, 'token:' ) ) {
-				// Look for an API token
-				$search = str_ireplace( 'token:', '', $search );
-				$key = '_edd_log_token';
-			} else {
-				// This is (probably) a user ID search
-				$userdata = get_userdata( $search );
-
-				if( $userdata ) {
-					$search = $userdata->ID;
-				}
-
-				$key = '_edd_log_user';
-			}
-
-			// Setup the meta query
-			$meta_query[] = array(
-				'key'     => $key,
-				'value'   => $search,
-				'compare' => '=',
-			);
-		}
-
-		return $meta_query;
-	}
-
-	/**
 	 * Gets the log entries for the current view
 	 *
 	 * @since 1.5

--- a/includes/admin/reporting/class-base-logs-list-table.php
+++ b/includes/admin/reporting/class-base-logs-list-table.php
@@ -358,12 +358,18 @@ class EDD_Base_Log_List_Table extends List_Table {
 					$user = get_user_by( 'email', $search );
 					if ( ! empty( $user->ID ) ) {
 						$retval['user_id'] = $user->ID;
+					} else {
+						// This is a fallback to help ensure an invalid email will produce zero results.
+						$retval['search'] = $search;
 					}
 				} else {
 					// All other logs are linked to customers.
 					$customer = edd_get_customer_by( 'email', $search );
 					if ( ! empty( $customer->id ) ) {
 						$retval['customer_id'] = $customer->id;
+					} else {
+						// This is a fallback to help ensure an invalid email will produce zero results.
+						$retval['search'] = $search;
 					}
 				}
 			} elseif ( 'api_requests' === $this->log_type && 32 === strlen( $search ) ) {
@@ -378,6 +384,8 @@ class EDD_Base_Log_List_Table extends List_Table {
 					$user = get_user_by( 'email', $search );
 					if ( ! empty( $user->ID ) ) {
 						$retval['user_id'] = $user->ID;
+					} else {
+						$retval['search'] = $search;
 					}
 				} else {
 					// All other logs are linked to customers.
@@ -386,6 +394,8 @@ class EDD_Base_Log_List_Table extends List_Table {
 						$retval['customer_id'] = $customer->id;
 					} elseif ( 'file_downloads' === $this->log_type ) {
 						$retval['product_id'] = $search;
+					} else {
+						$retval['search'] = $search;
 					}
 				}
 			} else {

--- a/includes/admin/reporting/class-base-logs-list-table.php
+++ b/includes/admin/reporting/class-base-logs-list-table.php
@@ -346,7 +346,7 @@ class EDD_Base_Log_List_Table extends List_Table {
 			if ( filter_var( $search, FILTER_VALIDATE_IP ) ) {
 				$retval['ip'] = $search;
 			} elseif ( is_email( $search ) ) {
-				$customer = edd_get_customer( $search );
+				$customer = edd_get_customer_by( 'email', $search );
 				if ( ! empty( $customer->id ) ) {
 					$retval['customer_id'] = $customer->id;
 				}

--- a/includes/admin/reporting/class-base-logs-list-table.php
+++ b/includes/admin/reporting/class-base-logs-list-table.php
@@ -23,6 +23,13 @@ use EDD\Admin\List_Table;
 class EDD_Base_Log_List_Table extends List_Table {
 
 	/**
+	 * Log type
+	 *
+	 * @var string
+	 */
+	protected $log_type = 'logs';
+
+	/**
 	 * Get things started
 	 *
 	 * @since 3.0
@@ -355,6 +362,12 @@ class EDD_Base_Log_List_Table extends List_Table {
 					$retval['customer_id'] = $customer->id;
 					$retval['user_id']     = $customer->user_id;
 				}
+			} elseif ( 'api_requests' === $this->log_type && 32 === strlen( $search ) ) {
+				// Look for an API key
+				$retval['api_key'] = $search;
+			} elseif ( 'api_requests' === $this->log_type && stristr( $search, 'token:' ) ) {
+				// Look for an API token
+				$retval['token'] = str_ireplace( 'token:', '', $search );
 			} elseif ( is_numeric( $search ) ) {
 				$customer = edd_get_customer( $search );
 
@@ -365,11 +378,15 @@ class EDD_Base_Log_List_Table extends List_Table {
 					 */
 					$retval['customer_id'] = $customer->id;
 					$retval['user_id']     = $customer->user_id;
-				} else {
-					$this->file_search = true;
+				} elseif ( 'file_downloads' === $this->log_type ) {
+					$retval['product_id'] = $search;
 				}
 			} else {
-				$retval['file_id'] = $search;
+				if ( 'file_downloads' === $this->log_type ) {
+					$this->file_search = true;
+				} else {
+					$retval['search'] = $search;
+				}
 			}
 		}
 

--- a/includes/admin/reporting/class-base-logs-list-table.php
+++ b/includes/admin/reporting/class-base-logs-list-table.php
@@ -348,13 +348,23 @@ class EDD_Base_Log_List_Table extends List_Table {
 			} elseif ( is_email( $search ) ) {
 				$customer = edd_get_customer_by( 'email', $search );
 				if ( ! empty( $customer->id ) ) {
+					/*
+					 * File logs users customer_id but API logs use user_id, so we're setting
+					 * both to be compatible with both.
+					 */
 					$retval['customer_id'] = $customer->id;
+					$retval['user_id']     = $customer->user_id;
 				}
 			} elseif ( is_numeric( $search ) ) {
 				$customer = edd_get_customer( $search );
 
 				if ( ! empty( $customer->id ) ) {
+					/*
+					 * File logs users customer_id but API logs use user_id, so we're setting
+					 * both to be compatible with both.
+					 */
 					$retval['customer_id'] = $customer->id;
+					$retval['user_id']     = $customer->user_id;
 				} else {
 					$this->file_search = true;
 				}


### PR DESCRIPTION
Fixes #8272 

Proposed Changes:
1. Remove entire `get_meta_query()` method, as it's no longer needed.
2. Fix email search to get customer by the email address.
3. When a customer is found via search, also set `user_id` parameter. Some log tables use `customer_id` and others use `user_id` so this ensures compatibility with both.

To test:

Follow original testing steps here: https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8272

You will need at least one API request. Then try a variety of searches, including:

- Use date parameters.
- Enter an IP address in search.
- Enter an email in search. (This should match the account that performed the API request.)
- Enter a user ID number in search. (This should match the account that performed the API request.)
- Also try some invalid search parameters to make sure you correctly get no results.