### PR TITLE
Fix backwards compatibility for log inserts #8383

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -310,7 +310,7 @@ class Data_Migrator {
 				'user_id'       => ! empty( $meta_to_migrate['_edd_log_user'] ) ? $meta_to_migrate['_edd_log_user'] : $data->post_author,
 				'type'          => $data->slug,
 				'title'         => $data->post_title,
-				'message'       => $data->post_content,
+				'content'       => $data->post_content,
 				'date_created'  => $data->post_date_gmt,
 				'date_modified' => $data->post_modified_gmt,
 			);

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -330,6 +330,9 @@ class Data_Migrator {
 
 		foreach ( $meta_to_migrate as $key => $value ) {
 			if ( ! in_array( $key, $meta_to_remove, true ) ) {
+				// Strip off `_edd_log_` prefix.
+				$key = str_replace( '_edd_log_', '', $key );
+
 				$add_meta_function( $new_log_id, $key, $value );
 			}
 		}

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -304,6 +304,7 @@ class Data_Migrator {
 			$log_data = array(
 				'object_id'     => $data->post_parent,
 				'object_type'   => 'download',
+				'user_id'       => $data->post_author,
 				'type'          => $data->slug,
 				'title'         => $data->post_title,
 				'message'       => $data->post_content,

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -300,11 +300,14 @@ class Data_Migrator {
 			$add_meta_function = 'edd_add_api_request_log_meta';
 		} else {
 			$post_meta = get_post_custom( $data->ID );
+			foreach ( $post_meta as $key => $value ) {
+				$meta_to_migrate[ $key ] = maybe_unserialize( $value[0] );
+			}
 
 			$log_data = array(
 				'object_id'     => $data->post_parent,
 				'object_type'   => 'download',
-				'user_id'       => $data->post_author,
+				'user_id'       => ! empty( $meta_to_migrate['_edd_log_user'] ) ? $meta_to_migrate['_edd_log_user'] : $data->post_author,
 				'type'          => $data->slug,
 				'title'         => $data->post_title,
 				'message'       => $data->post_content,
@@ -314,10 +317,9 @@ class Data_Migrator {
 
 			$meta_to_remove = array(
 				'_edit_lock',
+				'_edd_log_user',
 			);
-			foreach ( $post_meta as $key => $value ) {
-				$meta_to_migrate[ $key ] = maybe_unserialize( $value[0] );
-			}
+
 			$new_log_id        = edd_add_log( $log_data );
 			$add_meta_function = 'edd_add_log_meta';
 		}

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -146,6 +146,12 @@ class EDD_Logging {
 			'log_type'     => false,
 		) );
 
+		/**
+		 * Triggers just before a log is inserted.
+		 *
+		 * @param array $args     Log entry data.
+		 * @param array $log_meta Log meta data.
+		 */
 		do_action( 'edd_pre_insert_log', $args, $log_meta );
 
 		// Used to dynamically dispatch the method call to insert() to the correct class.
@@ -160,6 +166,7 @@ class EDD_Logging {
 			'object_type' => isset( $args['log_type'] )
 				? $args['log_type']
 				: null,
+			'user_id'     => ! empty( $args['post_author'] ) ? intval( $args['post_author'] ) : 0
 		);
 
 		$type = $args['log_type'];
@@ -176,15 +183,21 @@ class EDD_Logging {
 			$insert_method = 'edd_add_api_request_log';
 
 			$data = array(
-				'user_id' => $log_meta['user'],
-				'api_key' => $log_meta['key'],
-				'token'   => null === $log_meta['token'] ? 'public' : $log_meta['token'],
-				'version' => $log_meta['version'],
-				'request' => $args['post_excerpt'],
-				'error'   => $args['post_content'],
-				'ip'      => $log_meta['request_ip'],
-				'time'    => $log_meta['time'],
+				'user_id' => ! empty( $log_meta['user'] ) ? $log_meta['user'] : 0,
+				'api_key' => ! empty( $log_meta['key'] ) ? $log_meta['key'] : 'public',
+				'token'   => ! empty( $log_meta['token'] ) ? $log_meta['token'] : 'public',
+				'version' => ! empty( $log_meta['version'] ) ? $log_meta['version'] : '',
+				'request' => ! empty( $args['post_excerpt'] ) ? $args['post_excerpt'] : '',
+				'error'   => ! empty( $args['post_content'] ) ? $args['post_content'] : '',
+				'ip'      => ! empty( $log_meta['request_ip'] ) ? $log_meta['request_ip'] : '',
+				'time'    => ! empty( $log_meta['time'] ) ? $log_meta['time'] : '',
 			);
+
+			// Now unset the meta we've used up in the main data array.
+			$meta_to_unset = array( 'user', 'key', 'token', 'version', 'request_ip', 'time' );
+			foreach ( $meta_to_unset as $meta_key ) {
+				unset( $log_meta[ $meta_key ] );
+			}
 		} elseif ( 'file_download' === $args['log_type'] ) {
 			$insert_method = 'edd_add_file_download_log';
 
@@ -198,13 +211,19 @@ class EDD_Logging {
 
 			$data = array(
 				'product_id'  => $args['post_parent'],
-				'file_id'     => $log_meta['file_id'],
-				'order_id'    => $log_meta['order_id'],
-				'price_id'    => $log_meta['price_id'],
-				'customer_id' => $log_meta['customer_id'],
-				'ip'          => $log_meta['ip'],
+				'file_id'     => ! empty( $log_meta['file_id'] ) ? $log_meta['file_id'] : 0,
+				'order_id'    => ! empty( $log_meta['payment_id'] ) ? $log_meta['payment_id'] : 0,
+				'price_id'    => ! empty( $log_meta['price_id'] ) ? $log_meta['price_id'] : 0,
+				'customer_id' => ! empty( $log_meta['customer_id'] ) ? $log_meta['customer_id'] : 0,
+				'ip'          => ! empty( $log_meta['ip'] ) ? $log_meta['ip'] : '',
 				'user_agent'  => $user_agent,
 			);
+
+			// Now unset the meta we've used up in the main data array.
+			$meta_to_unset = array( 'file_id', 'payment_id', 'price_id', 'customer_id', 'ip' );
+			foreach ( $meta_to_unset as $meta_key ) {
+				unset( $log_meta[ $meta_key ] );
+			}
 		}
 
 		// Get the log ID if method is callable
@@ -231,6 +250,13 @@ class EDD_Logging {
 			}
 		}
 
+		/**
+		 * Triggers after a log has been inserted.
+		 *
+		 * @param int   $log_id   ID of the new log.
+		 * @param array $args     Log data.
+		 * @param array $log_meta Log meta data.
+		 */
 		do_action( 'edd_post_insert_log', $log_id, $args, $log_meta );
 
 		return $log_id;

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -182,6 +182,8 @@ class EDD_Logging {
 			$data['title'] = $args['post_title'];
 		}
 
+		$meta_to_unset = array( 'user' );
+
 		// Override $data and $insert_method based on the log type.
 		if ( 'api_request' === $args['log_type'] ) {
 			$insert_method = 'edd_add_api_request_log';
@@ -197,11 +199,7 @@ class EDD_Logging {
 				'time'    => ! empty( $log_meta['time'] ) ? $log_meta['time'] : '',
 			);
 
-			// Now unset the meta we've used up in the main data array.
 			$meta_to_unset = array( 'user', 'key', 'token', 'version', 'request_ip', 'time' );
-			foreach ( $meta_to_unset as $meta_key ) {
-				unset( $log_meta[ $meta_key ] );
-			}
 		} elseif ( 'file_download' === $args['log_type'] ) {
 			$insert_method = 'edd_add_file_download_log';
 
@@ -223,11 +221,12 @@ class EDD_Logging {
 				'user_agent'  => $user_agent,
 			);
 
-			// Now unset the meta we've used up in the main data array.
 			$meta_to_unset = array( 'file_id', 'payment_id', 'price_id', 'customer_id', 'ip' );
-			foreach ( $meta_to_unset as $meta_key ) {
-				unset( $log_meta[ $meta_key ] );
-			}
+		}
+
+		// Now unset the meta we've used up in the main data array.
+		foreach ( $meta_to_unset as $meta_key ) {
+			unset( $log_meta[ $meta_key ] );
 		}
 
 		// Get the log ID if method is callable

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -166,7 +166,11 @@ class EDD_Logging {
 			'object_type' => isset( $args['log_type'] )
 				? $args['log_type']
 				: null,
-			'user_id'     => ! empty( $args['post_author'] ) ? intval( $args['post_author'] ) : 0
+			/*
+			 * Fallback user ID is the current user, due to it previously being set to that by WordPress
+			 * core when setting post_author on the CPT.
+			 */
+			'user_id'     => ! empty( $log_meta['user'] ) ? $log_meta['user'] : get_current_user_id()
 		);
 
 		$type = $args['log_type'];


### PR DESCRIPTION
Fixes #8383 

Proposed Changes:
1. Add support for converting `$log_meta['user']` to `user_id`. If not provided, it falls back to `get_current_user_id()`
2. Set `user_id` to during 3.0 migration.
2. Check if all array keys exist before using.
3. Whenever a piece of `$log_meta` is used in the main `$data` array, ensure it gets unset from `$log_meta`. This ensures that we don't add duplicate meta data unnecessarily. (The data was being added to the main table _and_ the meta table.)
4. For file downloads: get the `order_id` arg from `$log_meta['payment_id']` instead of `$log_meta['order_id']`
5. Add PHPDocs for action hooks.
6. Strip `_edd_log_` meta key prefix during log migration.