### PR TITLE
Don't use associative array in call_user_func_array() #8358

### DIFF
--- a/includes/class-edd-html-elements.php
+++ b/includes/class-edd-html-elements.php
@@ -698,7 +698,7 @@ class EDD_HTML_Elements {
 		if ( ! empty( $args['show_option_all'] ) ) {
 			if ( $args['multiple'] && ! empty( $args['selected'] ) ) {
 				$selected = selected( true, in_array( 0, $args['selected'] ), false );
-			} else {
+			} elseif ( isset( $args['selected'] ) && ! is_array( $args['selected'] ) ) {
 				$selected = selected( $args['selected'], 0, false );
 			}
 			$output .= '<option value="all"' . $selected . '>' . esc_html( $args['show_option_all'] ) . '</option>';

--- a/includes/reports/data/class-endpoint.php
+++ b/includes/reports/data/class-endpoint.php
@@ -90,9 +90,9 @@ abstract class Endpoint extends Base_Object {
 
 		if ( is_callable( $callback ) ) {
 			call_user_func_array( $callback, array(
-				'endpoint' => $this,
-				'data'     => $this->get_data(),
-				'args'     => $this->get_display_args(),
+				$this, // Endpoint
+				$this->get_data(), // Data
+				$this->get_display_args(), // Args
 			) );
 		}
 	}

--- a/includes/reports/data/class-table-endpoint.php
+++ b/includes/reports/data/class-table-endpoint.php
@@ -212,9 +212,9 @@ final class Table_Endpoint extends Endpoint {
 				$this->get_data();
 
 				call_user_func_array( $callback, array(
-					'endpoint' => $this,
-					'table'    => $table,
-					'args'     => $this->get_display_args(),
+					$this, // Endpoint
+					$table, // Table
+					$this->get_display_args(), // Args
 				) );
 			}
 		}

--- a/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
+++ b/includes/reports/data/downloads/class-earnings-by-taxonomy-list-table.php
@@ -143,7 +143,7 @@ class Earnings_By_Taxonomy_List_Table extends List_Table {
 
 		// Sort by total earnings
 		usort( $sorted_data, function( $a, $b ) {
-			return $a->earnings < $b->earnings;
+			return ( $a->earnings < $b->earnings ) ? -1 : 1;
 		} );
 
 		return $sorted_data;

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1120,6 +1120,13 @@ function display_region_filter() {
 	$region  = get_filter_value( 'regions' );
 	$country = get_filter_value( 'countries' );
 
+	if ( empty( $region ) ) {
+		$region = '';
+	}
+	if ( empty( $country ) ) {
+		$country = '';
+	}
+
 	$regions = edd_get_shop_states( $country );
 
 	// Remove empty values.
@@ -1149,6 +1156,9 @@ function display_region_filter() {
  */
 function display_country_filter() {
 	$country = get_filter_value( 'countries' );
+	if ( empty( $country ) ) {
+		$country = '';
+	}
 
 	$countries = edd_get_country_list();
 


### PR DESCRIPTION
Fixes #8358

Proposed Changes:
1. Don't use an associative array.

## To test

Visit all reports and ensure everything displays correctly.

@robincornett please test in PHP 8
@LisaCee Please test in non-PHP 8