### PR TITLE
Add new indexes to custom tables #8176

### DIFF
--- a/includes/database/engine/class-table.php
+++ b/includes/database/engine/class-table.php
@@ -591,10 +591,12 @@ abstract class Table extends Base {
 			return false;
 		}
 
+		$column = esc_sql( $column );
+
 		// Query statement
-		$query    = "SHOW INDEXES FROM {$this->table_name} WHERE %s LIKE %s";
+		$query    = "SHOW INDEXES FROM {$this->table_name} WHERE {$column} LIKE %s";
 		$like     = $db->esc_like( $name );
-		$prepared = $db->prepare( $query, $column, $like );
+		$prepared = $db->prepare( $query, $like );
 		$result   = $db->query( $prepared );
 
 		// Does the index exist?

--- a/includes/database/schemas/class-logs-file-downloads.php
+++ b/includes/database/schemas/class-logs-file-downloads.php
@@ -101,7 +101,7 @@ class Logs_File_Downloads extends Schema {
 			'searchable' => true
 		),
 
-		// ip
+		// user_agent
 		array(
 			'name'       => 'user_agent',
 			'type'       => 'varchar',

--- a/includes/database/schemas/class-orders.php
+++ b/includes/database/schemas/class-orders.php
@@ -38,8 +38,7 @@ class Orders extends Schema {
 			'unsigned'   => true,
 			'extra'      => 'auto_increment',
 			'primary'    => true,
-			'sortable'   => true,
-			'searchable' => true
+			'sortable'   => true
 		),
 
 		// parent
@@ -49,7 +48,6 @@ class Orders extends Schema {
 			'length'     => '20',
 			'unsigned'   => true,
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -68,7 +66,6 @@ class Orders extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'pending',
-			'searchable' => true,
 			'sortable'   => true,
 			'transition' => true
 		),
@@ -79,7 +76,6 @@ class Orders extends Schema {
 			'type'       => 'varchar',
 			'length'     => '20',
 			'default'    => 'sale',
-			'searchable' => true,
 			'sortable'   => true
 		),
 
@@ -193,7 +189,6 @@ class Orders extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'searchable' => true,
 			'sortable'   => true
 		),
 

--- a/includes/database/tables/class-adjustments.php
+++ b/includes/database/tables/class-adjustments.php
@@ -80,7 +80,7 @@ final class Adjustments extends Table {
 			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
-			KEY status_type (status(20),type(20)),
+			KEY type_status (type(20), status(20)),
 			KEY code (code),
 			KEY date_created (date_created),
 			KEY date_start_end (start_date,end_date)";
@@ -198,7 +198,7 @@ final class Adjustments extends Table {
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX code_status_type_scope_amount" );
 		}
 
-		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX status_type (status(20),type(20))" );
+		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX type_status (type(20), status(20))" );
 		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX code (code)" );
 
 		return true;

--- a/includes/database/tables/class-adjustments.php
+++ b/includes/database/tables/class-adjustments.php
@@ -38,7 +38,7 @@ final class Adjustments extends Table {
 	 * @since 3.0
 	 * @var int
 	 */
-	protected $version = 202002121;
+	protected $version = 202102161;
 
 	/**
 	 * Array of upgrade versions and methods.
@@ -50,6 +50,7 @@ final class Adjustments extends Table {
 	protected $upgrades = array(
 		'201906031' => 201906031,
 		'202002121' => 202002121,
+		'202102161' => 202102161
 	);
 
 	/**
@@ -79,7 +80,8 @@ final class Adjustments extends Table {
 			date_modified datetime NOT NULL default CURRENT_TIMESTAMP,
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
-			KEY code_status_type_scope_amount (code(50),status(20),type(20),scope(20),amount_type(20)),
+			KEY status_type (status(20),type(20)),
+			KEY code (code),
 			KEY date_created (date_created),
 			KEY date_start_end (start_date,end_date)";
 	}
@@ -180,5 +182,25 @@ final class Adjustments extends Table {
 
 		return $this->is_success( $result );
 
+	}
+
+	/**
+	 * Upgrade to version 202102161
+	 * 	- Drop old `code_status_type_scope_amount` index
+	 * 	- Create new `status_type` index
+	 * 	- Create new `code` index
+	 *
+	 * @since 3.0
+	 * @return bool
+	 */
+	protected function __202102161() {
+		if ( $this->index_exists( 'code_status_type_scope_amount' ) ) {
+			$this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX code_status_type_scope_amount" );
+		}
+
+		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX status_type (status(20),type(20))" );
+		$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX code (code)" );
+
+		return true;
 	}
 }

--- a/includes/database/tables/class-orders.php
+++ b/includes/database/tables/class-orders.php
@@ -38,7 +38,7 @@ final class Orders extends Table {
 	 * @since  3.0
 	 * @var    int
 	 */
-	protected $version = 202012041;
+	protected $version = 202102161;
 
 	/**
 	 * Array of upgrade versions and methods.
@@ -50,7 +50,8 @@ final class Orders extends Table {
 	protected $upgrades = array(
 		'201901111' => 201901111,
 		'202002141' => 202002141,
-		'202012041' => 202012041
+		'202012041' => 202012041,
+		'202102161' => 202102161
 	);
 
 	/**
@@ -86,7 +87,7 @@ final class Orders extends Table {
 			uuid varchar(100) NOT NULL default '',
 			PRIMARY KEY (id),
 			KEY order_number (order_number({$max_index_length})),
-			KEY status (status(20)),
+			KEY status_type (status, type),
 			KEY user_id (user_id),
 			KEY customer_id (customer_id),
 			KEY email (email(100)),
@@ -199,5 +200,25 @@ final class Orders extends Table {
 
 		// Return success/fail.
 		return $this->is_success( $result );
+	}
+
+	/**
+	 * Upgrade to version 202102161
+	 * 	- Drop `status` index
+	 * 	- Create new `status_type` index
+	 *
+	 * @since 3.0
+	 * @return bool
+	 */
+	protected function __202102161() {
+		if ( $this->index_exists( 'status' ) ) {
+			$this->get_db()->query( "ALTER TABLE {$this->table_name} DROP INDEX status" );
+		}
+
+		if ( ! $this->index_exists( 'status_type' ) ) {
+			$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX status_type (status, type)" );
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
Fixes #8176

Proposed Changes:
1. Patches the `index_exists()` method in BerlinDB. The query wasn't working before.
2. **Orders Table:**
    - Removes `searchable` from some columns that do not need to be searched (id, parent, status, etc.). They can still be queried individually, but they do not need `LIKE` queries. This improves the performance of searching orders.
    - Drops old `KEY status (status(20))`
    - Creates new index `KEY status_type (status, type)` . Adding `type` improves the performance of the admin orders table.
3. **Adjustments Table:**
    - Drops the old `code_status_type_scope_amount` index. I couldn't find it being used anywhere. This came closest: https://github.com/easydigitaldownloads/easy-digital-downloads/blob/release/3.0/includes/admin/settings/register-settings.php#L1479-L1488 but funnily enough, that _still_ wouldn't use the index due to `code` not being in use.
    - New index: `KEY type_status (type(20), status(20))` . I put `type` first because I found several cases where we only query on type (such as: get the tax rates) and omit status, but none where it's the reverse.
    - New index: `KEY code (code)` due to removal of the old index that included code. And "get discount by code" is a common usage.

## Testing

- Checkout this branch on an existing 3.0 install. Ensure no database errors.
- Test a fresh EDD 3.0 install. Ensure no database errors.