### PR TITLE
Update discounts to accommodate for price variations

### DIFF
--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -108,8 +108,8 @@ function edd_admin_add_discount( $data = array() ) {
 	}
 
 	// Meta values.
-	$to_add['product_reqs']      = isset( $data['product_reqs'] ) ? array_unique( array_map( 'esc_attr', $data['product_reqs'] ) ) : '';
-	$to_add['excluded_products'] = isset( $data['excluded_products'] ) ? array_unique( array_map( 'esc_attr', $data['excluded_products'] ) ) : '';
+	$to_add['product_reqs']      = isset( $data['product_reqs'] ) ? array_unique( array_map( 'sanitize_text_field', $data['product_reqs'] ) ) : '';
+	$to_add['excluded_products'] = isset( $data['excluded_products'] ) ? array_unique( array_map( 'sanitize_text_field', $data['excluded_products'] ) ) : '';
 
 	$to_add = array_filter( $to_add );
 
@@ -236,8 +236,8 @@ function edd_admin_edit_discount( $data = array() ) {
 	}
 
 	// Known & accepted core discount meta
-	$to_update['product_reqs']      = isset( $data['product_reqs'] ) ? array_unique( array_map( 'esc_attr', $data['product_reqs'] ) ) : '';
-	$to_update['excluded_products'] = isset( $data['excluded_products'] ) ? array_unique( array_map( 'esc_attr', $data['excluded_products'] ) ) : '';
+	$to_update['product_reqs']      = isset( $data['product_reqs'] ) ? array_unique( array_map( 'sanitize_text_field', $data['product_reqs'] ) ) : '';
+	$to_update['excluded_products'] = isset( $data['excluded_products'] ) ? array_unique( array_map( 'sanitize_text_field', $data['excluded_products'] ) ) : '';
 
 	// "Once per customer" checkbox.
 	$to_update['once_per_customer'] = isset( $data['once_per_customer'] )

--- a/includes/admin/discounts/discount-actions.php
+++ b/includes/admin/discounts/discount-actions.php
@@ -108,8 +108,8 @@ function edd_admin_add_discount( $data = array() ) {
 	}
 
 	// Meta values.
-	$to_add['product_reqs']      = isset( $data['product_reqs']      ) ? wp_parse_id_list( $data['product_reqs']      ) : '';
-	$to_add['excluded_products'] = isset( $data['excluded_products'] ) ? wp_parse_id_list( $data['excluded_products'] ) : '';
+	$to_add['product_reqs']      = isset( $data['product_reqs'] ) ? array_unique( array_map( 'esc_attr', $data['product_reqs'] ) ) : '';
+	$to_add['excluded_products'] = isset( $data['excluded_products'] ) ? array_unique( array_map( 'esc_attr', $data['excluded_products'] ) ) : '';
 
 	$to_add = array_filter( $to_add );
 
@@ -236,8 +236,8 @@ function edd_admin_edit_discount( $data = array() ) {
 	}
 
 	// Known & accepted core discount meta
-	$to_update['product_reqs']      = isset( $data['product_reqs']      ) ? wp_parse_id_list( $data['product_reqs']      ) : '';
-	$to_update['excluded_products'] = isset( $data['excluded_products'] ) ? wp_parse_id_list( $data['excluded_products'] ) : '';
+	$to_update['product_reqs']      = isset( $data['product_reqs'] ) ? array_unique( array_map( 'esc_attr', $data['product_reqs'] ) ) : '';
+	$to_update['excluded_products'] = isset( $data['excluded_products'] ) ? array_unique( array_map( 'esc_attr', $data['excluded_products'] ) ) : '';
 
 	// "Once per customer" checkbox.
 	$to_update['once_per_customer'] = isset( $data['once_per_customer'] )

--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -717,11 +717,16 @@ class EDD_Cart {
 	 * @since 2.7
 	 *
 	 * @param int   $download_id Download ID of the item to check.
- 	 * @param array $options
+	 * @param array $options
 	 * @return bool
 	 */
 	public function is_item_in_cart( $download_id = 0, $options = array() ) {
-		$cart = $this->get_contents();
+		$cart      = $this->get_contents();
+		$variation = explode( '_', $download_id );
+		if ( ! empty( $variation[1] ) ) {
+			$download_id         = absint( $variation[0] );
+			$options['price_id'] = absint( $variation[1] );
+		}
 
 		$ret = false;
 

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -1032,7 +1032,7 @@ class EDD_Discount extends Adjustment {
 				if ( isset( $args['excluded_products'] ) ) {
 					if ( is_array( $args['excluded_products'] ) ) {
 						foreach ( $args['excluded_products'] as $product ) {
-							edd_add_adjustment_meta( $this->id, 'excluded_product', absint( $product ) );
+							edd_add_adjustment_meta( $this->id, 'excluded_product', esc_attr( $product ) );
 						}
 					}
 				}
@@ -1040,7 +1040,7 @@ class EDD_Discount extends Adjustment {
 				if ( isset( $args['product_reqs'] ) ) {
 					if ( is_array( $args['product_reqs'] ) ) {
 						foreach ( $args['product_reqs'] as $product ) {
-							edd_add_adjustment_meta( $this->id, 'product_requirement', absint( $product ) );
+							edd_add_adjustment_meta( $this->id, 'product_requirement', esc_attr( $product ) );
 						}
 					}
 				}
@@ -1130,7 +1130,7 @@ class EDD_Discount extends Adjustment {
 
 				// Now add each newly excluded product
 				foreach ( $args['excluded_products'] as $product ) {
-					$this->add_meta( 'excluded_product', absint( $product ) );
+					$this->add_meta( 'excluded_product', esc_attr( $product ) );
 				}
 			} else {
 				$this->delete_meta( 'excluded_product' );
@@ -1145,7 +1145,7 @@ class EDD_Discount extends Adjustment {
 
 				// Now add each newly required product
 				foreach ( $args['product_reqs'] as $product ) {
-					$this->add_meta( 'product_requirement', absint( $product ) );
+					$this->add_meta( 'product_requirement', esc_attr( $product ) );
 				}
 			} else {
 				$this->delete_meta( 'product_requirement' );
@@ -1401,12 +1401,12 @@ class EDD_Discount extends Adjustment {
 		 */
 
 		// First absint the items, then sort, and reset the array keys
-		$product_reqs = array_map( 'absint', $product_reqs );
+		$product_reqs = array_map( 'esc_attr', $product_reqs );
 		asort( $product_reqs );
 		$product_reqs = array_filter( array_values( $product_reqs ) );
 
 
-		$excluded_ps = array_map( 'absint', $excluded_ps );
+		$excluded_ps = array_map( 'esc_attr', $excluded_ps );
 		asort( $excluded_ps );
 		$excluded_ps = array_filter( array_values( $excluded_ps ) );
 

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -1032,7 +1032,7 @@ class EDD_Discount extends Adjustment {
 				if ( isset( $args['excluded_products'] ) ) {
 					if ( is_array( $args['excluded_products'] ) ) {
 						foreach ( $args['excluded_products'] as $product ) {
-							edd_add_adjustment_meta( $this->id, 'excluded_product', esc_attr( $product ) );
+							edd_add_adjustment_meta( $this->id, 'excluded_product', sanitize_text_field( $product ) );
 						}
 					}
 				}
@@ -1040,7 +1040,7 @@ class EDD_Discount extends Adjustment {
 				if ( isset( $args['product_reqs'] ) ) {
 					if ( is_array( $args['product_reqs'] ) ) {
 						foreach ( $args['product_reqs'] as $product ) {
-							edd_add_adjustment_meta( $this->id, 'product_requirement', esc_attr( $product ) );
+							edd_add_adjustment_meta( $this->id, 'product_requirement', sanitize_text_field( $product ) );
 						}
 					}
 				}
@@ -1130,7 +1130,7 @@ class EDD_Discount extends Adjustment {
 
 				// Now add each newly excluded product
 				foreach ( $args['excluded_products'] as $product ) {
-					$this->add_meta( 'excluded_product', esc_attr( $product ) );
+					$this->add_meta( 'excluded_product', sanitize_text_field( $product ) );
 				}
 			} else {
 				$this->delete_meta( 'excluded_product' );
@@ -1145,7 +1145,7 @@ class EDD_Discount extends Adjustment {
 
 				// Now add each newly required product
 				foreach ( $args['product_reqs'] as $product ) {
-					$this->add_meta( 'product_requirement', esc_attr( $product ) );
+					$this->add_meta( 'product_requirement', sanitize_text_field( $product ) );
 				}
 			} else {
 				$this->delete_meta( 'product_requirement' );
@@ -1401,12 +1401,12 @@ class EDD_Discount extends Adjustment {
 		 */
 
 		// First absint the items, then sort, and reset the array keys
-		$product_reqs = array_map( 'esc_attr', $product_reqs );
+		$product_reqs = array_map( 'sanitize_text_field', $product_reqs );
 		asort( $product_reqs );
 		$product_reqs = array_filter( array_values( $product_reqs ) );
 
 
-		$excluded_ps = array_map( 'esc_attr', $excluded_ps );
+		$excluded_ps = array_map( 'sanitize_text_field', $excluded_ps );
 		asort( $excluded_ps );
 		$excluded_ps = array_filter( array_values( $excluded_ps ) );
 

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1061,8 +1061,12 @@ function edd_get_item_discount_amount( $item, $items, $discounts ) {
 		$item_unit_price = edd_get_download_price( $item['id'] );
 	}
 
-	$item_amount     = ( $item_unit_price * $item['quantity'] );
-	$discount_amount = 0;
+	$item_amount                = ( $item_unit_price * $item['quantity'] );
+	$discount_amount            = 0;
+	$item_id_for_discount_check = $item['id'];
+	if ( edd_has_variable_prices( $item['id'] ) ) {
+		$item_id_for_discount_check = "{$item['id']}_{$item['options']['price_id']}";
+	}
 
 	foreach ( $discounts as $discount ) {
 		$reqs              = $discount->get_product_reqs();
@@ -1072,13 +1076,13 @@ function edd_get_item_discount_amount( $item, $items, $discounts ) {
 		if ( ! empty( $reqs ) && 'global' !== $discount->get_scope() ) {
 			// This is a product(s) specific discount.
 			foreach ( $reqs as $download_id ) {
-				if ( $download_id == $item['id'] && ! in_array( $item['id'], $excluded_products ) ) {
+				if ( $download_id == $item_id_for_discount_check && ! in_array( $item_id_for_discount_check, $excluded_products ) ) {
 					$discount_amount += ( $item_amount - $discount->get_discounted_amount( $item_amount ) );
 				}
 			}
 		} else {
 			// This is a global cart discount.
-			if ( ! in_array( $item['id'], $excluded_products ) ) {
+			if ( ! in_array( $item_id_for_discount_check, $excluded_products ) ) {
 				if ( 'flat' === $discount->get_type() ) {
 					// In order to correctly record individual item amounts, global flat rate discounts
 					// are distributed across all items.

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -1076,13 +1076,13 @@ function edd_get_item_discount_amount( $item, $items, $discounts ) {
 		if ( ! empty( $reqs ) && 'global' !== $discount->get_scope() ) {
 			// This is a product(s) specific discount.
 			foreach ( $reqs as $download_id ) {
-				if ( $download_id == $item_id_for_discount_check && ! in_array( $item_id_for_discount_check, $excluded_products ) ) {
+				if ( ( $download_id == $item['id'] && ! in_array( $item['id'], $excluded_products ) ) || ( $download_id == $item_id_for_discount_check && ! in_array( $item_id_for_discount_check, $excluded_products ) ) ) {
 					$discount_amount += ( $item_amount - $discount->get_discounted_amount( $item_amount ) );
 				}
 			}
 		} else {
 			// This is a global cart discount.
-			if ( ! in_array( $item_id_for_discount_check, $excluded_products ) ) {
+			if ( ! in_array( $item_id_for_discount_check, $excluded_products ) || ! in_array( $item['id'], $excluded_products ) ) {
 				if ( 'flat' === $discount->get_type() ) {
 					// In order to correctly record individual item amounts, global flat rate discounts
 					// are distributed across all items.


### PR DESCRIPTION
Fixes #8322

Proposed Changes:
1. Changes all sanitization on product requirements/exclusions to `esc_attr` instead of casting to an integer.
2. Updates the product in cart check and discount calculation to allow for price IDs, or just download ID even for variable products.