### PR TITLE
Add stripe revision during build #8528

### DIFF
--- a/bin/update-stripe.sh
+++ b/bin/update-stripe.sh
@@ -9,6 +9,8 @@ cd includes/gateways/stripe
 composer install --no-dev
 npm install && npm run build
 
+git rev-parse HEAD > ../.stripe-hash
+
 # Clean up files for distribution.
 # @todo Maybe use git archive? However composer.json would
 # need to be removed from .gitattributes export-ignore

--- a/includes/gateways/.stripe-hash
+++ b/includes/gateways/.stripe-hash
@@ -1,0 +1,1 @@
+cd6de33386fda825daebff77f5ca601eb476be20


### PR DESCRIPTION
Fixes #8528

Proposed Changes:
1. When updating Stripe, write the hash of the HEAD of the Stripe repo at the time of bundling.