### PR TITLE
Update discount compatibility

### DIFF
--- a/includes/compat/class-discount.php
+++ b/includes/compat/class-discount.php
@@ -316,7 +316,7 @@ class Discount extends Base {
 							}
 						}
 
-						if ( 0 < count( $clauses['where'] ) ) {
+						if ( ! empty( $clauses['where'] ) && is_array( $clauses['where'] ) ) {
 							$sql_where .= ' AND ( ' . implode( ' ' . $relation . ' ', $clauses['where'] ) . ' )';
 						}
 					}

--- a/includes/compat/class-discount.php
+++ b/includes/compat/class-discount.php
@@ -269,7 +269,7 @@ class Discount extends Base {
 							 * products as these would be serialized under the old schema.
 							 */
 							if ( in_array( $query['key'], $columns, true ) && array_key_exists( 'value', $query ) ) {
-								$meta_compare = $query['compare'];
+								$meta_compare = ! empty( $query['compare'] ) ? $query['compare'] : '=';
 								$meta_compare = strtoupper( $meta_compare );
 
 								$meta_value = $query['value'];


### PR DESCRIPTION
Fixes #8579 

Proposed Changes:
1. Check for `$query` values before using (`$query['compare']` and `$query['where']`).

To test:
I found two ways to trigger error notices--one got me the original error and one got me a new one. In `release/3.0`, run this query:

```php
new WP_Query(
	array(
		'post_type'  => 'edd_discount',
		'meta_query' => array(
			array(
				'key'   => 'expiration',
				'value' => '2021-01-01',
			),
		),
	)
);
```
You should get the original reported error. Note that this is not a validly used meta key for a discount, so it should not return any results anyway.

I encountered a second error when I changed the meta key to a key that EDD actually uses:
```php
new WP_Query(
	array(
		'post_type'  => 'edd_discount',
		'meta_query' => array(
			array(
				'key'   => '_edd_discount_status',
				'value' => 'active',
			),
		),
	)
);
```