### PR TITLE
Update block editor content for pages added on initial activation

### DIFF
--- a/includes/install.php
+++ b/includes/install.php
@@ -299,6 +299,9 @@ function edd_install_pages() {
 	// We'll only update settings on change
 	$changed  = false;
 
+	// Check if the block editor exists as that changes the content to add.
+	$block_editor = function_exists( 'register_block_type' );
+
 	// Loop through all pages, fix or create any missing ones
 	foreach ( array_flip( $pages ) as $page ) {
 
@@ -326,54 +329,71 @@ function edd_install_pages() {
 		switch ( $page ) {
 
 			// Checkout
-			case 'purchase_page' :
+			case 'purchase_page':
+				$content = '[download_checkout]';
+				if ( $block_editor ) {
+					$content = "<!-- wp:shortcode -->\n{$content}\n<!-- /wp:shortcode -->";
+				}
 				$page_attributes = array(
 					'post_title'     => __( 'Checkout', 'easy-digital-downloads' ),
-					'post_content'   => '[download_checkout]',
+					'post_content'   => $content,
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_parent'    => 0,
 					'post_type'      => 'page',
-					'comment_status' => 'closed'
+					'comment_status' => 'closed',
 				);
 				break;
 
 			// Success
-			case 'success_page' :
+			case 'success_page':
+				$text    = __( 'Thank you for your purchase!', 'easy-digital-downloads' );
+				$content = $text . '[edd_receipt]';
+				if ( $block_editor ) {
+					$content = "<!-- wp:paragraph -->\n<p>{$text}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:shortcode -->\n[edd_receipt]\n<!-- /wp:shortcode -->";
+				}
 				$page_attributes = array(
 					'post_title'     => __( 'Purchase Confirmation', 'easy-digital-downloads' ),
-					'post_content'   => __( 'Thank you for your purchase! [edd_receipt]', 'easy-digital-downloads' ),
+					'post_content'   => $content,
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_parent'    => $checkout,
 					'post_type'      => 'page',
-					'comment_status' => 'closed'
+					'comment_status' => 'closed',
 				);
 				break;
 
 			// Failure
-			case 'failure_page' :
+			case 'failure_page':
+				$content = __( 'Your transaction failed, please try again or contact site support.', 'easy-digital-downloads' );
+				if ( $block_editor ) {
+					$content = "<!-- wp:paragraph -->\n<p>{$content}</p>\n<!-- /wp:paragraph -->";
+				}
 				$page_attributes = array(
 					'post_title'     => __( 'Transaction Failed', 'easy-digital-downloads' ),
-					'post_content'   => __( 'Your transaction failed, please try again or contact site support.', 'easy-digital-downloads' ),
+					'post_content'   => $content,
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_type'      => 'page',
 					'post_parent'    => $checkout,
-					'comment_status' => 'closed'
+					'comment_status' => 'closed',
 				);
 				break;
 
 			// Purchase History
-			case 'purchase_history_page' :
+			case 'purchase_history_page':
+				$content = '[purchase_history]';
+				if ( $block_editor ) {
+					$content = "<!-- wp:shortcode -->\n{$content}\n<!-- /wp:shortcode -->";
+				}
 				$page_attributes = array(
 					'post_title'     => __( 'Purchase History', 'easy-digital-downloads' ),
-					'post_content'   => '[purchase_history]',
+					'post_content'   => $content,
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_type'      => 'page',
 					'post_parent'    => $checkout,
-					'comment_status' => 'closed'
+					'comment_status' => 'closed',
 				);
 				break;
 		}

--- a/includes/install.php
+++ b/includes/install.php
@@ -329,7 +329,7 @@ function edd_install_pages() {
 			case 'purchase_page':
 				$page_attributes = array(
 					'post_title'     => __( 'Checkout', 'easy-digital-downloads' ),
-					'post_content'   => "<!-- wp:shortcode -->\n[download_checkout]\n<!-- /wp:shortcode -->",
+					'post_content'   => "<!-- wp:shortcode -->[download_checkout]<!-- /wp:shortcode -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_parent'    => 0,
@@ -343,7 +343,7 @@ function edd_install_pages() {
 				$text            = __( 'Thank you for your purchase!', 'easy-digital-downloads' );
 				$page_attributes = array(
 					'post_title'     => __( 'Purchase Confirmation', 'easy-digital-downloads' ),
-					'post_content'   => "<!-- wp:paragraph -->\n<p>{$text}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:shortcode -->\n[edd_receipt]\n<!-- /wp:shortcode -->",
+					'post_content'   => "<!-- wp:paragraph --><p>{$text}</p><!-- /wp:paragraph --><!-- wp:shortcode -->[edd_receipt]<!-- /wp:shortcode -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_parent'    => $checkout,
@@ -357,7 +357,7 @@ function edd_install_pages() {
 				$text            = __( 'Your transaction failed, please try again or contact site support.', 'easy-digital-downloads' );
 				$page_attributes = array(
 					'post_title'     => __( 'Transaction Failed', 'easy-digital-downloads' ),
-					'post_content'   => "<!-- wp:paragraph -->\n<p>{$text}</p>\n<!-- /wp:paragraph -->",
+					'post_content'   => "<!-- wp:paragraph --><p>{$text}</p><!-- /wp:paragraph -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_type'      => 'page',
@@ -370,7 +370,7 @@ function edd_install_pages() {
 			case 'purchase_history_page':
 				$page_attributes = array(
 					'post_title'     => __( 'Purchase History', 'easy-digital-downloads' ),
-					'post_content'   => "<!-- wp:shortcode -->\n[purchase_history]\n<!-- /wp:shortcode -->",
+					'post_content'   => "<!-- wp:shortcode -->[purchase_history]<!-- /wp:shortcode -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_type'      => 'page',

--- a/includes/install.php
+++ b/includes/install.php
@@ -299,9 +299,6 @@ function edd_install_pages() {
 	// We'll only update settings on change
 	$changed  = false;
 
-	// Check if the block editor exists as that changes the content to add.
-	$block_editor = function_exists( 'register_block_type' );
-
 	// Loop through all pages, fix or create any missing ones
 	foreach ( array_flip( $pages ) as $page ) {
 
@@ -330,13 +327,9 @@ function edd_install_pages() {
 
 			// Checkout
 			case 'purchase_page':
-				$content = '[download_checkout]';
-				if ( $block_editor ) {
-					$content = "<!-- wp:shortcode -->\n{$content}\n<!-- /wp:shortcode -->";
-				}
 				$page_attributes = array(
 					'post_title'     => __( 'Checkout', 'easy-digital-downloads' ),
-					'post_content'   => $content,
+					'post_content'   => "<!-- wp:shortcode -->\n[download_checkout]\n<!-- /wp:shortcode -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_parent'    => 0,
@@ -347,14 +340,10 @@ function edd_install_pages() {
 
 			// Success
 			case 'success_page':
-				$text    = __( 'Thank you for your purchase!', 'easy-digital-downloads' );
-				$content = $text . '[edd_receipt]';
-				if ( $block_editor ) {
-					$content = "<!-- wp:paragraph -->\n<p>{$text}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:shortcode -->\n[edd_receipt]\n<!-- /wp:shortcode -->";
-				}
+				$text            = __( 'Thank you for your purchase!', 'easy-digital-downloads' );
 				$page_attributes = array(
 					'post_title'     => __( 'Purchase Confirmation', 'easy-digital-downloads' ),
-					'post_content'   => $content,
+					'post_content'   => "<!-- wp:paragraph -->\n<p>{$text}</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:shortcode -->\n[edd_receipt]\n<!-- /wp:shortcode -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_parent'    => $checkout,
@@ -365,13 +354,10 @@ function edd_install_pages() {
 
 			// Failure
 			case 'failure_page':
-				$content = __( 'Your transaction failed, please try again or contact site support.', 'easy-digital-downloads' );
-				if ( $block_editor ) {
-					$content = "<!-- wp:paragraph -->\n<p>{$content}</p>\n<!-- /wp:paragraph -->";
-				}
+				$text            = __( 'Your transaction failed, please try again or contact site support.', 'easy-digital-downloads' );
 				$page_attributes = array(
 					'post_title'     => __( 'Transaction Failed', 'easy-digital-downloads' ),
-					'post_content'   => $content,
+					'post_content'   => "<!-- wp:paragraph -->\n<p>{$text}</p>\n<!-- /wp:paragraph -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_type'      => 'page',
@@ -382,13 +368,9 @@ function edd_install_pages() {
 
 			// Purchase History
 			case 'purchase_history_page':
-				$content = '[purchase_history]';
-				if ( $block_editor ) {
-					$content = "<!-- wp:shortcode -->\n{$content}\n<!-- /wp:shortcode -->";
-				}
 				$page_attributes = array(
 					'post_title'     => __( 'Purchase History', 'easy-digital-downloads' ),
-					'post_content'   => $content,
+					'post_content'   => "<!-- wp:shortcode -->\n[purchase_history]\n<!-- /wp:shortcode -->",
 					'post_status'    => 'publish',
 					'post_author'    => 1,
 					'post_type'      => 'page',


### PR DESCRIPTION
Fixes #8423

Proposed Changes:
1. If the block editor exists, updates the content for pages added on activation to use blocks.

To test:
Do a fresh install of EDD with this branch on a site running WP 5.0 or higher. The pages automatically created by EDD should use paragraph and shortcode blocks rather than the classic editor block.