### PR TITLE
Update the edd_30_migrate_order parameters

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1089,10 +1089,11 @@ class Data_Migrator {
 		 * Now that we're done, let's run a hook here so we can allow extensions to make any necessary changes.
 		 *
 		 * @since 3.0
-		 * @param int   $order_id The order ID.
-		 * @param array $meta     The original post meta for the payment.
+		 * @param int   $order_id     The order ID.
+		 * @param array $payment_meta The `_edd_payment_meta` value for the original payment.
+		 * @param array $meta         The original post meta for the payment.
 		 */
-		do_action( 'edd_30_migrate_order', $order_id, $meta );
+		do_action( 'edd_30_migrate_order', $order_id, $payment_meta, $meta );
 	}
 
 	/**

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1091,7 +1091,7 @@ class Data_Migrator {
 		 * @since 3.0
 		 * @param int   $order_id     The order ID.
 		 * @param array $payment_meta The `_edd_payment_meta` value for the original payment.
-		 * @param array $meta         The original post meta for the payment.
+		 * @param array $meta         All post meta associated with the payment.
 		 */
 		do_action( 'edd_30_migrate_order', $order_id, $payment_meta, $meta );
 	}

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1085,8 +1085,14 @@ class Data_Migrator {
 			edd_add_order_meta( $order_id, $meta_key, $meta_value );
 		}
 
-		// Now that we're done, let's run a hook here so we can allow extensions to make any necessary changes
-		do_action( 'edd_30_migrate_order', $order_id, $data->ID );
+		/**
+		 * Now that we're done, let's run a hook here so we can allow extensions to make any necessary changes.
+		 *
+		 * @since 3.0
+		 * @param int   $order_id The order ID.
+		 * @param array $meta     The original post meta for the payment.
+		 */
+		do_action( 'edd_30_migrate_order', $order_id, $meta );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8342

Proposed Changes:
1. Removes the `$data->ID` parameter from the hook because it's identical to `$order_id`.
2. Adds the original `$meta` to the hook as the second parameter. Wondering if this should really be `$payment_meta` instead as that's been unserialized and is probably what's really needed (or hard to get) for an extension.