### PR TITLE
Fix purchase receipt email preview/test

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -569,6 +569,15 @@ class EDD_Notices {
 						'id'      => 'edd-sendwp-connected',
 						'message' => __( 'SendWP has been successfully connected!', 'easy-digital-downloads' )
 					) );
+
+				case 'test-purchase-email-sent':
+					$this->add_notice(
+						array(
+							'id'      => 'edd-test-purchase-receipt-sent',
+							'message' => __( 'The test email was sent successfully.', 'easy-digital-downloads' )
+						)
+					);
+					break;
 			}
 		}
 

--- a/includes/emails/actions.php
+++ b/includes/emails/actions.php
@@ -94,7 +94,15 @@ function edd_send_test_email( $data ) {
 	// Send a test email
 	edd_email_test_purchase_receipt();
 
-	// Remove the test email query arg
-	edd_redirect( remove_query_arg( 'edd_action' ) );
+	$url = add_query_arg(
+		array(
+			'page'        => 'edd-settings',
+			'tab'         => 'emails',
+			'section'     => 'purchase_receipts',
+			'edd-message' => 'test-purchase-email-sent',
+		),
+		edd_get_admin_base_url()
+	);
+	edd_redirect( $url );
 }
 add_action( 'edd_send_test_email', 'edd_send_test_email' );

--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -89,11 +89,11 @@ function edd_email_test_purchase_receipt() {
 	$subject     = wp_specialchars_decode( edd_do_email_tags( $subject, 0 ) );
 
 	$heading     = edd_get_option( 'purchase_heading', __( 'Purchase Receipt', 'easy-digital-downloads' ) );
-	$heading     = apply_filters( 'edd_purchase_heading', $heading, 0, array() );
+	$heading     = edd_email_preview_template_tags( apply_filters( 'edd_purchase_heading', $heading, 0, array() ) );
 
 	$attachments = apply_filters( 'edd_receipt_attachments', array(), 0, array() );
 
-	$message     = edd_do_email_tags( edd_get_email_body_content( 0, array() ), 0 );
+	$message     = edd_email_preview_template_tags( edd_get_email_body_content( 0, array() ), 0 );
 
 	$emails = EDD()->emails;
 	$emails->__set( 'from_name' , $from_name );

--- a/includes/emails/tags.php
+++ b/includes/emails/tags.php
@@ -284,6 +284,10 @@ function edd_email_tag_download_list( $payment_id ) {
 	$payment = new EDD_Payment( $payment_id );
 	$order   = edd_get_order( $payment_id );
 
+	if ( ! $order ) {
+		return '';
+	}
+
 	$payment_data  = $payment->get_meta();
 	$download_list = '<ul>';
 	$cart_items    = $payment->cart_details;


### PR DESCRIPTION
Fixes #8415

Proposed Changes:
1. If there isn't an order retrieved for the email tag, return an empty string.
2. Apply the `edd_email_preview_template_tags` to the test purchase receipt.
3. Add a success message when a test purchase receipt has been sent.