### PR TITLE
Remove trailing comma from function arguments #8486

### DIFF
--- a/includes/admin/payments/actions.php
+++ b/includes/admin/payments/actions.php
@@ -263,7 +263,7 @@ function edd_trigger_destroy_order( $data ) {
 				'edd-message' => 'payment_deleted',
 				'status'      => 'trash',
 			),
-			edd_get_admin_base_url(),
+			edd_get_admin_base_url()
 		);
 		edd_redirect( $redirect_link );
 	}


### PR DESCRIPTION
Fixes #8486

Proposed Changes:
1. Remove trailing comma from function arguments.