### PR TITLE
Update edd_get_payments backwards compatibilty

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -199,7 +199,7 @@ class EDD_Payments_Query extends EDD_Stats {
 			return intval( $this->items );
 		}
 
-		if ( $should_output_order_objects ) {
+		if ( $should_output_order_objects || ! empty( $this->args['fields'] ) ) {
 			return $this->items;
 		}
 
@@ -221,10 +221,6 @@ class EDD_Payments_Query extends EDD_Stats {
 			}
 
 			return $posts;
-		}
-
-		if ( $should_output_order_objects || ! empty( $this->args['fields'] ) ) {
-			return $this->items;
 		}
 
 		foreach ( $this->items as $order ) {

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -573,7 +573,9 @@ class EDD_Payments_Query extends EDD_Stats {
 		}
 
 		// Meta key and value
-		if ( isset( $this->initial_args['meta_key'] ) ) {
+		if ( isset( $this->initial_args['meta_query'] ) ) {
+			$arguments['meta_query'] = $this->initial_args['meta_query'];
+		} elseif ( isset( $this->initial_args['meta_key'] ) ) {
 			$meta_query = array(
 				'key' => $this->initial_args['meta_key']
 			);

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -223,7 +223,7 @@ class EDD_Payments_Query extends EDD_Stats {
 			return $posts;
 		}
 
-		if ( $should_output_order_objects ) {
+		if ( $should_output_order_objects || ! empty( $this->args['fields'] ) ) {
 			return $this->items;
 		}
 
@@ -850,6 +850,11 @@ class EDD_Payments_Query extends EDD_Stats {
 
 		if ( isset( $this->args['date_refundable_query'] ) ) {
 			$arguments['date_refundable_query'] = $this->args['date_refundable_query'];
+		}
+
+		// Make sure `fields` is honored if set (eg. 'ids').
+		if ( ! empty( $this->args['fields'] ) ) {
+			$arguments['fields'] = $this->args['fields'];
 		}
 
 		$this->args = $arguments;


### PR DESCRIPTION
Fixes #8430

Proposed Changes:
1. Update `remap_args` to inherit the `meta_query` if set.
2. Update `remap_args` and returned array to honor the `fields` parameter if set.

To test:
Either follow the steps in the related issue, or test with [this Simple Shipping PR](https://github.com/easydigitaldownloads/edd-simple-shipping/pull/101).