### PR TITLE
Ensure discount queries only return discount adjustments #8587

### DIFF
--- a/includes/compat/class-discount.php
+++ b/includes/compat/class-discount.php
@@ -233,7 +233,7 @@ class Discount extends Base {
 			$meta_query = $query->get( 'meta_query' );
 
 			$clauses   = array();
-			$sql_where = 'WHERE 1=1';
+			$sql_where = "WHERE type = 'discount'";
 
 			$meta_key   = $query->get( 'meta_key',   false );
 			$meta_value = $query->get( 'meta_value', false );


### PR DESCRIPTION
Fixes #8587

Proposed Changes:
1. Ensure the discount query has a clause to set `type = 'discount'`