### PR TITLE
#8374 Redirect After Permanently Deleting

### DIFF
--- a/includes/admin/admin-deprecated-functions.php
+++ b/includes/admin/admin-deprecated-functions.php
@@ -49,3 +49,27 @@ function edd_tools_banned_emails_display() {
 	do_action( 'edd_tools_banned_emails_after' );
 	do_action( 'edd_tools_after' );
 }
+
+/**
+ * Trigger a Purchase Deletion
+ *
+ * @since 1.3.4
+ * @deprecated 3.0 replaced by edd_trigger_destroy_order.
+ * @param array $data Arguments passed.
+ * @return void
+ */
+function edd_trigger_purchase_delete( $data ) {
+	if ( wp_verify_nonce( $data['_wpnonce'], 'edd_payment_nonce' ) ) {
+
+		$payment_id = absint( $data['purchase_id'] );
+
+		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
+			wp_die( __( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+		}
+
+		edd_delete_purchase( $payment_id );
+
+		edd_redirect( admin_url( '/edit.php?post_type=download&page=edd-payment-history&edd-message=payment_deleted' ) );
+	}
+}
+add_action( 'edd_delete_payment', 'edd_trigger_purchase_delete' );

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -239,29 +239,6 @@ function edd_update_payment_details( $data = array() ) {
 add_action( 'edd_update_payment_details', 'edd_update_payment_details' );
 
 /**
- * Trigger a Purchase Deletion
- *
- * @since 1.3.4
- * @param array $data Arguments passed
- * @return void
- */
-function edd_trigger_purchase_delete( $data ) {
-	if ( wp_verify_nonce( $data['_wpnonce'], 'edd_payment_nonce' ) ) {
-
-		$payment_id = absint( $data['purchase_id'] );
-
-		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
-			wp_die( __( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
-		}
-
-		edd_delete_purchase( $payment_id );
-
-		edd_redirect( admin_url( '/edit.php?post_type=download&page=edd-payment-history&edd-message=payment_deleted' ) );
-	}
-}
-add_action( 'edd_delete_payment', 'edd_trigger_purchase_delete' );
-
-/**
  * New in 3.0, permanently destroys an order, and all its data, and related data.
  *
  * @since 3.0
@@ -275,7 +252,7 @@ function edd_trigger_destroy_order( $data ) {
 		$payment_id = absint( $data['purchase_id'] );
 
 		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
-			wp_die( esc_html_e( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), esc_html_e( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+			wp_die( esc_html_e( 'You do not have permission to edit this order', 'easy-digital-downloads' ), esc_html_e( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 		}
 
 		edd_destroy_order( $payment_id );

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -252,7 +252,7 @@ function edd_trigger_destroy_order( $data ) {
 		$payment_id = absint( $data['purchase_id'] );
 
 		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
-			wp_die( esc_html_e( 'You do not have permission to edit this order', 'easy-digital-downloads' ), esc_html_e( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+			wp_die( esc_html__( 'You do not have permission to edit this order.', 'easy-digital-downloads' ), esc_html__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 		}
 
 		edd_destroy_order( $payment_id );

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -262,24 +262,34 @@ function edd_trigger_purchase_delete( $data ) {
 add_action( 'edd_delete_payment', 'edd_trigger_purchase_delete' );
 
 /**
- * New in 3.0, destroys an order, and all it's data, and related data.
+ * New in 3.0, permanently destroys an order, and all its data, and related data.
  *
  * @since 3.0
  *
- * @param $data
+ * @param array $data Arguments passed.
  */
 function edd_trigger_destroy_order( $data ) {
+
 	if ( wp_verify_nonce( $data['_wpnonce'], 'edd_payment_nonce' ) ) {
 
 		$payment_id = absint( $data['purchase_id'] );
 
 		if ( ! current_user_can( 'delete_shop_payments', $payment_id ) ) {
-			wp_die( __( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+			wp_die( esc_html_e( 'You do not have permission to edit this payment record', 'easy-digital-downloads' ), esc_html_e( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 		}
 
 		edd_destroy_order( $payment_id );
 
-		edd_redirect( admin_url( '/edit.php?post_type=download&page=edd-payment-history&edd-message=payment_deleted' ) );
+		$redirect_link = add_query_arg(
+			array(
+				'post_type'   => 'download',
+				'page'        => 'edd-payment-history',
+				'edd-message' => 'payment_deleted',
+				'status'      => 'trash',
+			),
+			admin_url( 'edit.php' ),
+		);
+		edd_redirect( $redirect_link );
 	}
 }
 add_action( 'edd_delete_order', 'edd_trigger_destroy_order' );

--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -282,12 +282,11 @@ function edd_trigger_destroy_order( $data ) {
 
 		$redirect_link = add_query_arg(
 			array(
-				'post_type'   => 'download',
 				'page'        => 'edd-payment-history',
 				'edd-message' => 'payment_deleted',
 				'status'      => 'trash',
 			),
-			admin_url( 'edit.php' ),
+			edd_get_admin_base_url(),
 		);
 		edd_redirect( $redirect_link );
 	}


### PR DESCRIPTION
Fixes #8374 

Proposed Changes:
1. Redirect to trashed orders after permanently deleting order
2. Escaping for function
3. Update doc block typo and param

I'm not quite sure the difference between this function and the one right above it, `edd_trigger_purchase_delete`.  I would love to clarify in the descriptions, once it is explained.



