### PR TITLE
Add ilnks to Termageddon on privacy policy and terms of agreement settings #8506

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -886,7 +886,15 @@ function edd_get_registered_settings() {
 					'show_agree_to_terms' => array(
 						'id'   => 'show_agree_to_terms',
 						'name' => __( 'Agree to Terms', 'easy-digital-downloads' ),
-						'desc' => __( 'Check this to show an agree to terms on checkout that users must agree to before purchasing.', 'easy-digital-downloads' ),
+						'desc' =>
+								__( 'Check this to show an agree to terms on checkout that users must agree to before purchasing.', 'easy-digital-downloads' ) .
+								'<p>' .
+								sprintf(
+										__( 'Need help creating a Terms of Agreement? We recommend using %sTermageddon%s.', 'easy-digital-downloads' ),
+										'<a href="https://termageddon.com/i/easy-digital-downloads-edd-termageddon-promotion/" target="_blank" rel="noopener noreferrer">',
+										'</a>'
+								) .
+								'</p>',
 						'type' => 'checkbox',
 					),
 					'agree_label' => array(
@@ -924,7 +932,9 @@ function edd_get_registered_settings() {
 					'show_privacy_policy_on_checkout' => array(
 						'id'   => 'show_privacy_policy_on_checkout',
 						'name' => __( 'Show the Privacy Policy on checkout', 'easy-digital-downloads' ),
-						'desc' => __( 'Display your Privacy Policy on checkout.', 'easy-digital-downloads' ) . ' <a href="' . esc_attr( admin_url( 'privacy.php' ) ) . '">' . __( 'Set your Privacy Policy here', 'easy-digital-downloads' ) .'</a>.',
+						'desc' =>
+								__( 'Display your Privacy Policy on checkout.', 'easy-digital-downloads' ) . ' <a href="' . esc_attr( admin_url( 'privacy.php' ) ) . '">' . __( 'Set your Privacy Policy here', 'easy-digital-downloads' ) .'</a>.' .
+								'<p>' . sprintf( __( 'Need help creating a Privacy Policy? We recommend %sTermageddon%s.', 'easy-digital-downloads' ), '<a href="https://termageddon.com/i/easy-digital-downloads-edd-termageddon-promotion/" target="_blank" rel="noopener noreferrer">', '</a>' ) . '</p>',
 						'type' => 'checkbox',
 					),
 				),


### PR DESCRIPTION
Fixes #8506 

Proposed Changes:
1. Adds link to Termageddon on Privacy Policy Settings
![Screenshot_2021-03-22 Easy Digital Downloads Settings ‹  DEV  EDD — WordPress(9)](https://user-images.githubusercontent.com/1390124/112066246-3c7eef00-8b23-11eb-8bbe-84fb6cd9cead.png)


2. Adds link to Termageddon on Terms of Agreement Settings
![Screenshot_2021-03-22 Easy Digital Downloads Settings ‹  DEV  EDD — WordPress(8)](https://user-images.githubusercontent.com/1390124/112066265-430d6680-8b23-11eb-944e-37a811ad7786.png)
