### PR TITLE
Fix user_id parameter for filtering orders

### DIFF
--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -803,7 +803,7 @@ class EDD_Payment_History_Table extends List_Table {
 		}
 
 		$args = array_filter( array(
-			'user'        => $user,
+			'user_id'     => $user,
 			'customer_id' => $customer,
 			'status'      => $status,
 			'gateway'     => $gateway,


### PR DESCRIPTION
Fixes #8362

Proposed Changes:
1. Updates `user` parameter to query for `user_id`.