### PR TITLE
Keep extra user_info during order migration

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -737,6 +737,14 @@ class Data_Migrator {
 		// Remove core keys from `user_info`.
 		$remaining_user_info = false;
 		if ( ! empty( $user_info ) ) {
+			/**
+			 * Array keys which are part of the core `user_info` in payment meta which are not needed as part of the order meta.
+			 * Extensions can add their keys to this filter if they use the `user_info` array to store data and have
+			 * established a migration process to keep the data intact with the new order tables.
+			 *
+			 * @since 3.0
+			 * @param array The array of user info keys.
+			 */
 			$core_user_info      = apply_filters( 'edd_30_core_user_info', array( 'id', 'email', 'first_name', 'last_name', 'discount', 'address', 'user_id' ) );
 			$remaining_user_info = array_diff_key( $user_info, array_flip( $core_user_info ) );
 		}

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -726,7 +726,6 @@ class Data_Migrator {
 			'key',
 			'email',
 			'date',
-			'user_info',
 			'downloads',
 			'cart_details',
 			'currency',
@@ -734,6 +733,20 @@ class Data_Migrator {
 			'subtotal',
 			'tax',
 		);
+
+		// Remove core keys from `user_info`.
+		$remaining_user_info = false;
+		if ( ! empty( $user_info ) ) {
+			$core_user_info      = array( 'id', 'email', 'first_name', 'last_name', 'discount', 'address' );
+			$remaining_user_info = array_diff_key( $user_info, array_flip( $core_user_info ) );
+		}
+
+		// If an extension has added data to `user_info`, migrate it.
+		if ( $remaining_user_info ) {
+			$payment_meta['user_info'] = $remaining_user_info;
+		} else {
+			$core_meta_keys[] = 'user_info';
+		}
 
 		// Remove all the core payment meta from the array, and...
 		if ( is_array( $payment_meta ) ) {

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -737,7 +737,7 @@ class Data_Migrator {
 		// Remove core keys from `user_info`.
 		$remaining_user_info = false;
 		if ( ! empty( $user_info ) ) {
-			$core_user_info      = array( 'id', 'email', 'first_name', 'last_name', 'discount', 'address', 'user_id' );
+			$core_user_info      = apply_filters( 'edd_30_core_user_info', array( 'id', 'email', 'first_name', 'last_name', 'discount', 'address', 'user_id' ) );
 			$remaining_user_info = array_diff_key( $user_info, array_flip( $core_user_info ) );
 		}
 

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -737,7 +737,7 @@ class Data_Migrator {
 		// Remove core keys from `user_info`.
 		$remaining_user_info = false;
 		if ( ! empty( $user_info ) ) {
-			$core_user_info      = array( 'id', 'email', 'first_name', 'last_name', 'discount', 'address' );
+			$core_user_info      = array( 'id', 'email', 'first_name', 'last_name', 'discount', 'address', 'user_id' );
 			$remaining_user_info = array_diff_key( $user_info, array_flip( $core_user_info ) );
 		}
 

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -3161,7 +3161,7 @@ class EDD_Payment {
 		}
 
 		// Check for old `user_info` meta which may still exist.
-		$old_meta = $this->get_meta( 'payment_meta' );
+		$old_meta = edd_get_order_meta( $this->ID, 'payment_meta', true );
 		if ( ! empty( $old_meta['user_info'] ) ) {
 			$user_info = array_merge( $user_info, $old_meta['user_info'] );
 		}

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -3160,6 +3160,12 @@ class EDD_Payment {
 			);
 		}
 
+		// Check for old `user_info` meta which may still exist.
+		$old_meta = $this->get_meta( 'payment_meta' );
+		if ( ! empty( $old_meta['user_info'] ) ) {
+			$user_info = array_merge( $user_info, $old_meta['user_info'] );
+		}
+
 		return $user_info;
 	}
 


### PR DESCRIPTION
Fixes #8350

Proposed Changes:
1. During order migration, only removes core `user_info` from the payment meta--if anything is left, it's saved.
2. Adds a backwards compatibility check to the `setup_user_info` method in `EDD_Payment` to get the extra `user_info`.
