### PR TITLE
Fix payment address setup

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -193,20 +193,8 @@ function edd_update_payment_details( $data = array() ) {
 	// Address
 	$address = $data['edd_order_address'];
 
-	// Setup first and last name from input values.
-	$name       = $customer->name;
-	$names      = explode( ' ', $name );
-	$first_name = ! empty( $names[0] ) ? $names[0] : '';
-	$last_name  = '';
-
-	if ( ! empty( $names[1] ) ) {
-		unset( $names[0] );
-		$last_name = implode( ' ', $names );
-	}
-
 	edd_update_order_address( absint( $address['address_id'] ), array(
-		'first_name'  => $first_name,
-		'last_name'   => $last_name,
+		'name'        => $customer->name,
 		'address'     => $address['address'],
 		'address2'    => $address['address2'],
 		'city'        => $address['city'],

--- a/includes/orders/functions/addresses.php
+++ b/includes/orders/functions/addresses.php
@@ -24,8 +24,7 @@ defined( 'ABSPATH' ) || exit;
  *     They will be automatically populated if empty.
  *
  *     @type int    $order_id      Order ID. Default `0`.
- *     @type string $first_name    Customer's first name. Default empty.
- *     @type string $last_name     Customer's last name. Default empty.
+ *     @type string $name          Customer's full name. Default empty.
  *     @type string $address       First line of address. Default empty.
  *     @type string $address2      Second line of address. Default empty.
  *     @type string $city          City. Default empty.
@@ -95,8 +94,7 @@ function edd_delete_order_address( $order_address_id = 0 ) {
  *     Array of order address data. Default empty.
  *
  *     @type int    $order_id      Order ID. Default `0`.
- *     @type string $first_name    Customer's first name. Default empty.
- *     @type string $last_name     Customer's last name. Default empty.
+ *     @type string $name          Customer's full name. Default empty.
  *     @type string $address       First line of address. Default empty.
  *     @type string $address2      Second line of address. Default empty.
  *     @type string $city          City. Default empty.

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -512,11 +512,11 @@ class EDD_Payment {
 		$this->customer_id     = $this->order->customer_id;
 		$this->user_id         = $this->setup_user_id();
 		$this->email           = $this->setup_email();
-		$this->address         = $this->setup_address();
 		$this->discounts       = $this->setup_discounts();
 		$this->user_info       = $this->setup_user_info();
 		$this->first_name      = $this->user_info['first_name'];
 		$this->last_name       = $this->user_info['last_name'];
+		$this->address         = $this->setup_address();
 
 		// Other Identifiers
 		$this->key             = $this->order->payment_key;

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2267,13 +2267,13 @@ class EDD_Payment {
 					}
 
 					$user_info = wp_parse_args( $user_info, $defaults );
+					$name      = $user_info['first_name'] . ' ' . $user_info['last_name'];
 
 					if ( null !== $this->order && $this->order->get_address()->id ) {
 						$order_address = $this->order->get_address();
 
 						edd_update_order_address( $order_address->id, array(
-							'first_name'  => $user_info['first_name'],
-							'last_name'   => $user_info['last_name'],
+							'name'        => $name,
 							'address'     => $user_info['address']['line1'],
 							'address2'    => $user_info['address']['line2'],
 							'city'        => $user_info['address']['city'],
@@ -2284,8 +2284,7 @@ class EDD_Payment {
 					} else {
 						edd_add_order_address( array(
 							'order_id'    => $this->ID,
-							'first_name'  => $user_info['first_name'],
-							'last_name'   => $user_info['last_name'],
+							'name'        => $name,
 							'address'     => $user_info['address']['line1'],
 							'address2'    => $user_info['address']['line2'],
 							'city'        => $user_info['address']['city'],

--- a/includes/privacy-functions.php
+++ b/includes/privacy-functions.php
@@ -420,8 +420,7 @@ function _edd_anonymize_payment( $order_id = 0 ) {
 
 			// Anonymize the line 1 and line 2 of the address. City, state, zip, and country are possibly needed for taxes.
 			$order_address_data = array(
-				'first_name' => '',
-				'last_name'  => '',
+				'name'       => '',
 				'address'    => '',
 				'address2'   => '',
 			);


### PR DESCRIPTION
Fixes #8309

Proposed Changes:
1. Sets up the payment/order address after the `user_info` has been set up (since it relies on `user_info`)
2. Update usage of `edd_add_order_address` and `edd_update_order_address` to use the correct `name` parameter instead of `first_name` and `last_name`, which are incorrect.
3. Update related doc blocks.