### PR TITLE
Add legacy pre/post refund hooks to edd_refund_order

### DIFF
--- a/includes/class-easy-digital-downloads.php
+++ b/includes/class-easy-digital-downloads.php
@@ -553,6 +553,7 @@ final class Easy_Digital_Downloads {
 		if ( file_exists( EDD_PLUGIN_DIR . 'includes/deprecated-functions.php' ) ) {
 			require_once EDD_PLUGIN_DIR . 'includes/deprecated-functions.php';
 		}
+		require_once EDD_PLUGIN_DIR . 'includes/deprecated-hooks.php';
 	}
 
 	/**

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -1157,3 +1157,27 @@ function edd_record_status_change( $payment_id, $new_status, $old_status ) {
 
 	edd_insert_payment_note( $payment_id, $status_change );
 }
+
+/**
+ * Legacy pre-refund hook which fired after a payment status changed, but before store stats were updated.
+ *
+ * @deprecated 3.0
+ * @param int $order_id The original order id.
+ */
+add_action( 'edd_refund_order', function( $order_id ) {
+	if ( has_action( 'edd_pre_refund_payment' ) ) {
+		do_action( 'edd_pre_refund_payment', edd_get_payment( $order_id ) );
+	}
+} );
+
+/**
+ * Legacy post-refund hook which fired after a payment status changed and store stats were updated.
+ *
+ * @deprecated 3.0
+ * @param int $order_id The original order id.
+ */
+add_action( 'edd_refund_order', function( $order_id ) {
+	if ( has_action( 'edd_post_refund_payment' ) ) {
+		do_action( 'edd_post_refund_payment', edd_get_payment( $order_id ) );
+	}
+} );

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -1162,6 +1162,9 @@ function edd_record_status_change( $payment_id, $new_status, $old_status ) {
  * Legacy pre-refund hook which fired after a payment status changed, but before store stats were updated.
  *
  * @deprecated 3.0
+ * @todo       Formally deprecate in EDD 3.1
+ * @link       https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8574
+ *
  * @param int $order_id The original order id.
  */
 add_action( 'edd_refund_order', function( $order_id ) {
@@ -1174,6 +1177,9 @@ add_action( 'edd_refund_order', function( $order_id ) {
  * Legacy post-refund hook which fired after a payment status changed and store stats were updated.
  *
  * @deprecated 3.0
+ * @todo       Formally deprecate in EDD 3.1
+ * @link       https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8574
+ *
  * @param int $order_id The original order id.
  */
 add_action( 'edd_refund_order', function( $order_id ) {

--- a/includes/deprecated-functions.php
+++ b/includes/deprecated-functions.php
@@ -1157,33 +1157,3 @@ function edd_record_status_change( $payment_id, $new_status, $old_status ) {
 
 	edd_insert_payment_note( $payment_id, $status_change );
 }
-
-/**
- * Legacy pre-refund hook which fired after a payment status changed, but before store stats were updated.
- *
- * @deprecated 3.0
- * @todo       Formally deprecate in EDD 3.1
- * @link       https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8574
- *
- * @param int $order_id The original order id.
- */
-add_action( 'edd_refund_order', function( $order_id ) {
-	if ( has_action( 'edd_pre_refund_payment' ) ) {
-		do_action( 'edd_pre_refund_payment', edd_get_payment( $order_id ) );
-	}
-} );
-
-/**
- * Legacy post-refund hook which fired after a payment status changed and store stats were updated.
- *
- * @deprecated 3.0
- * @todo       Formally deprecate in EDD 3.1
- * @link       https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8574
- *
- * @param int $order_id The original order id.
- */
-add_action( 'edd_refund_order', function( $order_id ) {
-	if ( has_action( 'edd_post_refund_payment' ) ) {
-		do_action( 'edd_post_refund_payment', edd_get_payment( $order_id ) );
-	}
-} );

--- a/includes/deprecated-hooks.php
+++ b/includes/deprecated-hooks.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Deprecated Hooks
+ *
+ * All hooks that have been deprecated.
+ *
+ * @package     EDD
+ * @subpackage  Deprecated
+ * @copyright   Copyright (c) 2021, Sandhills Development, LLC
+ * @license     https://opensource.org/licenses/gpl-2.0.php GNU Public License
+ * @since       3.0
+ */
+
+/**
+ * Legacy pre-refund hook which fired after a payment status changed, but before store stats were updated.
+ *
+ * @deprecated 3.0
+ * @todo       Formally deprecate in EDD 3.1
+ * @link       https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8574
+ *
+ * @param int $order_id The original order id.
+ */
+add_action( 'edd_refund_order', function( $order_id ) {
+	if ( has_action( 'edd_pre_refund_payment' ) ) {
+		do_action( 'edd_pre_refund_payment', edd_get_payment( $order_id ) );
+	}
+} );
+
+/**
+ * Legacy post-refund hook which fired after a payment status changed and store stats were updated.
+ *
+ * @deprecated 3.0
+ * @todo       Formally deprecate in EDD 3.1
+ * @link       https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8574
+ *
+ * @param int $order_id The original order id.
+ */
+add_action( 'edd_refund_order', function( $order_id ) {
+	if ( has_action( 'edd_post_refund_payment' ) ) {
+		do_action( 'edd_post_refund_payment', edd_get_payment( $order_id ) );
+	}
+} );

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -403,6 +403,17 @@ function edd_refund_order( $order_id = 0, $order_items = array() ) {
 		)
 	);
 
+	if ( has_action( 'edd_pre_refund_payment' ) ) {
+		$payment = edd_get_payment( $order_id );
+		/**
+		 * Legacy pre-refund hook which fired after a payment status changed, but before store stats were updated.
+		 *
+		 * @deprecated 3.0
+		 * @param EDD_Payment $payment An EDD Payment object.
+		 */
+		edd_do_action_deprecated( 'edd_pre_refund_payment', array( $payment ), '3.0', 'edd_refund_order' );
+	}
+
 	/**
 	 * Fires when an order has been refunded.
 	 *
@@ -413,6 +424,17 @@ function edd_refund_order( $order_id = 0, $order_items = array() ) {
 	 * @param float $total        Amount refunded.
 	 */
 	do_action( 'edd_refund_order', $order_id, $new_order_id, floatval( $order->total ) );
+
+	if ( has_action( 'edd_post_refund_payment' ) ) {
+		$payment = edd_get_payment( $order_id );
+		/**
+		 * Legacy post-refund hook which fired after store stats were updated.
+		 *
+		 * @deprecated 3.0
+		 * @param EDD_Payment $payment An EDD Payment object.
+		 */
+		edd_do_action_deprecated( 'edd_post_refund_payment', array( $payment ), '3.0', 'edd_refund_order' );
+	}
 
 	return $new_order_id;
 }

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -403,19 +403,10 @@ function edd_refund_order( $order_id = 0, $order_items = array() ) {
 		)
 	);
 
-	if ( has_action( 'edd_pre_refund_payment' ) ) {
-		$payment = edd_get_payment( $order_id );
-		/**
-		 * Legacy pre-refund hook which fired after a payment status changed, but before store stats were updated.
-		 *
-		 * @deprecated 3.0
-		 * @param EDD_Payment $payment An EDD Payment object.
-		 */
-		edd_do_action_deprecated( 'edd_pre_refund_payment', array( $payment ), '3.0', 'edd_refund_order' );
-	}
-
 	/**
 	 * Fires when an order has been refunded.
+	 * This hook will trigger the legacy `edd_pre_refund_payment` and `edd_post_refund_payment`
+	 * hooks for the time being, but any code using either of those should be updated.
 	 *
 	 * @since 3.0
 	 *
@@ -424,17 +415,6 @@ function edd_refund_order( $order_id = 0, $order_items = array() ) {
 	 * @param float $total        Amount refunded.
 	 */
 	do_action( 'edd_refund_order', $order_id, $new_order_id, floatval( $order->total ) );
-
-	if ( has_action( 'edd_post_refund_payment' ) ) {
-		$payment = edd_get_payment( $order_id );
-		/**
-		 * Legacy post-refund hook which fired after store stats were updated.
-		 *
-		 * @deprecated 3.0
-		 * @param EDD_Payment $payment An EDD Payment object.
-		 */
-		edd_do_action_deprecated( 'edd_post_refund_payment', array( $payment ), '3.0', 'edd_refund_order' );
-	}
 
 	return $new_order_id;
 }

--- a/tests/tests-easy-digital-downloads.php
+++ b/tests/tests-easy-digital-downloads.php
@@ -59,6 +59,7 @@ class Tests_EDD extends EDD_UnitTestCase {
 			array( EDD_PLUGIN_DIR . 'includes/install.php' ),
 			array( EDD_PLUGIN_DIR . 'includes/actions.php' ),
 			array( EDD_PLUGIN_DIR . 'includes/deprecated-functions.php' ),
+			array( EDD_PLUGIN_DIR . 'includes/deprecated-hooks.php' ),
 			array( EDD_PLUGIN_DIR . 'includes/ajax-functions.php' ),
 			array( EDD_PLUGIN_DIR . 'includes/template-functions.php' ),
 			array( EDD_PLUGIN_DIR . 'includes/checkout/template.php' ),


### PR DESCRIPTION
Fixes #8540

Marking this as a draft as it results in multiple failed unit tests and I'm not 100% sure how to handle those:

> There were 8 failures:
> 
> 1) EDD\Discounts\Tests_Discounts::test_is_used_case_insensitive
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528
> 
> 2) EDD\Orders\EDD_Payment_Tests::test_refund_payment
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528
> 
> 3) EDD\Orders\EDD_Payment_Tests::test_refund_payment_legacy
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528
> 
> 4) EDD\Orders\EDD_Payment_Tests::test_refund_affecting_stats
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528
> 
> 5) EDD\Orders\Refunds_Tests::test_refund_order
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528
> 
> 6) EDD\Orders\Trash_Tests::test_trash_order_with_refunds
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528
> 
> 7) Tests_Process_Download::test_refunded_item_in_partially_refunded_order_should_return_false
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528
> 
> 8) Tests_Process_Download::test_fully_refunded_order_should_return_false
> Unexpected deprecated notice for edd_pre_refund_payment
> Failed asserting that an array is empty.
> 
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:516
> /tmp/wordpress-tests-lib/includes/abstract-testcase.php:528

Note that the `edd_pre_refund_payment` hook is used in PayPal, and the post hook is not used anywhere in core.

Also noting that these hooks both technically fire _after_ the payment/order has been refunded, but `pre` is before the store stats have been updated, and `post` is afterwards.