### PR TITLE
Check if price is numeric before doing comparison #8365

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -185,7 +185,7 @@ function edd_currency_filter( $price = '', $currency = '' ) {
 
 	// Default vars
 	$position = edd_get_option( 'currency_position', 'before' );
-	$negative = $price < 0;
+	$negative = is_numeric( $price ) && $price < 0;
 
 	// Remove proceeding "-" -
 	if ( true === $negative ) {


### PR DESCRIPTION
Fixes #8365

Proposed Changes:
1. Check if price is numeric before doing a `<` comparison.