### PR TITLE
Use is_ssl() to set cookies to secure

### DIFF
--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -231,13 +231,11 @@ class EDD_Session {
 	 * @return void
 	 */
 	public function set_cart_cookie( $set = true ) {
-		if( ! headers_sent() ) {
-			if( $set ) {
-				@setcookie( 'edd_items_in_cart', '1', time() + 30 * 60, COOKIEPATH, COOKIE_DOMAIN, false );
-			} else {
-				if ( isset($_COOKIE['edd_items_in_cart']) ) {
-					@setcookie( 'edd_items_in_cart', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, false );
-				}
+		if ( ! headers_sent() ) {
+			if ( $set ) {
+				setcookie( 'edd_items_in_cart', '1', time() + 1800, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
+			} elseif ( isset( $_COOKIE['edd_items_in_cart'] ) ) {
+				setcookie( 'edd_items_in_cart', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN, is_ssl() );
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #8037

Proposed Changes:
1. Change the `secure` parameter for `setcookie` to check `is_ssl()`.
2. Remove error silencing.