### PR TITLE
Check if the export file exists before using unlink

### DIFF
--- a/includes/admin/reporting/export/class-batch-export.php
+++ b/includes/admin/reporting/export/class-batch-export.php
@@ -142,7 +142,9 @@ class EDD_Batch_Export extends EDD_Export {
 		if( $this->step < 2 ) {
 
 			// Make sure we start with a fresh file on step 1
-			@unlink( $this->file );
+			if ( file_exists( $this->file ) ) {
+				unlink( $this->file );
+			}
 			$this->print_csv_cols();
 		}
 


### PR DESCRIPTION
Fixes #8369

To test: switch to PHP8 and use an export tool which uses the EDD_Batch_Export class. Without the fix, you should get the warning noted in the issue; with it, you should not.