### PR TITLE
Create order recovery methods

### DIFF
--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -642,7 +642,7 @@ class Order extends Rows\Order {
 		$recovery_url = add_query_arg(
 			array(
 				'edd_action' => 'recover_payment',
-				'payment_id' => $this->id,
+				'payment_id' => urlencode( $this->id ),
 			),
 			edd_get_checkout_uri()
 		);
@@ -660,7 +660,8 @@ class Order extends Rows\Order {
 		 * The order recovery URL.
 		 *
 		 * @since 3.0
-		 * @param \EDD\Orders\Order $this The order object.
+		 * @param string            $recovery_url The order recovery URL.
+		 * @param \EDD\Orders\Order $this         The order object.
 		 */
 		return apply_filters( 'edd_order_recovery_url', $recovery_url, $this );
 	}

--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -610,4 +610,58 @@ class Order extends Rows\Order {
 	public function is_complete() {
 		return ( 'complete' === $this->status );
 	}
+
+	/**
+	 * Determines if this order is able to be resumed by the user.
+	 *
+	 * @since 3.0
+	 *
+	 * @return bool
+	 */
+	public function is_recoverable() {
+		$recoverable_statuses = edd_recoverable_order_statuses();
+		if ( in_array( $this->status, $recoverable_statuses, true ) && empty( $this->get_transaction_id() ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the URL that a customer can use to resume an order, or false if it's not recoverable.
+	 *
+	 * @since 3.0
+	 *
+	 * @return bool|string
+	 */
+	public function get_recovery_url() {
+		if ( ! $this->is_recoverable() ) {
+			return false;
+		}
+
+		$recovery_url = add_query_arg(
+			array(
+				'edd_action' => 'recover_payment',
+				'payment_id' => $this->id,
+			),
+			edd_get_checkout_uri()
+		);
+
+		/**
+		 * Legacy recovery URL filter.
+		 *
+		 * @param \EDD_Payment $payment The EDD payment object.
+		 */
+		if ( has_filter( 'edd_payment_recovery_url' ) ) {
+			$recovery_url = apply_filters( 'edd_payment_recovery_url', $recovery_url, edd_get_payment( $this->id ) );
+		}
+
+		/**
+		 * The order recovery URL.
+		 *
+		 * @since 3.0
+		 * @param \EDD\Orders\Order $this The order object.
+		 */
+		return apply_filters( 'edd_order_recovery_url', $recovery_url, $this );
+	}
 }

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -1379,6 +1379,26 @@ function edd_get_net_order_statuses() {
 }
 
 /**
+ * Get the order status array keys which are considered recoverable.
+ *
+ * @since 3.0
+ * @return array An array of order status keys which are considered recoverable.
+ */
+function edd_recoverable_order_statuses() {
+	$statuses = array( 'pending', 'abandoned', 'failed' );
+	$statuses = apply_filters( 'edd_recoverable_payment_statuses', $statuses );
+
+	/**
+	 * Order statuses which are considered recoverable.
+	 *
+	 * @param $statuses {
+	 *        An array of order status array keys.
+	 * }
+	 */
+	return apply_filters( 'edd_recoverable_order_statuses', $statuses );
+}
+
+/**
  * Generate unique payment key for orders.
  *
  * @since 3.0

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -1386,7 +1386,6 @@ function edd_get_net_order_statuses() {
  */
 function edd_recoverable_order_statuses() {
 	$statuses = array( 'pending', 'abandoned', 'failed' );
-	$statuses = apply_filters( 'edd_recoverable_payment_statuses', $statuses );
 
 	/**
 	 * Order statuses which are considered recoverable.
@@ -1395,7 +1394,7 @@ function edd_recoverable_order_statuses() {
 	 *        An array of order status array keys.
 	 * }
 	 */
-	return apply_filters( 'edd_recoverable_order_statuses', $statuses );
+	return apply_filters( 'edd_recoverable_payment_statuses', $statuses );
 }
 
 /**

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -524,7 +524,7 @@ function edd_is_order_recoverable( $order_id = 0 ) {
 		return false;
 	}
 
-	$recoverable_statuses = apply_filters( 'edd_recoverable_payment_statuses', array( 'pending', 'abandoned', 'failed' ) );
+	$recoverable_statuses = edd_recoverable_order_statuses();
 
 	$transaction_id = $order->get_transaction_id();
 
@@ -624,7 +624,7 @@ function edd_build_order( $order_data = array() ) {
 		$order = edd_get_order( $existing_order );
 
 		if ( $order ) {
-			$recoverable_statuses = apply_filters( 'edd_recoverable_payment_statuses', array( 'pending', 'abandoned', 'failed' ) );
+			$recoverable_statuses = edd_recoverable_order_statuses();
 
 			$transaction_id = $order->get_transaction_id();
 

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -2643,15 +2643,7 @@ class EDD_Payment {
 	 * @return bool
 	 */
 	public function is_recoverable() {
-		$recoverable = false;
-
-		$recoverable_statuses = apply_filters( 'edd_recoverable_payment_statuses', array( 'pending', 'abandoned', 'failed' ) );
-
-		if ( in_array( $this->status, $recoverable_statuses, true ) && empty( $this->transaction_id ) ) {
-			$recoverable = true;
-		}
-
-		return $recoverable;
+		return $this->order->is_recoverable();
 	}
 
 	/**
@@ -2662,16 +2654,7 @@ class EDD_Payment {
 	 * @return bool|string
 	 */
 	public function get_recovery_url() {
-		if ( ! $this->is_recoverable() ) {
-			return false;
-		}
-
-		$recovery_url = add_query_arg( array(
-			'edd_action' => 'recover_payment',
-			'payment_id' => $this->ID,
-		), edd_get_checkout_uri() );
-
-		return apply_filters( 'edd_payment_recovery_url', $recovery_url, $this );
+		return $this->order->get_recovery_url();
 	}
 
 	/**

--- a/templates/history-purchases.php
+++ b/templates/history-purchases.php
@@ -58,18 +58,14 @@ if ( $orders ) :
 					<?php if ( ! in_array( $order->status, array( 'complete' ), true ) ) : ?>
 						| <span class="edd_purchase_status <?php echo esc_attr( $order->status ); ?>"><?php echo esc_html( edd_get_status_label( $order->status ) ); ?></span>
 					<?php endif; ?>
-					<?php if ( in_array( $order->status, array( 'pending', 'abandoned', 'failed' ), true ) ) : ?>
-						<?php
-						$url = add_query_arg(
-							array(
-								'edd_action' => 'recover_payment',
-								'payment_id' => urlencode( $order->id ),
-							),
-							edd_get_checkout_uri()
-						);
+					<?php
+					$recovery_url = $order->get_recovery_url();
+					if ( $recovery_url ) :
 						?>
-						&mdash; <a href="<?php echo esc_url( $url ); ?>"><?php esc_html_e( 'Complete Purchase', 'easy-digital-downloads' ); ?></a>
-					<?php endif; ?>
+						&mdash; <a href="<?php echo esc_url( $recovery_url ); ?>"><?php esc_html_e( 'Complete Purchase', 'easy-digital-downloads' ); ?></a>
+						<?php
+					endif;
+					?>
 				</td>
 				<?php do_action( 'edd_order_history_row_end', $order ); ?>
 			</tr>


### PR DESCRIPTION
Fixes #8550; branched from #8549

Proposed Changes:
1. Create `edd_recoverable_order_statuses` to return an array of recoverable order statuses.
2. Create order recovery methods `$order->is_recoverable()` and `$order->get_recovery_url()`.
3. Use the new order methods in the purchase history template.
