### PR TITLE
Remove is_string() check #8337

### DIFF
--- a/includes/admin/class-sections.php
+++ b/includes/admin/class-sections.php
@@ -271,7 +271,7 @@ class Sections {
 
 				// Callback or action
 				if ( ! empty( $section->callback ) ) {
-					if ( is_string( $section->callback ) && is_callable( $section->callback ) ) {
+					if ( is_callable( $section->callback ) ) {
 						call_user_func( $section->callback, $this->item );
 
 					} elseif ( is_array( $section->callback ) && is_callable( $section->callback[0] ) ) {


### PR DESCRIPTION
Fixes #8337 

Proposed Changes:
1. Remove the `is_string()` check prior to checking if the callback is callable.

I opted to leave the reports-specific stuff in for now, because although only reports is using it, it seems reasonable that other implementations could use it too.