### PR TITLE
Fix additional customer email address migration

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -91,7 +91,7 @@ class Data_Migrator {
 			return;
 		}
 
-		$customer = edd_get_customer_by( 'user_id', absint( $data->edd_customer_id ) );
+		$customer = edd_get_customer( absint( $data->edd_customer_id ) );
 		if ( ! $customer ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #8616

Proposed Changes:
1. Use `edd_get_customer` to retrieve the customer object when migrating additional email address.

To Test:
1. Set up a storefront in 2.10 with customers who have more than one email address assigned.
2. You can see the issue caused by the current code by running a 3.0 migration and seeing that the additional email addresses are not necessarily mapped to the correct customers (if the customer ID and user ID are the same, they could match).
3. Switch to this branch and run the migration--additional email addresses should show with the correct customers.

Note: this PR only fixes the migration. There is nothing currently to remove the `additional_email` metadata from the customer record.