### PR TITLE
Clear the customer info section

### DIFF
--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -587,6 +587,7 @@ function edd_customers_view( $customer = null ) {
 					</span>
 				</div>
 			</div>
+			<div class="edd-clearfix"></div>
 		</form>
 	</div>
 

--- a/includes/admin/customers/customers.php
+++ b/includes/admin/customers/customers.php
@@ -587,8 +587,8 @@ function edd_customers_view( $customer = null ) {
 					</span>
 				</div>
 			</div>
-			<div class="edd-clearfix"></div>
 		</form>
+		<div class="edd-clearfix"></div>
 	</div>
 
 	<?php do_action( 'edd_customer_before_stats', $customer ); ?>


### PR DESCRIPTION
Fixes #8394

Proposed Changes:
1. Add a clearing `div` at the end of the customer info section.