### PR TITLE
Introduce new hooks for front-end templates #7759

### DIFF
--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -1132,3 +1132,59 @@ function edd_record_sale_in_log( $download_id, $payment_id, $price_id = false, $
 function edd_agree_to_terms_js() {
 	_edd_deprecated_function( __FUNCTION__, '3.0' );
 }
+
+add_action( 'edd_before_order_history', function( $orders ) {
+	if ( ! has_action( 'edd_before_purchase_history' ) ) {
+		return;
+	}
+
+	$payments  = array();
+
+	if ( ! empty( $orders ) ) {
+		$order_ids = wp_list_pluck( $orders, 'id' );
+		$payments  = edd_get_payments( array(
+			'id__in'  => $order_ids,
+			'orderby' => 'date',
+		) );
+	}
+
+	do_action( 'edd_before_purchase_history', $payments );
+} );
+
+add_action( 'edd_order_history_row_start', function( \EDD\Orders\Order $order ) {
+	if ( ! has_action( 'edd_purchase_history_row_start' ) ) {
+		return;
+	}
+
+	$payment = edd_get_payment( $order->id );
+
+	do_action( 'edd_purchase_history_row_start', $payment->ID, $payment->payment_meta );
+} );
+
+add_action( 'edd_order_history_row_end', function( \EDD\Orders\Order $order ) {
+	if ( ! has_action( 'edd_purchase_history_row_end' ) ) {
+		return;
+	}
+
+	$payment = edd_get_payment( $order->id );
+
+	do_action( 'edd_purchase_history_row_end', $payment->ID, $payment->payment_meta );
+} );
+
+add_action( 'edd_after_order_history', function( $orders ) {
+	if ( ! has_action( 'edd_after_purchase_history' ) ) {
+		return;
+	}
+
+	$payments  = array();
+
+	if ( ! empty( $orders ) ) {
+		$order_ids = wp_list_pluck( $orders, 'id' );
+		$payments  = edd_get_payments( array(
+				'id__in'  => $order_ids,
+				'orderby' => 'date',
+		) );
+	}
+
+	do_action( 'edd_after_purchase_history', $payments );
+} );

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -44,10 +44,6 @@ if ( $orders ) :
 			</tr>
 		</thead>
 		<?php foreach ( $orders as $order ) :
-			$downloads      = edd_get_payment_meta_cart_details( $order->id, true );
-			$purchase_data  = edd_get_payment_meta( $order->id );
-			$email          = edd_get_payment_user_email( $order->id );
-
 			foreach ( $order->get_items() as $key => $item ) :
 
 				// Skip over Bundles. Products included with a bundle will be displayed individually
@@ -81,7 +77,7 @@ if ( $orders ) :
 
 									foreach ( $download_files as $filekey => $file ) :
 
-										$download_url = edd_get_download_file_url( $purchase_data['key'], $email, $filekey, $item->product_id, $price_id );
+										$download_url = edd_get_download_file_url( $order->payment_key, $order->email, $filekey, $item->product_id, $price_id );
 										?>
 
 										<div class="edd_download_file">
@@ -90,7 +86,11 @@ if ( $orders ) :
 											</a>
 										</div>
 
-										<?php do_action( 'edd_download_history_files', $filekey, $file, $item->product_id, $order->id, $purchase_data );
+										<?php
+										if ( has_action( 'edd_download_history_files' ) ) {
+											$purchase_data  = edd_get_payment_meta( $order->id );
+											do_action( 'edd_download_history_files', $filekey, $file, $item->product_id, $order->id, $purchase_data );
+										}
 									endforeach;
 
 								else :

--- a/templates/history-purchases.php
+++ b/templates/history-purchases.php
@@ -18,9 +18,17 @@ endif;
  * This template is used to display the purchase history of the current user.
  */
 if ( is_user_logged_in() ):
-	$payments = edd_get_users_purchases( get_current_user_id(), 20, true, 'any' );
-	if ( $payments ) :
-		do_action( 'edd_before_purchase_history', $payments ); ?>
+	$page = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 0;
+	$orders = edd_get_orders( array(
+		'user_id' => get_current_user_id(),
+		'number'  => 20,
+		'offset'  => get_query_var( 'paged' ) ? 20 * ( intval( get_query_var( 'paged' ) ) - 1 ) : 0
+	) );
+
+	if ( $orders ) :
+		// do_action( 'edd_before_purchase_history', $payments );
+		do_action( 'edd_before_order_history', $orders );
+		?>
 		<table id="edd_user_history" class="edd-table">
 			<thead>
 				<tr class="edd_purchase_row">
@@ -32,26 +40,36 @@ if ( is_user_logged_in() ):
 					<?php do_action('edd_purchase_history_header_after'); ?>
 				</tr>
 			</thead>
-			<?php foreach ( $payments as $payment ) : ?>
-				<?php $payment = new EDD_Payment( $payment->ID ); ?>
+			<?php foreach ( $orders as $order ) : ?>
 				<tr class="edd_purchase_row">
-					<?php do_action( 'edd_purchase_history_row_start', $payment->ID, $payment->payment_meta ); ?>
-					<td class="edd_purchase_id">#<?php echo $payment->number ?></td>
-					<td class="edd_purchase_date"><?php echo edd_date_i18n( $payment->date ); ?></td>
+					<?php
+					do_action( 'edd_order_history_row_start', $order );
+					//do_action( 'edd_purchase_history_row_start', $payment->ID, $payment->payment_meta );
+					?>
+					<td class="edd_purchase_id">#<?php echo $order->order_number ? esc_html( $order->order_number ) : esc_html( $order->id ); ?></td>
+					<td class="edd_purchase_date"><?php echo edd_date_i18n( $order->date_created ); ?></td>
 					<td class="edd_purchase_amount">
-						<span class="edd_purchase_amount"><?php echo edd_currency_filter( edd_format_amount( $payment->total ) ); ?></span>
+						<span class="edd_purchase_amount"><?php echo edd_currency_filter( edd_format_amount( $order->total ) ); ?></span>
 					</td>
 					<td class="edd_purchase_details">
-						<?php if( ! in_array( $payment->status, array( 'complete', 'partially_refunded' ) ) ) : ?>
-							<span class="edd_purchase_status <?php echo $payment->status; ?>"><?php echo $payment->status_nicename; ?></span>
-							<?php if ( $payment->is_recoverable() ) : ?>
-								&mdash; <a href="<?php echo $payment->get_recovery_url(); ?>"><?php _e( 'Complete Purchase', 'easy-digital-downloads' ); ?></a>
+						<?php if( ! in_array( $order->status, array( 'complete', 'partially_refunded' ) ) ) : ?>
+							<span class="edd_purchase_status <?php echo esc_attr( $order->status ); ?>"><?php echo esc_html( edd_get_status_label( $order->status ) ); ?></span>
+							<?php
+							// @todo order recovery
+							/*
+							<?php if ( $order->is_recoverable() ) : ?>
+								&mdash; <a href="<?php echo $order->get_recovery_url(); ?>"><?php _e( 'Complete Purchase', 'easy-digital-downloads' ); ?></a>
 							<?php endif; ?>
+							 */
+							?>
 						<?php else: ?>
-							<a href="<?php echo esc_url( add_query_arg( 'payment_key', $payment->key, edd_get_success_page_uri() ) ); ?>"><?php _e( 'View Details and Downloads', 'easy-digital-downloads' ); ?></a>
+							<a href="<?php echo esc_url( add_query_arg( 'payment_key', urlencode( $order->payment_key ), edd_get_success_page_uri() ) ); ?>"><?php _e( 'View Details and Downloads', 'easy-digital-downloads' ); ?></a>
 						<?php endif; ?>
 					</td>
-					<?php do_action( 'edd_purchase_history_row_end', $payment->ID, $payment->payment_meta ); ?>
+					<?php
+					//do_action( 'edd_purchase_history_row_end', $order->id, $payment->payment_meta );
+					do_action( 'edd_order_history_row_end', $order );
+					?>
 				</tr>
 			<?php endforeach; ?>
 		</table>
@@ -59,12 +77,14 @@ if ( is_user_logged_in() ):
 			echo edd_pagination(
 				array(
 					'type'  => 'purchase_history',
-					'total' => ceil( edd_count_purchases_of_customer() / 20 ) // 20 items per page
+					'total' => ceil( edd_count_orders( array( 'user_id' => get_current_user_id() ) ) / 20 ) // 20 items per page
 				)
 			);
 		?>
-		<?php do_action( 'edd_after_purchase_history', $payments ); ?>
-		<?php wp_reset_postdata(); ?>
+		<?php
+		//do_action( 'edd_after_purchase_history', $payments );
+		do_action( 'edd_after_order_history', $orders );
+		?>
 	<?php else : ?>
 		<p class="edd-no-purchases"><?php _e('You have not made any purchases','easy-digital-downloads' ); ?></p>
 	<?php endif;


### PR DESCRIPTION
Fixes #7759

Proposed Changes:
1. `history-downloads.php` : 
    - Replace old `edd_get_payment_x` functions with data directly from the order.
    - Wrap `edd_download_history_files` action in `has_action()` so it only runs if someone has hooked in. (Due to the necessity for passing through payment meta.) Might still rework this.
2. `history-purchases.php` : 
    - Replace all payment queries with order queries.
    - Replace all `edd_x_purchase_history` hooks with new `edd_x_order_history` hooks.
    - In `deprecated-functions.php` (might move this stuff), hook into the new actions to trigger the old ones, only if they've been hooked into.

The goal is that all the old hooks still 100% work, but only get executed if they're actually in use. That way, someone with a fresh EDD install and no extensions will only use new code and reduce the queries on the page from 600+ to more like 50.

I'm keeping this as a draft for now because I don't 100% know how I feel about it. Was just playing around with an idea and want to get the code pushed up.