### PR TITLE
Update edd_count_file_downloads_of_user/customer functions

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -250,6 +250,7 @@ class Data_Migrator {
 				'_edd_log_price_id',
 				'_edd_log_customer_id',
 				'_edd_log_ip',
+				'_edd_log_user_id',
 			);
 			$meta_to_migrate   = $post_meta;
 			$new_log_id        = edd_add_file_download_log( $log_data );

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -244,7 +244,7 @@ class Data_Migrator {
 				'date_modified' => $data->post_modified_gmt,
 			);
 
-			$meta_to_remove    = array(
+			$meta_to_remove = array(
 				'_edd_log_file_id',
 				'_edd_log_payment_id',
 				'_edd_log_price_id',
@@ -252,6 +252,10 @@ class Data_Migrator {
 				'_edd_log_ip',
 				'_edd_log_user_id',
 			);
+			// If the log doesn't have a customer ID, but does have a user ID, keep the user ID as metadata.
+			if ( empty( $log_data['customer_id'] ) && ! empty( $post_meta['_edd_log_user_id'] ) && ! in_array( $post_meta['_edd_log_user_id'], array( 0, -1 ), true ) ) {
+				$meta_to_remove = array_diff( $meta_to_remove, array( '_edd_log_user_id' ) );
+			}
 			$meta_to_migrate   = $post_meta;
 			$new_log_id        = edd_add_file_download_log( $log_data );
 			$add_meta_function = 'edd_add_file_download_log_meta';

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -253,7 +253,7 @@ class Data_Migrator {
 				'_edd_log_user_id',
 			);
 			// If the log doesn't have a customer ID, but does have a user ID, keep the user ID as metadata.
-			if ( empty( $log_data['customer_id'] ) && ! empty( $post_meta['_edd_log_user_id'] ) && ! in_array( $post_meta['_edd_log_user_id'], array( 0, -1 ), true ) ) {
+			if ( empty( $log_data['customer_id'] ) && ! empty( $post_meta['_edd_log_user_id'] ) && ! in_array( $post_meta['_edd_log_user_id'], array( 0, -1, '-1' ), true ) ) {
 				$meta_to_remove = array_diff( $meta_to_remove, array( '_edd_log_user_id' ) );
 			}
 			$meta_to_migrate   = $post_meta;

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -253,7 +253,7 @@ class Data_Migrator {
 				'_edd_log_user_id',
 			);
 			// If the log doesn't have a customer ID, but does have a user ID, keep the user ID as metadata.
-			if ( empty( $log_data['customer_id'] ) && ! empty( $post_meta['_edd_log_user_id'] ) && ! in_array( $post_meta['_edd_log_user_id'], array( 0, -1, '-1' ), true ) ) {
+			if ( empty( $log_data['customer_id'] ) && ! empty( $post_meta['_edd_log_user_id'] ) && ! in_array( $post_meta['_edd_log_user_id'], array( 0, -1 ) ) ) {
 				$meta_to_remove = array_diff( $meta_to_remove, array( '_edd_log_user_id' ) );
 			}
 			$meta_to_migrate   = $post_meta;

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1580,7 +1580,7 @@ class EDD_CLI extends WP_CLI_Command {
 
 			$file_id_key = array_rand( $download_ids_with_files[ $product_id ], 1 );
 			$file_key    = $download_ids_with_files[ $product_id ][ $file_id_key ];
-			$log_id      = edd_add_file_download_log( array(
+			edd_add_file_download_log( array(
 				'product_id'   => absint( $product_id ),
 				'file_id'      => absint( $file_key ),
 				'order_id'     => absint( $order_id ),

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1590,14 +1590,6 @@ class EDD_CLI extends WP_CLI_Command {
 				'user_agent'   => 'EDD; WPCLI; download_logs;',
 				'date_created' => $order->date_completed,
 			) );
-			if ( ! empty( $user_info['id'] ) ) {
-				edd_add_file_download_log_meta(
-					$log_id,
-					'user_id',
-					absint( $user_info['id'] ),
-					true
-				);
-			}
 
 			$progress->tick();
 			$i ++;

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1580,7 +1580,7 @@ class EDD_CLI extends WP_CLI_Command {
 
 			$file_id_key = array_rand( $download_ids_with_files[ $product_id ], 1 );
 			$file_key    = $download_ids_with_files[ $product_id ][ $file_id_key ];
-			edd_add_file_download_log( array(
+			$log_id      = edd_add_file_download_log( array(
 				'product_id'   => absint( $product_id ),
 				'file_id'      => absint( $file_key ),
 				'order_id'     => absint( $order_id ),
@@ -1590,7 +1590,14 @@ class EDD_CLI extends WP_CLI_Command {
 				'user_agent'   => 'EDD; WPCLI; download_logs;',
 				'date_created' => $order->date_completed,
 			) );
-			//edd_record_download_in_log( $product_id, $file_key, $user_info, edd_get_ip(), $order_id, $price_id );
+			if ( ! empty( $user_info['id'] ) ) {
+				edd_add_file_download_log_meta(
+					$log_id,
+					'user_id',
+					absint( $user_info['id'] ),
+					true
+				);
+			}
 
 			$progress->tick();
 			$i ++;

--- a/includes/class-edd-logging.php
+++ b/includes/class-edd-logging.php
@@ -221,7 +221,7 @@ class EDD_Logging {
 				'user_agent'  => $user_agent,
 			);
 
-			$meta_to_unset = array( 'file_id', 'payment_id', 'price_id', 'customer_id', 'ip' );
+			$meta_to_unset = array( 'file_id', 'payment_id', 'price_id', 'customer_id', 'ip', 'user_id' );
 		}
 
 		// Now unset the meta we've used up in the main data array.

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -772,7 +772,7 @@ function edd_get_download_sales_stats( $download_id = 0 ) {
  *
  * @param int    $download_id Download ID.
  * @param int    $file_id     File ID.
- * @param array  $user_info   User information (Deprecated)
+ * @param array  $user_info   User information.
  * @param string $ip          User IP.
  * @param int    $order_id    Order ID.
  * @param int    $price_id    Optional. Price ID,
@@ -789,7 +789,7 @@ function edd_record_download_in_log( $download_id = 0, $file_id = 0, $user_info 
 
 	$user_agent = $browser->getBrowser() . ' ' . $browser->getVersion() . '/' . $browser->getPlatform();
 
-	edd_add_file_download_log( array(
+	$download_log = edd_add_file_download_log( array(
 		'product_id'  => absint( $download_id ),
 		'file_id'     => absint( $file_id ),
 		'order_id'    => absint( $order_id ),
@@ -798,6 +798,15 @@ function edd_record_download_in_log( $download_id = 0, $file_id = 0, $user_info 
 		'ip'          => sanitize_text_field( $ip ),
 		'user_agent'  => $user_agent,
 	) );
+
+	if ( ! empty( $user_info['id'] ) ) {
+		edd_add_file_download_log_meta(
+			$download_log,
+			'user_id',
+			absint( $user_info['id'] ),
+			true
+		);
+	}
 }
 
 /**

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -772,7 +772,7 @@ function edd_get_download_sales_stats( $download_id = 0 ) {
  *
  * @param int    $download_id Download ID.
  * @param int    $file_id     File ID.
- * @param array  $user_info   User information.
+ * @param array  $user_info   User information (deprecated).
  * @param string $ip          User IP.
  * @param int    $order_id    Order ID.
  * @param int    $price_id    Optional. Price ID,

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -798,15 +798,6 @@ function edd_record_download_in_log( $download_id = 0, $file_id = 0, $user_info 
 		'ip'          => sanitize_text_field( $ip ),
 		'user_agent'  => $user_agent,
 	) );
-
-	if ( ! empty( $user_info['id'] ) ) {
-		edd_add_file_download_log_meta(
-			$download_log,
-			'user_id',
-			absint( $user_info['id'] ),
-			true
-		);
-	}
 }
 
 /**

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -789,7 +789,7 @@ function edd_record_download_in_log( $download_id = 0, $file_id = 0, $user_info 
 
 	$user_agent = $browser->getBrowser() . ' ' . $browser->getVersion() . '/' . $browser->getPlatform();
 
-	$download_log = edd_add_file_download_log( array(
+	edd_add_file_download_log( array(
 		'product_id'  => absint( $download_id ),
 		'file_id'     => absint( $file_id ),
 		'order_id'    => absint( $order_id ),

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -340,11 +340,11 @@ function edd_count_file_downloads_of_user( $user ) {
 
 	$customer = edd_get_customer_by( 'user_id', $user );
 
-	return edd_count_file_download_logs(
+	return ! empty( $customer->id ) ? edd_count_file_download_logs(
 		array(
 			'customer_id' => $customer->id,
 		)
-	);
+	) : 0;
 }
 
 /**

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -326,47 +326,47 @@ function edd_purchase_total_of_user( $user = null ) {
  * given) has downloaded
  *
  * @since       1.3
+ * @since       3.0 Updated to use edd_count_file_download_logs.
  * @param       mixed $user - ID or email
  * @return      int - The total number of files the user has downloaded
  */
 function edd_count_file_downloads_of_user( $user ) {
-	$edd_logs = EDD()->debug_log;
 
 	// If we got an email, look up the customer ID and call the direct query
 	// for customer download counts.
 	if ( is_email( $user ) ) {
 		return edd_count_file_downloads_of_customer( $user );
-
-	} else {
-		$meta_query = array(
-			array(
-				'key'     => '_edd_log_user_id',
-				'value'   => $user
-			)
-		);
 	}
 
-	return $edd_logs->get_log_count( null, 'file_download', $meta_query );
+	return edd_count_file_download_logs(
+		array(
+			'meta_query' => array(
+				array(
+					'key'   => 'user_id',
+					'value' => $user,
+				),
+			),
+		)
+	);
 }
 
 /**
  * Counts the total number of files a customer has downloaded.
  *
+ * @since unknown
+ * @since 3.0     Updated to use edd_count_file_download_logs.
  * @param string|int $customer_id_or_email The email address or id of the customer.
  *
  * @return int The total number of files the customer has downloaded.
  */
 function edd_count_file_downloads_of_customer( $customer_id_or_email = '' ) {
-	$edd_logs   = EDD()->debug_log;
-	$customer   = new EDD_Customer( $customer_id_or_email );
-	$meta_query = array(
+	$customer = new EDD_Customer( $customer_id_or_email );
+
+	return edd_count_file_download_logs(
 		array(
-			'key'   => '_edd_log_customer_id',
-			'value' => $customer->id,
+			'customer_id' => $customer->id,
 		)
 	);
-
-	return $edd_logs->get_log_count( null, 'file_download', $meta_query );
 }
 
 /**

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -338,14 +338,11 @@ function edd_count_file_downloads_of_user( $user ) {
 		return edd_count_file_downloads_of_customer( $user );
 	}
 
+	$customer = edd_get_customer_by( 'user_id', $user );
+
 	return edd_count_file_download_logs(
 		array(
-			'meta_query' => array(
-				array(
-					'key'   => 'user_id',
-					'value' => $user,
-				),
-			),
+			'customer_id' => $customer->id,
 		)
 	);
 }


### PR DESCRIPTION
Fixes #8570

Proposed Changes:
1. Update `edd_count_file_downloads_of_user` and `edd_count_file_downloads_of_customer` to use the new `edd_count_file_download_logs` function.
2. Add the `user_id` as meta to the file download log if it exists (it looks like this was removed at one point, but we keep this data on migration, so adding it back for now. If we want to remove it, we should likely also remove it from the migration).

To test:
Make sure you have orders on your site. You can run this CLI command:
```
wp edd payments create --number=1000 --date=random --range=365 --generate_users=1
```

That will generate new customers, but not necessarily new users. You will need to link at least some of the customers to users. Then switch to this branch and run:
```
wp edd download_logs create --number=1000
```
Some of the download logs will be linked to a customer only, if the customer does not have a linked user account, but some should be linked to a user account. Check the `wp_edd_logs_file_downloadmeta` table for a user ID with records, and then you can replace the customer and user ID in this code to test:

```php
$customer_id = 101;
$user_id     = 2;
var_dump( edd_count_file_downloads_of_customer( $customer_id ) );
var_dump( edd_count_file_downloads_of_user( $user_id ) );
```

The numbers should be the same for a valid user. You can also pass an email address in to either function. In `release/3.0`, these functions will not work.

It is possible that the download numbers will not be the same. We were migrating the `user_id` for 2.x orders, but until this PR, were not storing the `user_id` for new downloads. If an existing user had downloads on `release/3.0`, the customer download number will be higher than the user download number.