### PR TITLE
Use esc_url_raw() to prevent ampersands from being converted #8425

### DIFF
--- a/includes/admin/upgrades/upgrades.php
+++ b/includes/admin/upgrades/upgrades.php
@@ -92,7 +92,7 @@ function edd_upgrades_screen() {
 			</div>
 			<script type="text/javascript">
 				setTimeout( function() {
-					document.location.href = '<?php echo esc_url( $redirect ); ?>';
+					document.location.href = '<?php echo esc_url_raw( $redirect ); ?>';
 				}, 250 );
 			</script>
 
@@ -124,7 +124,7 @@ function edd_upgrades_screen() {
 						jQuery( '#edd-upgrade-loader' ).hide();
 
 						setTimeout( function() {
-							document.location.href = '<?php echo esc_url( $redirect ); ?>';
+							document.location.href = '<?php echo esc_url_raw( $redirect ); ?>';
 						}, 250 );
 					});
 				});


### PR DESCRIPTION
Fixes #8425 

Proposed Changes:
1. Use `esc_url_raw()` instead of `esc_url()`. The main difference is that `esc_url_raw()` does not encode ampersands or single quotes.