### PR TITLE
Return after registration if Amazon gateway is not active

### DIFF
--- a/includes/gateways/amazon-payments.php
+++ b/includes/gateways/amazon-payments.php
@@ -41,6 +41,11 @@ final class EDD_Amazon_Payments {
 
 		// Run this separate so we can ditch as early as possible
 		$this->register();
+
+		if ( ! edd_is_gateway_active( $this->gateway_id ) ) {
+			return;
+		}
+
 		$this->config();
 		$this->includes();
 		$this->setup_client();


### PR DESCRIPTION
Fixes #8440

Proposed Changes:
Adds the `edd_is_gateway_active` check back after registering the gateway so that the rest of the code doesn't run if Amazon Payments isn't active.