### PR TITLE
Fix order fee backwards compatibility to avoid duplication #8412

### DIFF
--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -421,12 +421,7 @@ class Order extends Rows\Order {
 			/** @var Order_Adjustment $adjustment */
 
 			if ( 'fee' === $adjustment->type ) {
-				$id = is_null( $adjustment->type_key ) ? $adjustment->id : $adjustment->type_key;
-				if ( array_key_exists( $id, $fees ) ) {
-					$id .= '_2';
-				}
-
-				$fees[ $id ] = $adjustment;
+				$fees[] = $adjustment;
 			}
 		}
 
@@ -442,12 +437,7 @@ class Order extends Rows\Order {
 			foreach ( $item->get_fees() as $fee ) {
 				/** @var Order_Adjustment $fee */
 
-				$id = is_null( $fee->type_key ) ? $fee->id : $fee->type_key;
-				if ( array_key_exists( $id, $fees ) ) {
-					$id .= '_2';
-				}
-
-				$fees[ $id ] = $fee;
+				$fees[] = $fee;
 			}
 		}
 

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -318,7 +318,7 @@ function edd_add_manual_order( $args = array() ) {
 						}
 
 						$type_key = ! empty( $order_item_adjustment['description'] )
-							? sanitize_text_field( sanitize_title( $order_item_adjustment['description'] ) )
+							? sanitize_text_field( strtolower( sanitize_title( $order_item_adjustment['description'] ) ) )
 							: $index;
 
 						edd_add_order_adjustment( array(
@@ -352,7 +352,7 @@ function edd_add_manual_order( $args = array() ) {
 			}
 
 			$type_key = ! empty( $adjustment['description'] )
-				? sanitize_text_field( sanitize_title( $adjustment['description'] ) )
+				? sanitize_text_field( strtolower( sanitize_title( $adjustment['description'] ) ) )
 				: $index;
 
 			edd_add_order_adjustment( array(

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -310,17 +310,22 @@ function edd_add_manual_order( $args = array() ) {
 				if ( isset( $download['adjustments'] ) ) {
 					$order_item_adjustments = array_reverse( $download['adjustments'] );
 
-					foreach ( $order_item_adjustments as $order_item_adjustment ) {
+					foreach ( $order_item_adjustments as $index => $order_item_adjustment ) {
 
 						// Discounts are not tracked at the Order Item level.
 						if ( 'discount' === $order_item_adjustment['type'] ) {
 							continue;
 						}
 
+						$type_key = ! empty( $order_item_adjustment['description'] )
+							? sanitize_text_field( sanitize_title( $order_item_adjustment['description'] ) )
+							: $index;
+
 						edd_add_order_adjustment( array(
 							'object_id'   => $order_item_id,
 							'object_type' => 'order_item',
 							'type'        => sanitize_text_field( $order_item_adjustment['type'] ),
+							'type_key'    => $type_key,
 							'description' => sanitize_text_field( $order_item_adjustment['description'] ),
 							'subtotal'    => floatval( $order_item_adjustment['subtotal'] ),
 							'total'       => floatval( $order_item_adjustment['total'] ),
@@ -341,15 +346,20 @@ function edd_add_manual_order( $args = array() ) {
 	if ( isset( $data['adjustments'] ) ) {
 		$adjustments = array_reverse( $data['adjustments'] );
 
-		foreach ( $adjustments as $adjustment ) {
+		foreach ( $adjustments as $index => $adjustment ) {
 			if ( 'order_item' === $adjustment['object_type'] ) {
 				continue;
 			}
+
+			$type_key = ! empty( $adjustment['description'] )
+				? sanitize_text_field( sanitize_title( $adjustment['description'] ) )
+				: $index;
 
 			edd_add_order_adjustment( array(
 				'object_id'   => $order_id,
 				'object_type' => 'order',
 				'type'        => sanitize_text_field( $adjustment['type'] ),
+				'type_key'    => $type_key,
 				'description' => sanitize_text_field( $adjustment['description'] ),
 				'subtotal'    => floatval( $adjustment['subtotal'] ),
 				'total'       => floatval( $adjustment['total'] ),

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -70,8 +70,8 @@ function edd_complete_purchase( $order_id, $new_status, $old_status ) {
 					foreach ( $item->get_fees() as $key => $item_fee ) {
 						/** @var EDD\Orders\Order_Adjustment $item_fee */
 
-						$download_id = edd_get_order_adjustment_meta( $item_fee->id, 'download_id', true );
-						$price_id    = edd_get_order_adjustment_meta( $item_fee->id, 'price_id', true );
+						$download_id = $item->product_id;
+						$price_id    = $item->price_id;
 						$no_tax      = (bool) 0.00 === $item_fee->tax;
 						$id          = is_null( $item_fee->type_key ) ? $item_fee->id : $item_fee->type_key;
 						if ( array_key_exists( $id, $item_fees ) ) {

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2311,17 +2311,13 @@ class EDD_Payment {
 				if ( isset( $meta_value['fees'] ) && ! empty( $meta_value['fees'] ) ) {
 					foreach ( $meta_value['fees'] as $fee_id => $fee ) {
 						if ( ! empty( $fee['download_id'] ) && 0 < $fee['download_id'] ) {
-							$query_args = array(
+							$order_item_id = edd_get_order_items( array(
 								'number'     => 1,
 								'order_id'   => $this->ID,
 								'product_id' => $fee['download_id'],
+								'price_id'   => isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ? intval( $fee['price_id'] ) : 0,
 								'fields'     => 'ids',
-							);
-
-							if ( isset( $fee['price_id'] ) && ! is_null( $fee['price_id'] ) ) {
-								$query_args['price_id'] = intval( $fee['price_id'] );
-							}
-							$order_item_id = edd_get_order_items( $query_args);
+							) );
 
 							if ( is_array( $order_item_id ) ) {
 								$order_item_id = (int) $order_item_id[0];


### PR DESCRIPTION
Fixes #8412 

Proposed Changes:
1. `Order::get_fees()` no longer sets the array key. It's not actually needed in new 3.0 code, so I've removed this and we'll only implement this in 2.9 backwards compat layers (`EDD_Payment`).
2. Removes all usage of `download_id` and `price_id` order adjustment meta. These are only set when the adjustment type is `order_item`, and in that case they can be retrieved from the order item itself.
3. `EDD_Payment::setup_fees()` no longer loops over order items. This is where some duplication was coming from, because `Order::get_fees()` already includes the order item fees in the array.
4. `EDD_Payment::setup_fees()` - if we end up modifying the `type_key`, then actually update it in the DB to reflect that. Basically, in my reproduction steps, my `type_key` was getting modified in the setup. But then, when re-saving that meta, it was no longer coming up in this query: https://github.com/easydigitaldownloads/easy-digital-downloads/blob/release/3.0/includes/payments/class-edd-payment.php#L2366-L2373 (because in the DB the key was `null`, but in the array we passed back to the customer it was like `87_2` or something. So that query had no results, which means it fell into this `else` block to add a new fee: https://github.com/easydigitaldownloads/easy-digital-downloads/blob/release/3.0/includes/payments/class-edd-payment.php#L2386
This also has me rethinking the fact that `type_key` is null for all new fees in 3.0. I'm thinking we should just set it anyway. :thinking: 
5. (update) Set `type_key` value for adjustments in manually created orders.