### PR TITLE
Start fixing tests failing at end of the month #8532

### DIFF
--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -510,7 +510,7 @@ function get_dates_filter_options() {
  * }
  */
 function get_dates_filter( $values = 'strings', $timezone = null ) {
-	$dates = parse_dates_for_range();
+	$dates = parse_dates_for_range( null, 'now', $timezone );
 
 	if ( 'strings' === $values ) {
 		if ( ! empty( $dates['start'] ) ) {
@@ -549,10 +549,12 @@ function get_dates_filter( $values = 'strings', $timezone = null ) {
  * @param string          $date  Date string converted to `\EDD\Utils\Date` to anchor calculations to.
  * @return \EDD\Utils\Date[] Array of start and end date objects.
  */
-function parse_dates_for_range( $range = null, $date = 'now' ) {
+function parse_dates_for_range( $range = null, $date = 'now', $timezone = null ) {
+
+	$timezone = ! empty( $timezone ) ? $timezone : edd_get_timezone_id();
 
 	// Set the time ranges in the user's timezone, so they ultimately see them in their own timezone.
-	$date = EDD()->utils->date( $date, edd_get_timezone_id(), false );
+	$date = EDD()->utils->date( $date, $timezone, false );
 
 	if ( null === $range || ! array_key_exists( $range, get_dates_filter_options() ) ) {
 		$range = get_dates_filter_range();

--- a/tests/tests-date-functions.php
+++ b/tests/tests-date-functions.php
@@ -133,9 +133,9 @@ class Date_Functions_Tests extends EDD_UnitTestCase {
 		$this->assertEquals( 1, $dates['day'] );
 		$this->assertEquals( date( 'n' ), $dates['m_start'] );
 		$this->assertEquals( date( 'Y' ), $dates['year'] );
-		$this->assertEquals( 1, $dates['day_end'] );
-		$this->assertEquals( date( 'n', strtotime( '+1 month' ) ), $dates['m_end'] );
-		$this->assertEquals( date( 'Y', strtotime( '+1 month' ) ), $dates['year_end'] );
+		$this->assertEquals( date( 't' ), $dates['day_end'] );
+		$this->assertEquals( date( 'n' ), $dates['m_end'] );
+		$this->assertEquals( date( 'Y' ), $dates['year_end'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8532

Proposed Changes:
1. Pass time zone all the way through to `parse_dates_for_range()` function. It's passed through `edd_get_report_dates()`, but then that time zone is not ultimately used when parsing dates, which is why tests fail.
2. Rewrite unit tests to fix assertions. It's testing for the range `this_month`, which should have a start of day 1 in the month, and an end of the last day of that month. It was doing `strtotime( '+1 month' )`, which didn't make sense to me, because that would be _next month_ and not part of this month's range. :thinking: 

I only updated one of the tests, but I think the other failing tests are also wrong in their assertions.

What I have so far was passing yesterday (March 31st) and is passing again to day.

I don't want to update the others as a priority, but thought I'd push up what I'd started tinkering with yesterday.