### PR TITLE
Add exception handling to date parsing #8496

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -130,9 +130,14 @@ class Data_Migrator {
 
 			if ( ! empty( $notes ) ) {
 				foreach ( $notes as $note ) {
-					$date = isset( $note[0] )
-						? EDD()->utils->date( $note[0], edd_get_timezone_id() )->setTimezone( 'UTC' )->toDateTimeString()
-						: '';
+					try {
+						$date = isset( $note[0] )
+							? EDD()->utils->date( $note[0], edd_get_timezone_id() )->setTimezone( 'UTC' )->toDateTimeString()
+							: '';
+					} catch ( \Exception $e ) {
+						// An empty date will be changed to current time in BerlinDB.
+						$date = '';
+					}
 
 					$note_content = isset( $note[1] )
 						? $note[1]
@@ -513,7 +518,11 @@ class Data_Migrator {
 		if ( ! in_array( $order_status, $non_completed_statuses ) ) {
 
 			if ( ! empty( $date_completed ) ) {  // Update the data_completed to the UTC.
-				$date_completed = EDD()->utils->date( $date_completed, edd_get_timezone_id() )->setTimezone( 'UTC' )->toDateTimeString();
+				try {
+					$date_completed = EDD()->utils->date( $date_completed, edd_get_timezone_id() )->setTimezone( 'UTC' )->toDateTimeString();
+				} catch ( \Exception $e ) {
+					$date_completed = $date_created_gmt;
+				}
 			} elseif ( is_null( $date_completed ) ) { // Backfill a missing date_completed (for things like recurring payments).
 				$date_completed = $date_created_gmt;
 			}

--- a/includes/class-utilities.php
+++ b/includes/class-utilities.php
@@ -218,6 +218,7 @@ class Utilities {
 	 *                             date. Default false.
 	 *
 	 * @return \EDD\Utils\Date Date instance. Time is returned as UTC.
+	 * @throws \Exception
 	 */
 	public function date( $date_string = 'now', $timezone = null, $localize = false ) {
 

--- a/includes/utils/class-date.php
+++ b/includes/utils/class-date.php
@@ -28,6 +28,7 @@ final class Date extends \Carbon\Carbon {
 	 * Sets up the date.
 	 *
 	 * @since 3.0
+	 * @throws \Exception
 	 */
 	public function __construct( $time = 'now', \DateTimeZone $timezone = null ) {
 		if ( null === $timezone ) {


### PR DESCRIPTION
Fixes #8496

Proposed Changes:
1. Add `@throws` to docblocks to clarify methods can throw exceptions.
2. Add exception handling in date parsing and set fallback date to an empty string (BerlinDB should then take over and set it to be the current time).

To test:

1. Start on EDD `master` branch and have a customer.
2. Add a note to the customer.
3. Then manually edit the customer's record in the DB (`notes` column) to set the date to something that won't parse. For example:
`I am an invalid date! - This is my note`
Make sure you have at least one ` - ` (space, hyphen, space) in there because the migration code explodes on that.
4. Run the migration.
5. Ensure no errors. Ensure the note gets migrated with a `date_created` of today/now.

You can also change your site language prior to adding the note to get a "real" unparsable date, but I personally think editing the DB manually is a little easier and a better way to _guarantee_ a failure.