### PR TITLE
Change heading to 'Discounts' #8286

### DIFF
--- a/includes/admin/adjustments/adjustment-functions.php
+++ b/includes/admin/adjustments/adjustment-functions.php
@@ -40,7 +40,7 @@ function edd_adjustments_page() {
 	ob_start(); ?>
 
 	<div class="wrap">
-		<h1 class="wp-heading-inline"><?php esc_html_e( 'Adjustments', 'easy-digital-downloads' ); ?></h1>
+		<h1 class="wp-heading-inline"><?php esc_html_e( 'Discounts', 'easy-digital-downloads' ); ?></h1>
 		<a href="<?php echo esc_url( $add_new_url ); ?>" class="page-title-action"><?php esc_html_e( 'Add New', 'easy-digital-downloads' ); ?></a>
 
 		<hr class="wp-header-end">


### PR DESCRIPTION
Fixes #8286

Proposed Changes:
1. Change the main header to `Discounts` to match the admin menu item and Add/Edit pages ("Add New Discount")