### PR TITLE
Remove backwards compat _edd_payment_ removal

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2599,8 +2599,6 @@ class EDD_Payment {
 				}
 		}
 
-		$meta_key = str_replace( '_edd_payment_', '', $meta_key );
-
 		return edd_update_order_meta( $this->ID, $meta_key, $meta_value, $prev_value );
 	}
 


### PR DESCRIPTION
Fixes #8373

To test:
Use this branch with an extension which uses the `edd_update_payment_meta` and `edd_get_payment_meta` functions, especially with their own meta keys with the `_edd_payment_` prefix. Cross-Sell/Upsell is one; Simple Shipping is another ([use this branch to get a 3.0 compatible version](https://github.com/easydigitaldownloads/edd-simple-shipping/tree/issue/89-meta)). Meta keys should continue to be saved with the prefix and should be able to be updated and retrieved with either the payment or order meta functions.

ACK! Just realized this wasn't mine to do--I'm so sorry I messed that up. Checked with Lisa and am leaving as is.