### PR TITLE
Migrate log metadata

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -238,6 +238,13 @@ class Data_Migrator {
 				'date_modified' => $data->post_modified_gmt,
 			);
 
+			$meta_to_remove    = array(
+				'_edd_log_file_id',
+				'_edd_log_payment_id',
+				'_edd_log_price_id',
+				'_edd_log_customer_id',
+				'_edd_log_ip',
+			);
 			$new_log_id        = edd_add_file_download_log( $log_data );
 			$add_meta_function = 'edd_add_file_download_log_meta';
 		} elseif ( 'api_request' === $data->slug ) {
@@ -275,6 +282,14 @@ class Data_Migrator {
 				'date_modified' => $data->post_modified_gmt,
 			);
 
+			$meta_to_remove    = array(
+				'_edd_log_request_ip',
+				'_edd_log_user',
+				'_edd_log_key',
+				'_edd_log_token',
+				'_edd_log_version',
+				'_edd_log_time',
+			);
 			$new_log_id        = edd_add_api_request_log( $log_data );
 			$add_meta_function = 'edd_add_api_request_log_meta';
 		} else {
@@ -291,6 +306,7 @@ class Data_Migrator {
 				'date_modified' => $data->post_modified_gmt,
 			);
 
+			$meta_to_remove    = array();
 			$new_log_id        = edd_add_log( $log_data );
 			$add_meta_function = 'edd_add_log_meta';
 		}
@@ -307,7 +323,9 @@ class Data_Migrator {
 
 		if ( ! empty( $meta_to_migrate ) ) {
 			foreach ( $meta_to_migrate as $key => $value ) {
-				$add_meta_function( $new_log_id, $key, $value );
+				if ( ! in_array( $key, $meta_to_remove, true ) ) {
+					$add_meta_function( $new_log_id, $key, $value );
+				}
 			}
 		}
 	}

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -299,11 +299,10 @@ class Data_Migrator {
 			$new_log_id        = edd_add_api_request_log( $log_data );
 			$add_meta_function = 'edd_add_api_request_log_meta';
 		} else {
-			$post      = \WP_Post::get_instance( $data->ID );
 			$post_meta = get_post_custom( $data->ID );
 
 			$log_data = array(
-				'object_id'     => $post->post_parent,
+				'object_id'     => $data->post_parent,
 				'object_type'   => 'download',
 				'type'          => $data->slug,
 				'title'         => $data->post_title,

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -254,7 +254,9 @@ class Log extends Base {
 						break;
 					case 'user':
 						$key = 'user_id';
-
+						break;
+					case 'payment_id':
+						$key = 'order_id';
 						break;
 				}
 
@@ -326,6 +328,10 @@ class Log extends Base {
 			case '_edd_log_price_id':
 			case '_edd_log_customer_id':
 				$key = str_replace( '_edd_log_', '', $meta_key );
+
+				if ( 'payment_id' === $key ) {
+					$key = 'order_id';
+				}
 
 				$check = edd_update_file_download_log( $object_id, array(
 					$key => $meta_value,

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -253,21 +253,24 @@ class Log extends Base {
 						$key = 'api_key';
 						break;
 					case 'user':
-						$key = 'customer_id';
+						$key = 'user_id';
 
 						break;
 				}
 
-				$value = $file_download_log->{$key};
-				if ( 'user' === $meta_key ) {
-					$customer = new EDD_Customer( $value );
-					$value    = $customer ? $customer->user_id : 0;
+				if ( isset( $file_download_log->{$key} ) ) {
+					$value = $file_download_log->{$key};
+				}
+
+				if ( 'user_id' === $meta_key ) {
+					$customer = new \EDD_Customer( $value );
+					$value    = ! empty( $customer->user_id ) ? $customer->user_id : 0;
 				}
 				break;
 		}
 
 		if ( $this->show_notices ) {
-			_doing_it_wrong( 'get_post_meta()', 'All log postmeta has been <strong>deprecated</strong> since Easy Digital Downloads 3.0! Use <code>edd_get_api_request_log()</code> instead.', 'EDD 3.0' );
+			_doing_it_wrong( 'get_post_meta()', __( 'All log postmeta has been <strong>deprecated</strong> since Easy Digital Downloads 3.0! Use <code>edd_get_api_request_log()</code> instead.', 'easy-digital-downloads' ), 'EDD 3.0' );
 
 			if ( $this->show_backtrace ) {
 				$backtrace = debug_backtrace();

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -220,7 +220,7 @@ class Log extends Base {
 			'_edd_log_user_info',
 			'_edd_log_user_id',
 			'_edd_log_file_id',
-			'_edd_key_ip',
+			'_edd_log_ip',
 			'_edd_log_payment_id',
 			'_edd_log_price_id',
 			'_edd_log_customer_id',
@@ -239,7 +239,7 @@ class Log extends Base {
 		switch ( $meta_key ) {
 			case '_edd_log_user_id':
 			case '_edd_log_file_id':
-			case '_edd_key_ip':
+			case '_edd_log_ip':
 			case '_edd_log_payment_id':
 			case '_edd_log_price_id':
 			case '_edd_log_customer_id':
@@ -302,7 +302,7 @@ class Log extends Base {
 			'_edd_log_user_info',
 			'_edd_log_user_id',
 			'_edd_log_file_id',
-			'_edd_key_ip',
+			'_edd_log_ip',
 			'_edd_log_payment_id',
 			'_edd_log_price_id',
 			'_edd_log_customer_id',

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -223,6 +223,7 @@ class Log extends Base {
 			'_edd_key_ip',
 			'_edd_log_payment_id',
 			'_edd_log_price_id',
+			'_edd_log_customer_id',
 		);
 
 		if ( ! in_array( $meta_key, $meta_keys, true ) ) {
@@ -241,6 +242,7 @@ class Log extends Base {
 			case '_edd_key_ip':
 			case '_edd_log_payment_id':
 			case '_edd_log_price_id':
+			case '_edd_log_customer_id':
 				$key = str_replace( '_edd_log_', '', $meta_key );
 
 				switch ( $key ) {
@@ -251,11 +253,16 @@ class Log extends Base {
 						$key = 'api_key';
 						break;
 					case 'user':
-						$key = 'user_id';
+						$key = 'customer_id';
+
 						break;
 				}
 
 				$value = $file_download_log->{$key};
+				if ( 'user' === $meta_key ) {
+					$customer = new EDD_Customer( $value );
+					$value    = $customer ? $customer->user_id : 0;
+				}
 				break;
 		}
 
@@ -295,6 +302,7 @@ class Log extends Base {
 			'_edd_key_ip',
 			'_edd_log_payment_id',
 			'_edd_log_price_id',
+			'_edd_log_customer_id',
 		);
 
 		if ( ! in_array( $meta_key, $meta_keys, true ) ) {
@@ -313,6 +321,7 @@ class Log extends Base {
 			case '_edd_key_ip':
 			case '_edd_log_payment_id':
 			case '_edd_log_price_id':
+			case '_edd_log_customer_id';
 				$key = str_replace( '_edd_log_', '', $meta_key );
 
 				$check = edd_update_file_download_log( $object_id, array(
@@ -329,6 +338,20 @@ class Log extends Base {
 					edd_update_file_download_log( $object_id, array(
 						'user_id' => $user_id
 					) );
+				}
+				break;
+
+			case '_edd_log_customer_id':
+				$customer_id = isset( $meta_value['id'] )
+					? absint( $meta_value['id'] )
+					: 0;
+
+				if ( $customer_id ) {
+					edd_update_file_download_log(
+						$object_id, array(
+							'customer_id' => $customer_id,
+						)
+					);
 				}
 				break;
 		}

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -321,7 +321,7 @@ class Log extends Base {
 			case '_edd_key_ip':
 			case '_edd_log_payment_id':
 			case '_edd_log_price_id':
-			case '_edd_log_customer_id';
+			case '_edd_log_customer_id':
 				$key = str_replace( '_edd_log_', '', $meta_key );
 
 				$check = edd_update_file_download_log( $object_id, array(

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -343,20 +343,6 @@ class Log extends Base {
 					) );
 				}
 				break;
-
-			case '_edd_log_customer_id':
-				$customer_id = isset( $meta_value['id'] )
-					? absint( $meta_value['id'] )
-					: 0;
-
-				if ( $customer_id ) {
-					edd_update_file_download_log(
-						$object_id, array(
-							'customer_id' => $customer_id,
-						)
-					);
-				}
-				break;
 		}
 
 		return $check;

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -262,7 +262,7 @@ class Log extends Base {
 					$value = $file_download_log->{$key};
 				}
 
-				if ( 'user_id' === $meta_key ) {
+				if ( 'user_id' === $key ) {
 					$customer = new \EDD_Customer( $file_download_log->customer_id );
 					$value    = ! empty( $customer->user_id ) ? $customer->user_id : 0;
 				}

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -263,7 +263,7 @@ class Log extends Base {
 				}
 
 				if ( 'user_id' === $meta_key ) {
-					$customer = new \EDD_Customer( $value );
+					$customer = new \EDD_Customer( $file_download_log->customer_id );
 					$value    = ! empty( $customer->user_id ) ? $customer->user_id : 0;
 				}
 				break;

--- a/includes/compat/class-log.php
+++ b/includes/compat/class-log.php
@@ -337,18 +337,6 @@ class Log extends Base {
 					$key => $meta_value,
 				) );
 				break;
-			case '_edd_log_user_info':
-
-				$user_id = isset( $meta_value['id'] )
-					? absint( $meta_value['id'] )
-					: 0;
-
-				if ( $user_id ) {
-					edd_update_file_download_log( $object_id, array(
-						'user_id' => $user_id
-					) );
-				}
-				break;
 		}
 
 		return $check;


### PR DESCRIPTION
Fixes #8317

Proposed Changes:
1. Updates the data migrator code to update the log metadata for all core log types (previously just main logs; file download and API request logs were excluded).
2. Does not migrate metadata which has been migrated to a column in the main/related log table.

Note: a meta key which did exist in 2.x, apparently, is `_edd_log_user_id`. However, looking at all of the rows that include it (on the site I'm migrating), I'm not convinced we need to keep it. The empty value appears to be saved as `-`, so I see a lot of that; additionally, the rows with values are all single digit numbers, and that does not make sense for a very large site. Actually, the newest rows (migration still going) are all the `-` value, so maybe that's a meta value which is no longer valid at all?