### PR TITLE
Replace "start_date" with "end_date" property when building the "before" part of the query inside of "remap_args" function

### DIFF
--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -609,7 +609,7 @@ class EDD_Payments_Query extends EDD_Stats {
 
 		if ( $this->args['end_date'] ) {
 			if ( is_numeric( $this->end_date ) ) {
-				$this->end_date = \Carbon\Carbon::createFromTimestamp( $this->start_date )->toDateTimeString();
+				$this->end_date = \Carbon\Carbon::createFromTimestamp( $this->end_date )->toDateTimeString();
 			}
 
 			$this->end_date = \Carbon\Carbon::parse( $this->end_date, edd_get_timezone_id() )->setTimezone( 'UTC' )->timestamp;


### PR DESCRIPTION
# Fixes

Proposed Changes:
1. Replace "start_date" with "end_date" property, when building the "before" part of the query inside of "remap_args" function.

This closes #8542.
