### PR TITLE
Remove variations from discount product options

### DIFF
--- a/includes/admin/discounts/add-discount.php
+++ b/includes/admin/discounts/add-discount.php
@@ -82,7 +82,6 @@ defined( 'ABSPATH' ) || exit;
 							'selected'    => array(),
 							'multiple'    => true,
 							'chosen'      => true,
-							'variations'  => true,
 							'placeholder' => sprintf( esc_html__( 'Select %s', 'easy-digital-downloads' ), esc_html( edd_get_label_plural() ) ),
 						) ); // WPCS: XSS ok. ?>
 						<div id="edd-discount-product-conditions" style="display:none;">
@@ -120,7 +119,6 @@ defined( 'ABSPATH' ) || exit;
 							'selected'    => array(),
 							'multiple'    => true,
 							'chosen'      => true,
-							'variations'  => true,
 							'placeholder' => sprintf( esc_html__( 'Select %s', 'easy-digital-downloads' ), esc_html( edd_get_label_plural() ) ),
 						) ); // WPCS: XSS ok. ?>
 						<p class="description"><?php printf( esc_html__( '%s this discount cannot be applied to. Leave blank for none.', 'easy-digital-downloads' ), esc_html( edd_get_label_plural() ) ); ?></p>

--- a/includes/admin/discounts/edit-discount.php
+++ b/includes/admin/discounts/edit-discount.php
@@ -123,7 +123,6 @@ $minutes              = edd_get_minute_values();
 							'selected'    => $product_requirements,
 							'multiple'    => true,
 							'chosen'      => true,
-							'variations'  => true,
 							'placeholder' => sprintf( __( 'Select %s', 'easy-digital-downloads' ), edd_get_label_plural() )
 						) ); ?>
 						<div id="edd-discount-product-conditions"<?php echo $condition_display; ?>>
@@ -161,7 +160,6 @@ $minutes              = edd_get_minute_values();
 							'selected'    => $excluded_products,
 							'multiple'    => true,
 							'chosen'      => true,
-							'variations'  => true,
 							'placeholder' => sprintf( __( 'Select %s', 'easy-digital-downloads' ), edd_get_label_plural() )
 						) ); ?>
 						<p class="description"><?php printf( __( '%s this discount cannot be applied to. Leave blank for none.', 'easy-digital-downloads' ), edd_get_label_plural() ); ?></p>


### PR DESCRIPTION
Fixes #8322

Proposed Changes:
1. Do not allow variations in the product dropdowns for discounts. Variations were added in #7786, but have unintended consequences.