### PR TITLE
Filter out empty arguments #8275

### DIFF
--- a/includes/admin/reporting/class-base-logs-list-table.php
+++ b/includes/admin/reporting/class-base-logs-list-table.php
@@ -388,6 +388,8 @@ class EDD_Base_Log_List_Table extends List_Table {
 			}
 		}
 
+		$retval = array_filter( $retval );
+
 		// Return query arguments
 		return ( true === $paginate )
 			? $this->parse_pagination_args( $retval )

--- a/includes/admin/tools/logs.php
+++ b/includes/admin/tools/logs.php
@@ -41,8 +41,8 @@ function edd_logs_view_setup( $type = '' ) {
  *
  * @since 3.0
  *
- * @param object $logs_table List table class to work with
- * @param string $tag        Type of log to view
+ * @param EDD_Base_Log_List_Table $logs_table List table class to work with
+ * @param string                  $tag        Type of log to view
  */
 function edd_logs_view_page( $logs_table, $tag = '' ) {
 	$tag = sanitize_key( $tag );


### PR DESCRIPTION
Fixes #8275

Proposed Changes:
1. Filter out empty arguments. 
2. Update PHP docs to reference specific class name.