### PR TITLE
Add custom tax rates to manually created orders

### DIFF
--- a/includes/admin/views/tmpl-order-tax.php
+++ b/includes/admin/views/tmpl-order-tax.php
@@ -70,3 +70,4 @@
 <# } #>
 
 <input type="hidden" value="{{ data.tax }}" name="tax" />
+<input type="hidden" value="{{ data.state.hasTax.rate }}" name="tax_rate" />

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -199,6 +199,18 @@ function edd_add_manual_order( $args = array() ) {
 		$customer->attach_payment( $order_id, false );
 	}
 
+	// If we have tax, but no tax rate, manually save the percentage.
+	if ( empty( $tax_rate->id ) && $order_tax > 0 ) {
+		$tax_rate_percentage = $data['tax_rate'];
+		if ( ! empty( $tax_rate_percentage ) ) {
+			if ( $tax_rate_percentage > 0 && $tax_rate_percentage < 1 ) {
+				$tax_rate_percentage = $tax_rate_percentage * 100;
+			}
+
+			edd_update_order_meta( $order_id, 'tax_rate', $tax_rate_percentage );
+		}
+	}
+
 	/** Insert order address **************************************************/
 
 	if ( isset( $data['edd_order_address'] ) ) {


### PR DESCRIPTION
Fixes #8591

Proposed Changes:
1. Add the tax rate as a hidden input for manually created orders.
2. If a manually created order has tax, but no tax rate object, save the tax rate as metadata.

To Test:
1. Use a VAT plugin to manually generate an  order with tax which does not have a tax rate object in the database.