### PR TITLE
Update minimum WordPress version to 4.9

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -470,19 +470,15 @@ final class EDD_Requirements_Check {
 		// Set filter for plugin's languages directory.
 		$edd_lang_dir = dirname( $this->base ) . '/languages/';
 		$edd_lang_dir = apply_filters( 'edd_languages_directory', $edd_lang_dir );
-		$get_locale   = function_exists( 'get_user_locale' )
-			? get_user_locale()
-			: get_locale();
 
 		unload_textdomain( 'easy-digital-downloads' );
 
 		/**
 		 * Defines the plugin language locale used in Easy Digital Downloads.
 		 *
-		 * @var $get_locale The locale to use. Uses get_user_locale()` in WordPress 4.7 or greater,
-		 *                  otherwise uses `get_locale()`.
+		 * @var $get_locale The locale to use.
 		 */
-		$locale = apply_filters( 'plugin_locale', $get_locale, 'easy-digital-downloads' );
+		$locale = apply_filters( 'plugin_locale', 'get_user_locale', 'easy-digital-downloads' );
 		$mofile = sprintf( '%1$s-%2$s.mo', 'easy-digital-downloads', $locale );
 
 		// Look for wp-content/languages/edd/easy-digital-downloads-{lang}_{country}.mo

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -74,7 +74,7 @@ final class EDD_Requirements_Check {
 
 		// WordPress
 		'wp' => array(
-			'minimum' => '4.7.0',
+			'minimum' => '4.9.0',
 			'name'    => 'WordPress',
 			'exists'  => true,
 			'current' => false,

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -478,7 +478,7 @@ final class EDD_Requirements_Check {
 		 *
 		 * @var $get_locale The locale to use.
 		 */
-		$locale = apply_filters( 'plugin_locale', 'get_user_locale', 'easy-digital-downloads' );
+		$locale = apply_filters( 'plugin_locale', get_user_locale(), 'easy-digital-downloads' );
 		$mofile = sprintf( '%1$s-%2$s.mo', 'easy-digital-downloads', $locale );
 
 		// Look for wp-content/languages/edd/easy-digital-downloads-{lang}_{country}.mo

--- a/includes/cart/template.php
+++ b/includes/cart/template.php
@@ -144,7 +144,7 @@ function edd_checkout_cart_columns() {
 
 	if ( ! empty( $wp_filter['edd_checkout_table_header_first'] ) ) {
 		$header_first_count = 0;
-		$callbacks = version_compare( $wp_version, '4.7', '>=' ) ? $wp_filter['edd_checkout_table_header_first']->callbacks : $wp_filter['edd_checkout_table_header_first'] ;
+		$callbacks          = $wp_filter['edd_checkout_table_header_first']->callbacks;
 
 		foreach ( $callbacks as $callback ) {
 			$header_first_count += count( $callback );
@@ -154,7 +154,7 @@ function edd_checkout_cart_columns() {
 
 	if ( ! empty( $wp_filter['edd_checkout_table_header_last'] ) ) {
 		$header_last_count = 0;
-		$callbacks = version_compare( $wp_version, '4.7', '>=' ) ? $wp_filter['edd_checkout_table_header_last']->callbacks : $wp_filter['edd_checkout_table_header_last'] ;
+		$callbacks         = $wp_filter['edd_checkout_table_header_first']->callbacks;
 
 		foreach ( $callbacks as $callback ) {
 			$header_last_count += count( $callback );

--- a/includes/class-edd-cache-helper.php
+++ b/includes/class-edd-cache-helper.php
@@ -76,19 +76,17 @@ class EDD_Cache_Helper {
 			}
 		}
 
-		if ( function_exists( 'wp_suspend_cache_addition' ) ) {
-			add_action( 'edd_pre_update_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-			add_action( 'edd_pre_insert_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-			add_action( 'edd_pre_delete_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-			add_action( 'edd_pre_update_discount_status',  array( $this, 'w3tc_suspend_cache_addition_pre' ) );
-			add_action( 'edd_pre_remove_cart_discount',    array( $this, 'w3tc_suspend_cache_addition_pre' ) );
+		add_action( 'edd_pre_update_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
+		add_action( 'edd_pre_insert_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
+		add_action( 'edd_pre_delete_discount',         array( $this, 'w3tc_suspend_cache_addition_pre' ) );
+		add_action( 'edd_pre_update_discount_status',  array( $this, 'w3tc_suspend_cache_addition_pre' ) );
+		add_action( 'edd_pre_remove_cart_discount',    array( $this, 'w3tc_suspend_cache_addition_pre' ) );
 
-			add_action( 'edd_post_update_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
-			add_action( 'edd_post_insert_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
-			add_action( 'edd_post_delete_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
-			add_action( 'edd_post_update_discount_status', array( $this, 'w3tc_suspend_cache_addition_post' ) );
-			add_action( 'edd_post_remove_cart_discount',   array( $this, 'w3tc_suspend_cache_addition_post' ) );
-		}
+		add_action( 'edd_post_update_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
+		add_action( 'edd_post_insert_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
+		add_action( 'edd_post_delete_discount',        array( $this, 'w3tc_suspend_cache_addition_post' ) );
+		add_action( 'edd_post_update_discount_status', array( $this, 'w3tc_suspend_cache_addition_post' ) );
+		add_action( 'edd_post_remove_cart_discount',   array( $this, 'w3tc_suspend_cache_addition_post' ) );
 	}
 
 	/**

--- a/includes/class-edd-register-meta.php
+++ b/includes/class-edd-register-meta.php
@@ -76,11 +76,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		// Pre-WordPress 4.6 compatibility
-		if ( ! has_filter( 'sanitize_post_meta__edd_download_earnings' ) ) {
-			add_filter( 'sanitize_post_meta__edd_download_earnings', 'edd_sanitize_amount', 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_download_sales',
@@ -91,10 +86,6 @@ class EDD_Register_Meta {
 				'description'       => __( 'The number of sales for the specified product.', 'easy-digital-downloads' ),
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_download_sales' ) ) {
-			add_filter( 'sanitize_post_meta__edd_download_sales', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
 
 		register_meta(
 			'post',
@@ -107,10 +98,6 @@ class EDD_Register_Meta {
 				'show_in_rest'      => true,
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta_edd_price' ) ) {
-			add_filter( 'sanitize_post_meta_edd_price', array( $this, 'sanitize_price' ), 10, 4 );
-		}
 
 		/**
 		 * Even though this is an array, we're using 'object' as the type here. Since the variable pricing can be either
@@ -149,10 +136,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta_edd_variable_prices' ) ) {
-			add_filter( 'sanitize_post_meta_edd_variable_prices', array( $this, 'sanitize_variable_prices' ), 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'edd_download_files',
@@ -163,10 +146,6 @@ class EDD_Register_Meta {
 				'description'       => __( 'The files associated with the product, available for download.', 'easy-digital-downloads' ),
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta_edd_download_files' ) ) {
-			add_filter( 'sanitize_post_meta_edd_download_files', array( $this, 'sanitize_files' ), 10, 4 );
-		}
 
 		register_meta(
 			'post',
@@ -188,10 +167,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_bundled_products' ) ) {
-			add_filter( 'sanitize_post_meta__edd_bundled_products', array( $this, 'sanitize_array' ), 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_button_behavior',
@@ -204,10 +179,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_button_behavior' ) ) {
-			add_filter( 'sanitize_post_meta__edd_button_behavior', 'sanitize_text_field', 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_default_price_id',
@@ -219,11 +190,6 @@ class EDD_Register_Meta {
 				'show_in_rest'      => true,
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_default_price_id' ) ) {
-			add_filter( 'sanitize_post_meta__edd_default_price_id', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
-
 	}
 
 	/**
@@ -245,11 +211,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		// Pre-WordPress 4.6 compatibility
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_user_email' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_user_email', 'sanitize_email', 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_payment_customer_id',
@@ -260,10 +221,6 @@ class EDD_Register_Meta {
 				'description'       => __( 'The Customer ID associated with the payment.', 'easy-digital-downloads' ),
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_customer_id' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_customer_id', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
 
 		register_meta(
 			'post',
@@ -276,10 +233,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_user_id' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_user_id', array( $this, 'intval_wrapper' ), 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_payment_user_ip',
@@ -289,10 +242,6 @@ class EDD_Register_Meta {
 				'description'       => __( 'The IP address the payment was made from.', 'easy-digital-downloads' ),
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_user_ip' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_user_ip', 'sanitize_text_field', 10, 4 );
-		}
 
 		register_meta(
 			'post',
@@ -304,10 +253,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_purchase_key' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_purchase_key', 'sanitize_text_field', 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_payment_total',
@@ -317,10 +262,6 @@ class EDD_Register_Meta {
 				'description'       => __( 'The purchase total for this payment.', 'easy-digital-downloads' ),
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_total' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_total', 'edd_sanitize_amount', 10, 4 );
-		}
 
 		register_meta(
 			'post',
@@ -332,10 +273,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_mode' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_mode', 'sanitize_text_field', 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_payment_gateway',
@@ -345,10 +282,6 @@ class EDD_Register_Meta {
 				'description'       => __( 'The registered gateway that was used to process this payment.', 'easy-digital-downloads' ),
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_gateway' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_gateway', 'sanitize_text_field', 10, 4 );
-		}
 
 		register_meta(
 			'post',
@@ -360,10 +293,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_meta' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_meta', array( $this, 'sanitize_array' ), 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_payment_tax',
@@ -374,10 +303,6 @@ class EDD_Register_Meta {
 			)
 		);
 
-		if ( ! has_filter( 'sanitize_post_meta__edd_payment_tax' ) ) {
-			add_filter( 'sanitize_post_meta__edd_payment_tax', 'edd_sanitize_amount', 10, 4 );
-		}
-
 		register_meta(
 			'post',
 			'_edd_completed_date',
@@ -387,12 +312,6 @@ class EDD_Register_Meta {
 				'description'       => __( 'The date this payment was changed to the `completed` status.', 'easy-digital-downloads' ),
 			)
 		);
-
-		if ( ! has_filter( 'sanitize_post_meta__edd_completed_date' ) ) {
-			add_filter( 'sanitize_post_meta__edd_completed_date', 'sanitize_text_field', 10, 4 );
-		}
-
-
 	}
 
 	/**

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1264,12 +1264,8 @@ function edd_doing_cron() {
  */
 function edd_doing_ajax() {
 
-	// Bail if not doing WordPress AJAX (>4.8.0)
-	if ( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() ) {
-		return true;
-
-	// Bail if not doing WordPress AJAX (<4.8.0)
-	} elseif ( defined( 'DOING_AJAX' ) && ( true === DOING_AJAX ) ) {
+	// Bail if doing WordPress AJAX.
+	if ( wp_doing_ajax() ) {
 		return true;
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1285,12 +1285,8 @@ function edd_doing_ajax() {
  */
 function edd_doing_autosave() {
 
-	// Bail if not doing WordPress autosave
-	if ( function_exists( 'wp_doing_autosave' ) && wp_doing_autosave() ) {
-		return true;
-
-	// Bail if not doing WordPress autosave
-	} elseif ( defined( 'DOING_AUTOSAVE' ) && ( true === DOING_AUTOSAVE ) ) {
+	// Bail if doing WordPress autosave.
+	if ( defined( 'DOING_AUTOSAVE' ) && ( true === DOING_AUTOSAVE ) ) {
 		return true;
 	}
 

--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1243,12 +1243,8 @@ function edd_payment_get_ip_address_url( $order_id ) {
  */
 function edd_doing_cron() {
 
-	// Bail if not doing WordPress cron (>4.8.0)
-	if ( function_exists( 'wp_doing_cron' ) && wp_doing_cron() ) {
-		return true;
-
-	// Bail if not doing WordPress cron (<4.8.0)
-	} elseif ( defined( 'DOING_CRON' ) && ( true === DOING_CRON ) ) {
+	// Bail if doing WordPress cron.
+	if ( wp_doing_cron() ) {
 		return true;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Plugin URI: https://easydigitaldownloads.com
 Contributors: easydigitaldownloads, mordauk, sunnyratilal, chriscct7, section214, sumobi, sdavis2702, cklosows, mindctrl, sksmatt, SpencerFinnell, johnstonphilip, brashrebel, drewapicture, johnjamesjacoby, nosegraze, littlerchicken, lisacee
 Donate link: https://easydigitaldownloads.com/donate/
 Tags: ecommerce, sell, checkout, payments, stripe
-Requires at least: 4.6
+Requires at least: 4.9
 Tested up to: 5.5.1
 Requires PHP: 5.6
 Stable Tag: 3.0

--- a/templates/shortcode-content-image.php
+++ b/templates/shortcode-content-image.php
@@ -1,4 +1,4 @@
-<?php if ( function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( get_the_ID() ) ) : ?>
+<?php if ( has_post_thumbnail( get_the_ID() ) ) : ?>
 	<div class="edd_download_image">
 		<a href="<?php the_permalink(); ?>">
 			<?php echo get_the_post_thumbnail( get_the_ID(), 'thumbnail' ); ?>

--- a/tests/helpers/shims.php
+++ b/tests/helpers/shims.php
@@ -5,21 +5,3 @@
  *
  * We'll need to periodly make sure these shims are in parity with the core functions.
  */
-
-
-if ( ! function_exists( 'is_post_type_viewable' ) ) {
-	/**
-	 * Determines whether a post type is considered "viewable".
-	 *
-	 * For built-in post types such as posts and pages, the 'public' value will be evaluated.
-	 * For all others, the 'publicly_queryable' value will be used.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @param object $post_type_object Post type object.
-	 * @return bool Whether the post type should be considered viewable.
-	 */
-	function is_post_type_viewable( $post_type_object ) {
-		return $post_type_object->publicly_queryable || ( $post_type_object->_builtin && $post_type_object->public );
-	}
-}

--- a/tests/tests-register-meta.php
+++ b/tests/tests-register-meta.php
@@ -24,43 +24,6 @@ class Tests_Register_Meta extends EDD_UnitTestCase {
 		EDD_Helper_Download::delete_download( $this->download_id );
 	}
 
-	public function test_download_meta() {
-		global $wp_filter;
-
-		// Uses standalone function callbacks
-		$this->assertarrayHasKey( 'edd_sanitize_amount', $wp_filter['sanitize_post_meta__edd_download_earnings'][10] );
-		$this->assertarrayHasKey( 'sanitize_text_field', $wp_filter['sanitize_post_meta__edd_button_behavior'][10] );
-
-		// Callbacks are part of the object, so just make sure it got registered
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta__edd_default_price_id'][10] );
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta__edd_download_sales'][10] );
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta_edd_variable_prices'][10] );
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta_edd_download_files'][10] );
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta__edd_bundled_products'][10] );
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta_edd_price'][10] );
-
-	}
-
-	public function test_purchase_meta() {
-		global $wp_filter;
-
-		// Uses standalone function callbacks
-		$this->assertarrayHasKey( 'sanitize_email',      $wp_filter['sanitize_post_meta__edd_payment_user_email'][10] );
-		$this->assertarrayHasKey( 'sanitize_text_field', $wp_filter['sanitize_post_meta__edd_payment_user_ip'][10] );
-		$this->assertarrayHasKey( 'sanitize_text_field', $wp_filter['sanitize_post_meta__edd_payment_purchase_key'][10] );
-		$this->assertarrayHasKey( 'edd_sanitize_amount', $wp_filter['sanitize_post_meta__edd_payment_total'][10] );
-		$this->assertarrayHasKey( 'sanitize_text_field', $wp_filter['sanitize_post_meta__edd_payment_mode'][10] );
-		$this->assertarrayHasKey( 'sanitize_text_field', $wp_filter['sanitize_post_meta__edd_payment_gateway'][10] );
-		$this->assertarrayHasKey( 'edd_sanitize_amount', $wp_filter['sanitize_post_meta__edd_payment_tax'][10] );
-		$this->assertarrayHasKey( 'sanitize_text_field', $wp_filter['sanitize_post_meta__edd_completed_date'][10] );
-
-		// Callbacks are part of the object, so just make sure it got registered
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta__edd_payment_customer_id'][10] );
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta__edd_payment_user_id'][10] );
-		$this->assertNotEmpty( $wp_filter['sanitize_post_meta__edd_payment_meta'][10] );
-
-	}
-
 	public function test_intval_wrapper() {
 		$this->setExpectedIncorrectUsage( 'add_post_meta()/update_post_meta()' );
 


### PR DESCRIPTION
Fixes #8443

Proposed Changes:
1. Update minimum required WordPress version in readme.txt.
2. Update minimum version in internal requirements check.
3. Remove check for `get_user_locale` (WP 4.7)
4. Remove check for `wp_doing_cron` (WP 4.8)
5. Remove check for `wp_doing_ajax` (WP 4.8)
6. Remove check for `wp_doing_autosave` (doesn't exist)
7. Remove WP version checks for `$wp_filter` callbacks (WP 4.7)
8. Remove `sanitize_post_meta` compatibility filters and related tests (WP 4.6)
9. Remove `wp_suspend_cache_addition` check (WP 3.3)
10. Remove `is_post_type_viewable` shim (WP 4.4)
11. Remove `has_post_thumbnail` check (WP 2.9)

There is a check for `wp_add_privacy_policy_content` which I've left in as it was added in WP 4.9.6, not 4.9.0. It looks like `is_countable` and `is_iterable` are shims for PHP functions which were also added in 4.9.6, so I've left them in as well.

