### PR TITLE
Fix the old logs filter bar

### DIFF
--- a/includes/admin/tools/logs.php
+++ b/includes/admin/tools/logs.php
@@ -216,7 +216,7 @@ function edd_log_views() {
 	<!-- EDD 3.0 Hack -->
 	</div></div>
 	<form method="get" class="edd-old-log-filters" action="<?php echo admin_url( 'edit.php?post_type=download&page=edd-payment-history' ); ?>">
-		<?php edd_admin_filter_bar( 'old-logs' ); ?>
+		<?php edd_admin_filter_bar( 'old_logs' ); ?>
 	</form>
 	<div class="tablenav top"><div>
 	<!-- EDD 3.0 Hack -->


### PR DESCRIPTION
Fixes #8329

Proposed Changes:
Just changes the `$context` being passed to the function so that it matches the action hook used.