### PR TITLE
Remove database upgrades from 2018 #8341

### DIFF
--- a/includes/database/tables/class-adjustment-meta.php
+++ b/includes/database/tables/class-adjustment-meta.php
@@ -47,9 +47,7 @@ final class Adjustment_Meta extends Table {
      * @since 3.0
      * @var array
      */
-    protected $upgrades = array(
-        '201806142' => 201806142
-    );
+    protected $upgrades = array();
 
 	/**
 	 * Setup the database schema.
@@ -67,56 +65,4 @@ final class Adjustment_Meta extends Table {
 			KEY edd_adjustment_id (edd_adjustment_id),
 			KEY meta_key (meta_key({$max_index_length}))";
 	}
-
-    /**
-     * Upgrade to version 201806142
-     * - Migrate data from `edd_discounts` to `edd_adjustments`.
-     *
-	 * This is only for 3.0 beta testers, and can be removed in 3.0.1 or above.
-	 *
-     * @since 3.0
-     *
-     * @return boolean True if upgrade was successful, false otherwise.
-     */
-    protected function __201806142() {
-
-        // Old discounts table
-        $table_name = $this->get_db()->get_blog_prefix( null ) . 'edd_discountmeta';
-
-		// Does old table exist?
-		$query    = "SHOW TABLES LIKE %s";
-		$like     = $this->get_db()->esc_like( $table_name );
-		$prepared = $this->get_db()->prepare( $query, $like );
-		$result   = $this->get_db()->get_var( $prepared );
-
-		// Bail if no old table
-		if ( empty( $result ) || is_wp_error( $result ) ) {
-			return true;
-		}
-
-        // Get the contents
-        $discounts = $this->get_db()->get_results( "SELECT * FROM {$table_name}" );
-
-		// Migrate discounts to adjustments
-		if ( ! empty( $discounts ) ) {
-			foreach ( $discounts as $discount ) {
-				$this->get_db()->insert( $this->table_name, array(
-					'edd_adjustment_id' => $discount->edd_discount_id,
-					'meta_key'          => $discount->meta_key,
-					'meta_value'        => $discount->meta_value
-				) );
-			}
-		}
-
-		// Delete the old option
-		delete_option( 'wpdb_edd_discountmeta_version' );
-
-		// Attempt to drop the old table
-		$this->get_db()->query( "
-			DROP TABLE {$table_name};
-		" );
-
-        // Return success/fail
-        return true;
-    }
 }

--- a/includes/database/tables/class-adjustments.php
+++ b/includes/database/tables/class-adjustments.php
@@ -48,8 +48,6 @@ final class Adjustments extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201806142' => 201806142,
-		'201807273' => 201807273,
 		'201906031' => 201906031,
 		'202002121' => 202002121,
 	);
@@ -111,117 +109,6 @@ final class Adjustments extends Table {
 
 		return $created;
 
-	}
-
-	/**
-	 * Upgrade to version 201806142
-	 * - Migrate data from `edd_discounts` to `edd_adjustments`.
-	 *
-	 * This is only for 3.0 beta testers, and can be removed in 3.0.1 or above.
-	 *
-	 * @access protected
-	 * @since 3.0
-	 *
-	 * @return boolean True if upgrade was successful, false otherwise.
-	 */
-	protected function __201806142() {
-
-		// Old discounts table
-		$table_name = $this->get_db()->get_blog_prefix( null ) . 'edd_discounts';
-
-		// Does old table exist?
-		$query    = "SHOW TABLES LIKE %s";
-		$like     = $this->get_db()->esc_like( $table_name );
-		$prepared = $this->get_db()->prepare( $query, $like );
-		$result   = $this->get_db()->get_var( $prepared );
-
-		// Bail if no old table
-		if ( empty( $result ) || is_wp_error( $result ) ) {
-			return true;
-		}
-
-		// Get the contents
-		$discounts = $this->get_db()->get_results( "SELECT * FROM {$table_name}" );
-
-		// Migrate discounts to adjustments
-		if ( ! empty( $discounts ) ) {
-			foreach ( $discounts as $discount ) {
-				$this->get_db()->insert( $this->table_name, array(
-					'parent'            => $discount->parent,
-					'name'              => $discount->name,
-					'code'              => $discount->code,
-					'status'            => $discount->status,
-					'type'              => 'discount',
-					'scope'             => $discount->scope,
-					'amount_type'       => $discount->type,
-					'amount'            => $discount->amount,
-					'description'       => $discount->description,
-					'max_uses'          => $discount->max_uses,
-					'use_count'         => $discount->use_count,
-					'once_per_customer' => $discount->once_per_customer,
-					'min_cart_price'    => $discount->min_cart_price,
-					'date_created'      => $discount->date_created,
-					'date_modified'     => $discount->date_modified,
-					'start_date'        => $discount->start_date,
-					'end_date'          => $discount->end_date
-				) );
-			}
-		}
-
-		// Delete the old option
-		delete_option( 'wpdb_edd_discounts_version' );
-
-		// Attempt to drop the old table
-		$this->get_db()->query( "
-			DROP TABLE {$table_name};
-		" );
-
-		// Return success/fail
-		return true;
-	}
-
-	/**
-	 * Upgrade to version 201807111
-	 * - Rename `min_cart_price` to `min_charge_amount`.
-	 *
-	 * This is only for 3.0 beta testers, and can be removed in 3.0.1 or above.
-	 *
-	 * @access protected
-	 * @since 3.0
-	 *
-	 * @return boolean True if upgrade was successful, false otherwise.
-	 */
-	protected function __201807111() {
-		$retval = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} CHANGE `min_cart_price` `min_charge_amount` decimal(18,9) NOT NULL default '0';
-		" );
-
-		// Return success/fail
-		return $this->is_success( $retval );
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column.
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean True if upgrade was successful, false otherwise.
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-customer-addresses.php
+++ b/includes/database/tables/class-customer-addresses.php
@@ -48,7 +48,6 @@ final class Customer_Addresses extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807273' => 201807273,
 		'201906251' => 201906251,
 		'202002141' => 202002141,
 		'202004051' => 202004051,
@@ -82,30 +81,6 @@ final class Customer_Addresses extends Table {
 			KEY type (type(20)),
 			KEY status (status(20)),
 			KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-customer-email-addresses.php
+++ b/includes/database/tables/class-customer-email-addresses.php
@@ -48,8 +48,6 @@ final class Customer_Email_Addresses extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201808141' => 201808141,
-		'201808171' => 201808171,
 		'202002141' => 202002141,
 	);
 
@@ -75,47 +73,6 @@ final class Customer_Email_Addresses extends Table {
 			KEY type (type(20)),
 			KEY status (status(20)),
 			KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201808141
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201808141() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201808171
-	 * - Add the `email` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201808171() {
-
-		$result = $this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY COLUMN `email` varchar(100) NOT NULL default ''" );
-		$result = $this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX email (email)" );
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-customers.php
+++ b/includes/database/tables/class-customers.php
@@ -48,11 +48,6 @@ final class Customers extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807111' => 201807111,
-		'201807131' => 201807131,
-		'201807132' => 201807132,
-		'201807273' => 201807273,
-		'201810091' => 201810091,
 		'202002141' => 202002141,
 		'202006101' => 202006101,
 	);
@@ -126,106 +121,6 @@ final class Customers extends Table {
 		}
 
 		parent::maybe_upgrade();
-	}
-
-	/**
-	 * Upgrade to version 201806071
-	 * - Change `purchase_value` from mediumtext to decimal(18,9).
-	 * - Add the `status` column.
-	 *
-	 * @since 3.0
-	 *
-	 * @return bool
-	 */
-	protected function __201807111() {
-
-		// Alter the database
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `purchase_value` decimal(18,9) NOT NULL default '0'" );
-
-		if ( ! $this->column_exists( 'status' ) ) {
-			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `status` varchar(20) NOT NULL default 'active' AFTER `name`" );
-			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX status (status(20))" );
-		}
-
-		// Return success/fail
-		return $this->is_success( true );
-	}
-
-	/**
-	 * Upgrade to version 201807131
-	 * - Add `date_modified` column.
-	 *
-	 * @since 3.0
-	 *
-	 * @return bool
-	 */
-	protected function __201807131() {
-
-		if ( ! $this->column_exists( 'date_modified' ) ) {
-			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN date_modified datetime NOT NULL default '0000-00-00 00:00:00' AFTER `date_created`" );
-		}
-
-		// Return success/fail
-		return $this->is_success( true );
-	}
-
-	/**
-	 * Upgrade to version 201807132
-	 * - Set values of `date_modified` to `date_created` (no empties)
-	 *
-	 * @since 3.0
-	 *
-	 * @return bool
-	 */
-	protected function __201807132() {
-
-		// Update modified row values
-		$this->get_db()->query( "UPDATE {$this->table_name} SET `date_modified` = `date_created`" );
-
-		// Return success/fail
-		return $this->is_success( true );
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201810091
-	 * - Modify the `name` column from mediumtext to varchar(255)
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201810091() {
-
-		$result = $this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY `name` varchar(255) NOT NULL default '';
-		" );
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-logs-api-requests.php
+++ b/includes/database/tables/class-logs-api-requests.php
@@ -48,8 +48,6 @@ final class Logs_Api_Requests extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807272' => 201807272,
-		'201807273' => 201807273,
 		'202002141' => 202002141,
 	);
 
@@ -76,54 +74,6 @@ final class Logs_Api_Requests extends Table {
 		PRIMARY KEY (id),
 		KEY user_id (user_id),
 		KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `date_modified` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807272() {
-
-		// Look for column
-		$result = $this->column_exists( 'date_modified' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00' AFTER `date_created`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201807272
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-logs-file-downloads.php
+++ b/includes/database/tables/class-logs-file-downloads.php
@@ -48,8 +48,6 @@ final class Logs_File_Downloads extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201806281' => 201806281,
-		'201807273' => 201807273,
 		'202002141' => 202002141,
 	);
 
@@ -76,51 +74,6 @@ final class Logs_File_Downloads extends Table {
 		KEY customer_id (customer_id),
 		KEY product_id (product_id),
 		KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201806281
-	 * - Rename  `download_id` column to `product_id`
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201806281() {
-
-		// Alter the database with separate queries so indexes succeed
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE COLUMN download_id product_id bigint(20) unsigned NOT NULL default 0" );
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE COLUMN user_id customer_id bigint(20) unsigned NOT NULL default 0" );
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE COLUMN payment_id order_id bigint(20) unsigned NOT NULL default 0" );
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX download_id" );
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX product_id (product_id)" );
-
-		// Return success/fail
-		return $this->is_success( true );
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-logs.php
+++ b/includes/database/tables/class-logs.php
@@ -48,9 +48,6 @@ final class Logs extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807241' => 201807241,
-		'201807272' => 201807272,
-		'201807273' => 201807273,
 		'202002141' => 202002141,
 	);
 
@@ -77,74 +74,6 @@ final class Logs extends Table {
 		KEY user_id (user_id),
 		KEY type (type(20)),
 		KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201807231
-	 * - Add `user_id` column.
-	 *
-	 * @since 3.0
-	 *
-	 * @return bool
-	 */
-	protected function __201807241() {
-
-		// Alter the database
-		if ( ! $this->column_exists( 'user_id' ) ) {
-			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN user_id bigint(20) unsigned NOT NULL default '0' AFTER object_type" );
-			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX user_id (user_id)" );
-		}
-
-		// Return success/fail
-		return $this->is_success( true );
-	}
-
-	/**
-	 * Upgrade to version 201807272
-	 * - Add the `date_modified` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807272() {
-
-		// Look for column
-		$result = $this->column_exists( 'date_modified' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00' AFTER `date_created`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-notes.php
+++ b/includes/database/tables/class-notes.php
@@ -48,8 +48,6 @@ final class Notes extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807272' => 201807272,
-		'201807273' => 201807273,
 		'202002141' => 202002141,
 	);
 
@@ -73,54 +71,6 @@ final class Notes extends Table {
 			KEY object_id_type (object_id,object_type(20)),
 			KEY user_id (user_id),
 			KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201807272
-	 * - Add the `date_modified` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807272() {
-
-		// Look for column
-		$result = $this->column_exists( 'date_modified' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00' AFTER `date_created`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-order-addresses.php
+++ b/includes/database/tables/class-order-addresses.php
@@ -48,7 +48,6 @@ final class Order_Addresses extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807273' => 201807273,
 		'201906251' => 201906251,
 		'201906281' => 201906281,
 		'202002141' => 202002141,
@@ -83,30 +82,6 @@ final class Order_Addresses extends Table {
 			KEY postal_code (postal_code(32)),
 			KEY country (country({$max_index_length})),
 			KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-order-adjustments.php
+++ b/includes/database/tables/class-order-adjustments.php
@@ -48,8 +48,6 @@ final class Order_Adjustments extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807071' => 201807071,
-		'201807273' => 201807273,
 		'202002141' => 202002141,
 		'202011122' => 202011122,
 	);
@@ -78,50 +76,6 @@ final class Order_Adjustments extends Table {
 		PRIMARY KEY (id),
 		KEY object_id_type (object_id,object_type(20)),
 		KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201807071
-	 * - Add subtotal and tax columns.
-	 * - Rename amount column to total.
-	 *
-	 * @since 3.0
-	 *
-	 * @return bool
-	 */
-	protected function __201807071() {
-
-		// Alter the database.
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} CHANGE `amount` `total` decimal(18,9) NOT NULL default '0'" );
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `subtotal` decimal(18,9) NOT NULL default '0';" );
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `tax` decimal(18,9) NOT NULL default '0'" );
-
-		// Return success/fail.
-		return $this->is_success( true );
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-order-items.php
+++ b/includes/database/tables/class-order-items.php
@@ -48,8 +48,6 @@ final class Order_Items extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807272' => 201807272,
-		'201807273' => 201807273,
 		'201906241' => 201906241,
 		'202002141' => 202002141,
 		'202102010' => 202102010,
@@ -83,64 +81,6 @@ final class Order_Items extends Table {
 			PRIMARY KEY (id),
 			KEY order_product_price_id (order_id,product_id,price_id),
 			KEY type_status (type(20),status(20))";
-	}
-
-	/**
-	 * Upgrade to version 201807272
-	 * - Add the `date_modified` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807272() {
-
-		// Look for column
-		$result = $this->column_exists( 'date_created' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `date_created` datetime NOT NULL default '0000-00-00 00:00:00' AFTER `total`;
-			" );
-		}
-
-		// Look for column
-		$result = $this->column_exists( 'date_modified' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `date_modified` datetime NOT NULL default '0000-00-00 00:00:00' AFTER `date_created`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-order-transactions.php
+++ b/includes/database/tables/class-order-transactions.php
@@ -48,7 +48,6 @@ final class Order_Transactions extends Table {
 	 * @var array
 	 */
 	protected $upgrades = array(
-		'201807273' => 201807273,
 		'202002141' => 202002141,
 		'202005261' => 202005261,
 	);
@@ -76,30 +75,6 @@ final class Order_Transactions extends Table {
 			KEY gateway (gateway(20)),
 			KEY status (status(20)),
 			KEY date_created (date_created)";
-	}
-
-	/**
-	 * Upgrade to version 201807273
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_modified`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
 	}
 
 	/**

--- a/includes/database/tables/class-orders.php
+++ b/includes/database/tables/class-orders.php
@@ -48,10 +48,6 @@ final class Orders extends Table {
 	 * @var    array
 	 */
 	protected $upgrades = array(
-		'201806111' => 201806111,
-		'201807273' => 201807273,
-		'201808141' => 201808141,
-		'201808151' => 201808151,
 		'201901111' => 201901111,
 		'202002141' => 202002141,
 		'202012041' => 202012041
@@ -123,101 +119,6 @@ final class Orders extends Table {
 
 		return $created;
 
-	}
-
-	/**
-	 * Upgrade to version 201806111
-	 * - Add the `date_refundable` datetime column.
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201806111() {
-
-		// Look for column
-		$result = $this->get_db()->query( "SHOW COLUMNS FROM {$this->table_name} LIKE 'date_refundable'" );
-
-		// Maybe add column
-		if ( ! $this->is_success( $result ) ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `date_refundable` datetime DEFAULT '0000-00-00 00:00:00' AFTER `date_completed`;
-			" );
-		}
-
-		// Return success/fail
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201807271
-	 * - Add the `uuid` varchar column
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201807273() {
-
-		// Look for column
-		$result = $this->column_exists( 'uuid' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `uuid` varchar(100) default '' AFTER `date_refundable`;
-			" );
-		}
-
-		// Return success/fail.
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201808141
-	 * - Add the `type` column.
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201808141() {
-
-		// Look for column
-		$result = $this->column_exists( 'type' );
-
-		// Maybe add column
-		if ( false === $result ) {
-			$result = $this->get_db()->query( "
-				ALTER TABLE {$this->table_name} ADD COLUMN `type` varchar(20) NOT NULL default 'sale' AFTER status;
-			" );
-		}
-
-		// Return success/fail.
-		return $this->is_success( $result );
-	}
-
-	/**
-	 * Upgrade to version 201808151
-	 * - Change the default value of the `type` column to `sale`.
-	 *
-	 * @since 3.0
-	 *
-	 * @return boolean
-	 */
-	protected function __201808151() {
-
-		// Alter the database
-		$this->get_db()->query( "
-			ALTER TABLE {$this->table_name} MODIFY COLUMN `type` varchar(20) NOT NULL default 'sale';
-		" );
-
-		$this->get_db()->query( "
-			UPDATE {$this->table_name} SET `type` = 'sale';
-		" );
-
-		// Return success/fail.
-		return $this->is_success( true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8341

Proposed Changes:
1. Removes all database upgrades from 2018.

We should test:

1. An upgrade from 2.9.
2. A fresh install of EDD 3.0.

And in both cases ensure there are no database errors.