### PR TITLE
Add 'Product Categories' report filter & add filter on all filters #8470

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -318,34 +318,38 @@ function get_filters() {
 	}
 
 	$filters = array(
-		'dates'     => array(
-			'label'            => __( 'Date', 'easy-digital-downloads' ),
-			'display_callback' => __NAMESPACE__ . '\\display_dates_filter'
-		),
-		'products'  => array(
-			'label'            => __( 'Products', 'easy-digital-downloads' ),
-			'display_callback' => __NAMESPACE__ . '\\display_products_filter'
-		),
-		'taxes'     => array(
-			'label'            => __( 'Exclude Taxes', 'easy-digital-downloads' ),
-			'display_callback' => __NAMESPACE__ . '\\display_taxes_filter'
-		),
-		'gateways'  => array(
-			'label'            => __( 'Gateways', 'easy-digital-downloads' ),
-			'display_callback' => __NAMESPACE__ . '\\display_gateways_filter'
-		),
-		'discounts' => array(
-			'label'            => __( 'Discounts', 'easy-digital-downloads' ),
-			'display_callback' => __NAMESPACE__ . '\\display_discounts_filter'
-		),
-		'regions'   => array(
-			'label'            => __( 'Regions', 'easy-digital-downloads' ),
-			'display_callback' => __NAMESPACE__ . '\\display_region_filter'
-		),
-		'countries' => array(
-			'label'            => __( 'Countries', 'easy-digital-downloads' ),
-			'display_callback' => __NAMESPACE__ . '\\display_country_filter'
-		)
+			'dates'              => array(
+					'label'            => __( 'Date', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_dates_filter'
+			),
+			'products'           => array(
+					'label'            => __( 'Products', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_products_filter'
+			),
+			'product_categories' => array(
+					'label'            => __( 'Product Categories', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_product_categories_filter'
+			),
+			'taxes'              => array(
+					'label'            => __( 'Exclude Taxes', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_taxes_filter'
+			),
+			'gateways'           => array(
+					'label'            => __( 'Gateways', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_gateways_filter'
+			),
+			'discounts'          => array(
+					'label'            => __( 'Discounts', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_discounts_filter'
+			),
+			'regions'            => array(
+					'label'            => __( 'Regions', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_region_filter'
+			),
+			'countries'          => array(
+					'label'            => __( 'Countries', 'easy-digital-downloads' ),
+					'display_callback' => __NAMESPACE__ . '\\display_country_filter'
+			)
 	);
 
 	/**
@@ -1034,6 +1038,19 @@ function display_products_filter() {
 	<span class="edd-graph-filter-options graph-option-section"><?php
 		echo $select;
 	?></span><?php
+}
+
+/**
+ * Handles display of the 'Products Dropdown' filter for reports.
+ *
+ * @since 3.0
+ */
+function display_product_categories_filter() {
+	?>
+	<span class="edd-graph-filter-optiosn graph-option-selection">
+		<?php echo EDD()->html->category_dropdown( 'edd_categories', get_filter_value( 'product_categories' ) ); ?>
+	</span>
+	<?php
 }
 
 /**

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -318,38 +318,38 @@ function get_filters() {
 	}
 
 	$filters = array(
-			'dates'              => array(
-					'label'            => __( 'Date', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_dates_filter'
-			),
-			'products'           => array(
-					'label'            => __( 'Products', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_products_filter'
-			),
-			'product_categories' => array(
-					'label'            => __( 'Product Categories', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_product_categories_filter'
-			),
-			'taxes'              => array(
-					'label'            => __( 'Exclude Taxes', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_taxes_filter'
-			),
-			'gateways'           => array(
-					'label'            => __( 'Gateways', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_gateways_filter'
-			),
-			'discounts'          => array(
-					'label'            => __( 'Discounts', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_discounts_filter'
-			),
-			'regions'            => array(
-					'label'            => __( 'Regions', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_region_filter'
-			),
-			'countries'          => array(
-					'label'            => __( 'Countries', 'easy-digital-downloads' ),
-					'display_callback' => __NAMESPACE__ . '\\display_country_filter'
-			)
+		'dates'              => array(
+			'label'            => __( 'Date', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_dates_filter'
+		),
+		'products'           => array(
+			'label'            => __( 'Products', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_products_filter'
+		),
+		'product_categories' => array(
+			'label'            => __( 'Product Categories', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_product_categories_filter'
+		),
+		'taxes'              => array(
+			'label'            => __( 'Exclude Taxes', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_taxes_filter'
+		),
+		'gateways'           => array(
+			'label'            => __( 'Gateways', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_gateways_filter'
+		),
+		'discounts'          => array(
+			'label'            => __( 'Discounts', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_discounts_filter'
+		),
+		'regions'            => array(
+			'label'            => __( 'Regions', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_region_filter'
+		),
+		'countries'          => array(
+			'label'            => __( 'Countries', 'easy-digital-downloads' ),
+			'display_callback' => __NAMESPACE__ . '\\display_country_filter'
+		)
 	);
 
 	/**

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -311,12 +311,6 @@ function parse_endpoint_views( $views ) {
  * @return array List of supported endpoint filters.
  */
 function get_filters() {
-	static $filters = null;
-
-	if ( is_array( $filters ) ) {
-		return $filters;
-	}
-
 	$filters = array(
 		'dates'              => array(
 			'label'            => __( 'Date', 'easy-digital-downloads' ),

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1048,7 +1048,7 @@ function display_products_filter() {
 function display_product_categories_filter() {
 	?>
 	<span class="edd-graph-filter-optiosn graph-option-selection">
-		<?php echo EDD()->html->category_dropdown( 'edd_categories', get_filter_value( 'product_categories' ) ); ?>
+		<?php echo EDD()->html->category_dropdown( 'product_categories', get_filter_value( 'product_categories' ) ); ?>
 	</span>
 	<?php
 }

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -1041,7 +1041,7 @@ function display_products_filter() {
  */
 function display_product_categories_filter() {
 	?>
-	<span class="edd-graph-filter-optiosn graph-option-selection">
+	<span class="edd-graph-filter-options graph-option-selection">
 		<?php echo EDD()->html->category_dropdown( 'product_categories', get_filter_value( 'product_categories' ) ); ?>
 	</span>
 	<?php

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -348,7 +348,14 @@ function get_filters() {
 		)
 	);
 
-	return $filters;
+	/**
+	 * Filters the list of available report filters.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array[] $filters
+	 */
+	return apply_filters( 'edd_report_filters', $filters );
 }
 
 /**

--- a/tests/reports/tests-reports-functions.php
+++ b/tests/reports/tests-reports-functions.php
@@ -280,7 +280,7 @@ class Reports_Functions_Tests extends \EDD_UnitTestCase {
 	 * @covers \EDD\Reports\get_filters()
 	 */
 	public function test_get_filters_should_return_records_for_all_official_filters() {
-		$expected = array( 'dates', 'products', 'taxes', 'gateways', 'discounts', 'regions', 'countries' );
+		$expected = array( 'dates', 'products', 'product_categories', 'taxes', 'gateways', 'discounts', 'regions', 'countries' );
 
 		$this->assertEqualSets( $expected, array_keys( get_filters() ) );
 	}


### PR DESCRIPTION
Fixes #8470 

Proposed Changes:
1. Add `edd_report_filters` filter so add-ons can add their own filters.
2. Add 'Product Categories' filter.

Use these add-ons to test:

1. `edd_report_filters` - https://github.com/easydigitaldownloads/edd-campaign-tracker/pull/9
2. Product Categories - https://github.com/easydigitaldownloads/edd-cross-sell-upsell/pull/39