### PR TITLE
Remove date_created fallback for payment completion date #8334

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2842,11 +2842,7 @@ class EDD_Payment {
 			return false; // This payment was never completed
 		}
 
-		$date = ( $date = $order->date_completed )
-			? $date
-			: $order->date_created;
-
-		return $date;
+		return $order->date_completed ? $order->date_completed : '';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8334

Proposed Changes:
1. Remove fallback to `date_created`

Follow testing steps in the issue. Ensure that if there is no order `date_completed`, an empty string is returned. If there is a `date_completed`, that date should be returned.

You can also test that EDD Commissions now get recorded. See https://github.com/easydigitaldownloads/EDD-Commissions/issues/394