### PR TITLE
Use helper functions to add log metadata

### DIFF
--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -270,8 +270,8 @@ class EDD_Logging {
 		}
 
 		// Used to dynamically dispatch the method call to insert() to the correct class.
-		$update_method = 'edd_update_log';
-		$meta_update   = 'edd_update_log_meta';
+		$update_method        = 'edd_update_log';
+		$update_meta_function = 'edd_update_log_meta';
 
 		$type = $args['log_type'];
 		if ( ! empty( $type ) ) {
@@ -286,8 +286,8 @@ class EDD_Logging {
 		);
 
 		if ( 'api_request' === $data['type'] ) {
-			$meta_update = 'edd_update_api_request_log_meta';
-			$legacy      = array(
+			$update_meta_function = 'edd_update_api_request_log_meta';
+			$legacy               = array(
 				'user'         => 'user_id',
 				'key'          => 'api_key',
 				'token'        => 'token',
@@ -306,8 +306,8 @@ class EDD_Logging {
 				}
 			}
 		} elseif ( 'file_download' === $data['type'] ) {
-			$meta_update = 'edd_update_file_download_log_meta';
-			$legacy      = array(
+			$update_meta_function = 'edd_update_file_download_log_meta';
+			$legacy               = array(
 				'file_id'    => 'file_id',
 				'payment_id' => 'payment_id',
 				'price_id'   => 'price_id',
@@ -338,9 +338,11 @@ class EDD_Logging {
 		call_user_func( $update_method, $data );
 
 		// Set log meta, if any
-		if ( 'edd_update_log' === $update_method && ! empty( $log_meta ) ) {
-			foreach ( (array) $log_meta as $key => $meta ) {
-				$meta_update( $log_id, sanitize_key( $key ), $meta );
+		if ( is_callable( $update_meta_function ) ) {
+			if ( 'edd_update_log' === $update_method && ! empty( $log_meta ) ) {
+				foreach ( (array) $log_meta as $key => $meta ) {
+					$update_meta_function( $log_id, sanitize_key( $key ), $meta );
+				}
 			}
 		}
 

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -217,15 +217,15 @@ class EDD_Logging {
 
 			// Use the right log fetching function based on the type of log this is.
 			if ( 'edd_add_api_request_log' === $insert_method ) {
-				$log = edd_get_file_download_log( $log_id );
+				$add_meta = 'edd_add_api_request_log_meta';
 			} elseif ( 'edd_add_file_download_log' === $insert_method ) {
-				$log = edd_get_file_download_log( $log_id );
+				$add_meta = 'edd_add_file_download_log_meta';
 			} else {
-				$log = edd_get_log( $log_id );
+				$add_meta = 'edd_add_log_meta';
 			}
 
 			foreach ( (array) $log_meta as $key => $meta ) {
-				$log->add_meta( sanitize_key( $key ), $meta );
+				$add_meta( $log_id, sanitize_key( $key ), $meta );
 			}
 		}
 
@@ -337,7 +337,7 @@ class EDD_Logging {
 			$log = edd_get_log( $log_id );
 
 			foreach ( (array) $log_meta as $key => $meta ) {
-				$log->update_meta( sanitize_key( $key ), $meta );
+				edd_update_log_meta( $log_id, sanitize_key( $key ), $meta );
 			}
 		}
 

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -217,15 +217,17 @@ class EDD_Logging {
 
 			// Use the right log fetching function based on the type of log this is.
 			if ( 'edd_add_api_request_log' === $insert_method ) {
-				$add_meta = 'edd_add_api_request_log_meta';
+				$add_meta_function = 'edd_add_api_request_log_meta';
 			} elseif ( 'edd_add_file_download_log' === $insert_method ) {
-				$add_meta = 'edd_add_file_download_log_meta';
+				$add_meta_function = 'edd_add_file_download_log_meta';
 			} else {
-				$add_meta = 'edd_add_log_meta';
+				$add_meta_function = 'edd_add_log_meta';
 			}
 
-			foreach ( (array) $log_meta as $key => $meta ) {
-				$add_meta( $log_id, sanitize_key( $key ), $meta );
+			if ( is_callable( $add_meta_function ) ) {
+				foreach ( (array) $log_meta as $key => $meta ) {
+					$add_meta_function( $log_id, sanitize_key( $key ), $meta );
+				}
 			}
 		}
 

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -269,6 +269,7 @@ class EDD_Logging {
 
 		// Used to dynamically dispatch the method call to insert() to the correct class.
 		$update_method = 'edd_update_log';
+		$meta_update   = 'edd_update_log_meta';
 
 		$type = $args['log_type'];
 		if ( ! empty( $type ) ) {
@@ -283,7 +284,8 @@ class EDD_Logging {
 		);
 
 		if ( 'api_request' === $data['type'] ) {
-			$legacy = array(
+			$meta_update = 'edd_update_api_request_log_meta';
+			$legacy      = array(
 				'user'         => 'user_id',
 				'key'          => 'api_key',
 				'token'        => 'token',
@@ -302,7 +304,8 @@ class EDD_Logging {
 				}
 			}
 		} elseif ( 'file_download' === $data['type'] ) {
-			$legacy = array(
+			$meta_update = 'edd_update_file_download_log_meta';
+			$legacy      = array(
 				'file_id'    => 'file_id',
 				'payment_id' => 'payment_id',
 				'price_id'   => 'price_id',
@@ -334,10 +337,8 @@ class EDD_Logging {
 
 		// Set log meta, if any
 		if ( 'edd_update_log' === $update_method && ! empty( $log_meta ) ) {
-			$log = edd_get_log( $log_id );
-
 			foreach ( (array) $log_meta as $key => $meta ) {
-				edd_update_log_meta( $log_id, sanitize_key( $key ), $meta );
+				$meta_update( $log_id, sanitize_key( $key ), $meta );
 			}
 		}
 


### PR DESCRIPTION
Fixes #8299

Proposed Changes:
1. Use the `edd_add_log_meta` (and related file download/api request functions) to add metadata to the log.
2. Use `edd_update_log_meta` (and related file download/api request functions) to update metadata in `update_log`.