### PR TITLE
Fix status label fallbacks

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1516,6 +1516,10 @@ function edd_negate_int( $value = 0 ) {
  */
 function edd_get_status_label( $status = '' ) {
 
+	// Set a default.
+	$status_label = str_replace( '_', ' ', $status );
+	$status_label = ucwords( $status_label );
+
 	// If this is a payment label, fetch from `edd_get_payment_status_label()`.
 	if ( array_key_exists( $status, edd_get_payment_statuses() ) ) {
 		$status_label = edd_get_payment_status_label( $status );
@@ -1536,9 +1540,9 @@ function edd_get_status_label( $status = '' ) {
 		);
 
 		// Return the label if set, or uppercase the first letter if not
-		$status_label = isset( $labels[ $status ] )
-				? $labels[ $status ]
-				: ucwords( $status );
+		if ( isset( $labels[ $status ] ) ) {
+			$status_label = $labels[ $status ];
+		}
 	}
 
 	/**

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -576,7 +576,8 @@ function edd_get_payment_status( $order, $return_label = false ) {
  * @return bool|mixed
  */
 function edd_get_payment_status_label( $status = '' ) {
-	$default  = ucwords( $status );
+	$default  = str_replace( '_', ' ', $status );
+	$default  = ucwords( $default );
 	$statuses = edd_get_payment_statuses();
 
 	if ( ! is_array( $statuses ) || empty( $statuses ) ) {

--- a/includes/payments/functions.php
+++ b/includes/payments/functions.php
@@ -561,7 +561,7 @@ function edd_get_payment_status( $order, $return_label = false ) {
 	} else {
 		$keys      = edd_get_payment_status_keys();
 		$found_key = array_search( strtolower( $status ), $keys );
-		$status    = array_key_exists( $found_key, $keys ) ? $keys[ $found_key ] : false;
+		$status    = $found_key && array_key_exists( $found_key, $keys ) ? $keys[ $found_key ] : false;
 	}
 
 	return ! empty( $status ) ? $status : false;


### PR DESCRIPTION
Fixes #8526

Proposed Changes:
1. Make sure that `$found_key` has a value before using it in `edd_get_payment_status`.
2. Update the default/fallback label strings in `edd_get_payment_status_label` and `edd_get_status_label` to remove underscores before capitalizing the words.