### PR TITLE
#8333 Backwards Compatibility Logs post_parent

### DIFF
--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -522,9 +522,13 @@ class EDD_Logging {
 			$r['type'] = $r['log_type'];
 		}
 
-		// Back-compat for post_parent
+		// Back-compat for post_parent.
 		if ( ! empty( $r['post_parent'] ) ) {
-			$r['object_id'] = $r['post_parent'];
+			if ( ! empty( $r['log_type'] ) ) {
+				$r['post_parent'] = $r['product_id'];
+			} else {
+				$r['object_id'] = $r['post_parent'];
+			}
 		}
 
 		// Back compat for posts_per_page

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -524,8 +524,8 @@ class EDD_Logging {
 
 		// Back-compat for post_parent.
 		if ( ! empty( $r['post_parent'] ) ) {
-			if ( ! empty( $r['log_type'] ) ) {
-				$r['post_parent'] = $r['product_id'];
+			if ( ! empty( $r['log_type'] && 'file_download' === $r['log_type'] ) ) {
+				$r['product_id'] = $r['post_parent'];
 			} else {
 				$r['object_id'] = $r['post_parent'];
 			}


### PR DESCRIPTION
Fixes #8333 

Proposed Changes:
1. Add check if `log_type` is `file_download` (3.0)
2. Change `post_parent` to `product_id` if 3.0

