### PR TITLE
Move Stripe to the frist payment gateway in the Available Gateway Settings when it is found #8499

### DIFF
--- a/includes/gateways/functions.php
+++ b/includes/gateways/functions.php
@@ -32,7 +32,18 @@ function edd_get_payment_gateways() {
 		),
 	);
 
-	return apply_filters( 'edd_payment_gateways', $gateways );
+	$gateways = apply_filters( 'edd_payment_gateways', $gateways );
+
+	// Since Stripe is added via a filter still, move to the top.
+	if ( array_key_exists( 'stripe', $gateways ) ) {
+		$stripe_attributes = $gateways['stripe'];
+		unset( $gateways['stripe'] );
+
+		$gateways = array_merge( array( 'stripe' => $stripe_attributes ), $gateways );
+	}
+
+	return $gateways;
+
 }
 
 /**


### PR DESCRIPTION
Resolves #8499 

Proposed Changes:
1. Moves the return value out of a direct return and into a variable for registered gateways.
2. Searches for the `stripe` gateway key and then moves it to the top of the list instead of in the order of registration.