### PR TITLE
Allow migration step recovery #8118

### DIFF
--- a/includes/admin/upgrades/v3/class-customer-email-addresses.php
+++ b/includes/admin/upgrades/v3/class-customer-email-addresses.php
@@ -51,6 +51,17 @@ class Customer_Email_Addresses extends Base {
 
 		if ( ! empty( $results ) ) {
 			foreach ( $results as $result ) {
+				// Check if email has already been migrated.
+				if ( ! empty( $result->edd_customer_id ) && $result->meta_value ) {
+					$number_results = edd_count_customer_email_addresses( array(
+						'customer_id' => $result->edd_customer_id,
+						'email'       => $result->meta_value
+					) );
+					if ( $number_results > 0 ) {
+						continue;
+					}
+				}
+
 				Data_Migrator::customer_email_addresses( $result );
 			}
 

--- a/includes/admin/upgrades/v3/upgrade-actions.php
+++ b/includes/admin/upgrades/v3/upgrade-actions.php
@@ -48,10 +48,10 @@ function edd_process_v3_upgrade() {
 
 	// If we have a step already saved, use that instead.
 	// This is commented out for now because some changes are required in the migration processes first.
-	/*$saved_step = get_option( sprintf( 'edd_v3_migration_%s_step', sanitize_key( $upgrade_key ) ) );
+	$saved_step = get_option( sprintf( 'edd_v3_migration_%s_step', sanitize_key( $upgrade_key ) ) );
 	if ( ! empty( $saved_step ) ) {
 		$step = absint( $saved_step );
-	}*/
+	}
 
 	$class_name = $all_upgrades[ $upgrade_key ]['class'];
 
@@ -70,10 +70,8 @@ function edd_process_v3_upgrade() {
 		wp_die( -1, 403, array( 'response' => 403 ) );
 	}
 
-	$was_processed = $export->process_step();
-	//$was_processed       = false; // @todo remove
+	$was_processed       = $export->process_step();
 	$percentage_complete = round( $export->get_percentage_complete(), 2 );
-	//$percentage_complete = 100; // @todo remove
 
 	// Build some shared args.
 	$response_args = array(

--- a/includes/admin/upgrades/v3/upgrade-actions.php
+++ b/includes/admin/upgrades/v3/upgrade-actions.php
@@ -47,7 +47,6 @@ function edd_process_v3_upgrade() {
 	$step = ! empty( $_POST['step'] ) ? absint( $_POST['step'] ) : 1;
 
 	// If we have a step already saved, use that instead.
-	// This is commented out for now because some changes are required in the migration processes first.
 	$saved_step = get_option( sprintf( 'edd_v3_migration_%s_step', sanitize_key( $upgrade_key ) ) );
 	if ( ! empty( $saved_step ) ) {
 		$step = absint( $saved_step );


### PR DESCRIPTION
Fixes #8118

Proposed Changes:
1. Comment out step recovery.

This actually needed less work than I thought because it turns out we already have checks in place to skip items that already exist:

https://github.com/easydigitaldownloads/easy-digital-downloads/blob/release/3.0/includes/admin/upgrades/v3/class-discounts.php#L56

https://github.com/easydigitaldownloads/easy-digital-downloads/blob/release/3.0/includes/admin/upgrades/v3/class-orders.php#L57

Note that this recovery process may result in a few duplicate logs and notes getting added, but those won't be the end of the world.

To test:

- Start a migration via the UI.
- For easiest testing, wait for one of the long running processes to start (orders, logs).
- Then note which percentage you're on for that step.
- Navigate away from the page or just refresh the page.
- Resume the migration. Ensure you start back up again on the same (or nearly the same) percentage.