### PR TITLE
#8480 3.0 Manual order status change notes

### DIFF
--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -1132,3 +1132,28 @@ function edd_record_sale_in_log( $download_id, $payment_id, $price_id = false, $
 function edd_agree_to_terms_js() {
 	_edd_deprecated_function( __FUNCTION__, '3.0' );
 }
+
+/**
+ * Record payment status change
+ *
+ * @since 1.4.3
+ * @deprecated since 3.0
+ * @param int    $payment_id the ID number of the payment.
+ * @param string $new_status the status of the payment, probably "publish".
+ * @param string $old_status the status of the payment prior to being marked as "complete", probably "pending".
+ * @return void
+ */
+function edd_record_status_change( $payment_id, $new_status, $old_status ) {
+	$backtrace = debug_backtrace();
+
+	_edd_deprecated_function( __FUNCTION__, '3.0', 'edd_record_order_status_change', $backtrace );
+
+	// Get the list of statuses so that status in the payment note can be translated
+	$stati      = edd_get_payment_statuses();
+	$old_status = isset( $stati[ $old_status ] ) ? $stati[ $old_status ] : $old_status;
+	$new_status = isset( $stati[ $new_status ] ) ? $stati[ $new_status ] : $new_status;
+
+	$status_change = sprintf( __( 'Status changed from %s to %s', 'easy-digital-downloads' ), $old_status, $new_status );
+
+	edd_insert_payment_note( $payment_id, $status_change );
+}

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -253,26 +253,31 @@ function edd_process_after_payment_actions( $payment_id = 0, $force = false ) {
 add_action( 'edd_after_payment_scheduled_actions', 'edd_process_after_payment_actions', 10, 1 );
 
 /**
- * Record payment status change
+ * Record order status change
  *
- * @since 1.4.3
- * @param int $payment_id the ID number of the payment
- * @param string $new_status the status of the payment, probably "publish"
- * @param string $old_status the status of the payment prior to being marked as "complete", probably "pending"
+ * @since 3.0
+ * @param string $old_status the status of the order prior to being marked as "complete", probably "pending".
+ * @param string $new_status the status of the order, probably "publish".
+ * @param int    $order_id the ID number of the order.
  * @return void
  */
-function edd_record_status_change( $payment_id, $new_status, $old_status ) {
+function edd_record_order_status_change( $old_status, $new_status, $order_id ) {
 
-	// Get the list of statuses so that status in the payment note can be translated
+	// Get the list of statuses so that status in the payment note can be translated.
 	$stati      = edd_get_payment_statuses();
 	$old_status = isset( $stati[ $old_status ] ) ? $stati[ $old_status ] : $old_status;
 	$new_status = isset( $stati[ $new_status ] ) ? $stati[ $new_status ] : $new_status;
 
-	$status_change = sprintf( __( 'Status changed from %s to %s', 'easy-digital-downloads' ), $old_status, $new_status );
+	$status_change = sprintf(
+		/* translators: %1$s Old order status. %2$s New order status. */
+		__( 'Status changed from %1$s to %2$s', 'easy-digital-downloads' ),
+		$old_status,
+		$new_status
+	);
 
-	edd_insert_payment_note( $payment_id, $status_change );
+	edd_insert_payment_note( $order_id, $status_change );
 }
-add_action( 'edd_update_payment_status', 'edd_record_status_change', 100, 3 );
+add_action( 'edd_transition_order_status', 'edd_record_order_status_change', 100, 3 );
 
 /**
  * Flushes the current user's purchase history transient when a payment status

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -256,8 +256,8 @@ add_action( 'edd_after_payment_scheduled_actions', 'edd_process_after_payment_ac
  * Record order status change
  *
  * @since 3.0
- * @param string $old_status the status of the order prior to being marked as "complete", probably "pending".
- * @param string $new_status the status of the order, probably "publish".
+ * @param string $old_status the status of the order prior to this change.
+ * @param string $new_status The new order status.
  * @param int    $order_id the ID number of the order.
  * @return void
  */

--- a/tests/tests-filters.php
+++ b/tests/tests-filters.php
@@ -259,7 +259,7 @@ class Tests_Filters extends EDD_UnitTestCase {
 	public function test_edd_update_payment_status() {
 		global $wp_filter;
 		$this->assertArrayHasKey( 'edd_complete_purchase', $wp_filter['edd_update_payment_status'][100] );
-		$this->assertArrayHasKey( 'edd_record_status_change', $wp_filter['edd_update_payment_status'][100] );
+		$this->assertArrayHasKey( 'edd_record_order_status_change', $wp_filter['edd_update_payment_status'][100] );
 		$this->assertArrayHasKey( 'edd_clear_user_history_cache', $wp_filter['edd_update_payment_status'][10] );
 	}
 

--- a/tests/tests-filters.php
+++ b/tests/tests-filters.php
@@ -259,7 +259,7 @@ class Tests_Filters extends EDD_UnitTestCase {
 	public function test_edd_update_payment_status() {
 		global $wp_filter;
 		$this->assertArrayHasKey( 'edd_complete_purchase', $wp_filter['edd_update_payment_status'][100] );
-		$this->assertArrayHasKey( 'edd_record_order_status_change', $wp_filter['edd_update_payment_status'][100] );
+		$this->assertArrayHasKey( 'edd_record_order_status_change', $wp_filter['edd_transition_order_status'][100] );
 		$this->assertArrayHasKey( 'edd_clear_user_history_cache', $wp_filter['edd_update_payment_status'][10] );
 	}
 


### PR DESCRIPTION
Fixes #8480 

Proposed Changes:
1. Deprecate `edd_record_status_change()` and replace with `edd_record_order_status_change()` 
2. Hook new function into `edd_transition_order_status`
3. Update test with new function name