### PR TITLE
Format price in Products (Raw) column

### DIFF
--- a/includes/admin/reporting/export/class-batch-export-payments.php
+++ b/includes/admin/reporting/export/class-batch-export-payments.php
@@ -180,7 +180,7 @@ class EDD_Batch_Payments_Export extends EDD_Batch_Export {
 						}
 
 						/* Set up raw products column - Nothing but product names */
-						$products_raw .= html_entity_decode( get_the_title( $id ) ) . '|' . $price . '{' . $download_tax . '}';
+						$products_raw .= html_entity_decode( get_the_title( $id ) ) . '|' . edd_format_amount( $price ) . '{' . $download_tax . '}';
 
 						// if we have a Price ID, include it.
 						if ( false !== $download_price_id ) {


### PR DESCRIPTION
It seems that the Products (Raw) column in "Export Payment History" is showing the incorrect price when there's a discount applied.

In the referred screenshot, you may see the amount displayed as `79.2`, whereas the order total is actually $79.

![image](https://user-images.githubusercontent.com/1505631/114564688-2da4db80-9c8e-11eb-8f24-33ae6b9a7655.png)

Other columns in export are using `edd_format_amount` but the price in the Products (Raw) column isn't. 

This PR simply wraps the price with `edd_format_amount` function.
