### PR TITLE
Version bump for 2.10.1

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -5,7 +5,7 @@
  * Description: The easiest way to sell digital products with WordPress.
  * Author: Sandhills Development, LLC
  * Author URI: https://sandhillsdev.com
- * Version: 2.10
+ * Version: 2.10.1
  * Text Domain: easy-digital-downloads
  * Domain Path: languages
  *
@@ -25,7 +25,7 @@
  * @package EDD
  * @category Core
  * @author Pippin Williamson
- * @version 2.10
+ * @version 2.10.1
  */
 
 // Exit if accessed directly.
@@ -206,7 +206,7 @@ final class Easy_Digital_Downloads {
 
 		// Plugin version.
 		if ( ! defined( 'EDD_VERSION' ) ) {
-			define( 'EDD_VERSION', '2.10' );
+			define( 'EDD_VERSION', '2.10.1' );
 		}
 
 		// Plugin Folder Path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-digital-downloads",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "private": true,
   "devDependencies": {
     "grunt": "^1.0.4",

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: ecommerce, sell, checkout, payments, stripe
 Requires at least: 4.4
 Tested up to: 5.7
 Requires PHP: 5.3
-Stable Tag: 2.10
+Stable Tag: 2.10.1
 License: GNU Version 2 or Any Later Version
 
 Sell your digital products the simple way. Easily build an online store complete with a cart system, checkout forms, reports, coupons, and more!
@@ -247,6 +247,9 @@ Yes, through the use of our commercial addon called [Recurring Payments](https:/
 11. Google Pay checkout
 
 == Changelog ==
+= 2.10.1, March 9, 2021 =
+* Fix: Removed incorrect inclusiong of license key field for the Stripe integration when the Stripe Pro Payment Gateway extension is not active.
+
 = 2.10, March 9, 2021 =
 * New: Accept credit cards, Apple Pay, Google Pay, and Microsoft Pay with the included Stripe Standard payment gateway. Read more about this feature here: https://easydigitaldownloads.com/edd-stripe-integration
 * New: Updated bundled add-on updater class to the latest version (1.8.0).

--- a/readme.txt
+++ b/readme.txt
@@ -248,7 +248,7 @@ Yes, through the use of our commercial addon called [Recurring Payments](https:/
 
 == Changelog ==
 = 2.10.1, March 9, 2021 =
-* Fix: Removed incorrect inclusiong of license key field for the Stripe integration when the Stripe Pro Payment Gateway extension is not active.
+* Fix: Removed incorrect inclusion of license key field for the Stripe integration when the Stripe Pro Payment Gateway extension is not active.
 
 = 2.10, March 9, 2021 =
 * New: Accept credit cards, Apple Pay, Google Pay, and Microsoft Pay with the included Stripe Standard payment gateway. Read more about this feature here: https://easydigitaldownloads.com/edd-stripe-integration


### PR DESCRIPTION
This PR is a version bump, but is intended to be run along side the build/testing of pulling from Stripe 2.8.4

Please run the `npm run build` in order to test the following:
1. When Running EDD Core only, no Stripe payment gateway license field shows.
2. Possible conflict with the number of plugins needing updates could be showing when unnecessary.
