### PR TITLE
Ensure that tax_rate order meta is copied to refunds

### DIFF
--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -520,7 +520,7 @@ class Order extends Rows\Order {
 		 * If we have a tax_amount, but no rate, check in order meta. This is where legacy rates are stored
 		 * if they cannot be resolved to an actual adjustment object.
 		 */
-		if ( empty( $rate ) && $this->tax > 0 ) {
+		if ( empty( $rate ) && abs( $this->tax ) > 0 ) {
 			$rate = edd_get_order_meta( $this->id, 'tax_rate', true );
 		}
 

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -318,6 +318,12 @@ function edd_refund_order( $order_id, $order_items = 'all', $adjustments = 'all'
 	// new order ID.
 	$refund_id = edd_add_order( $order_data );
 
+	// If we have tax, but no tax rate, manually save the percentage.
+	$tax_rate_meta = edd_get_order_meta( $order_id, 'tax_rate', true );
+	if ( $tax_rate_meta ) {
+		edd_update_order_meta( $refund_id, 'tax_rate', $tax_rate_meta );
+	}
+
 	/** Insert order items ****************************************************/
 
 	// Maintain a mapping of old order item IDs => new for easier lookup when we do fees.


### PR DESCRIPTION
Fixes #8546

Branched from #8075 because of variable name changes, code refactoring

Proposed Changes:
1. Changes tax rate logic to use an absolute value instead of just checking if it's greater than 0 (refunds have negative tax value).
2. If the original order has a `tax_rate` meta value, copy it to the related refund.