### PR TITLE
Do not migrate amount, user ID for payment meta

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -752,6 +752,8 @@ class Data_Migrator {
 			'discount',
 			'subtotal',
 			'tax',
+			'amount',
+			'user_id',
 		);
 
 		// Remove core keys from `user_info`.


### PR DESCRIPTION
Fixes #8603

Proposed Changes:
1. Adds `user_id` and `amount` to the core meta keys which don't need to be migrated.

To Test:
1. Run yet another migration from 2.x order data to 3.0. It may require having an older dataset.