### PR TITLE
Issue/8623

### DIFF
--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -1291,7 +1291,9 @@ class Query extends Base {
 				}
 
 				// Remove " AND " from meta_query query where clause
-				$where['meta_query'] = preg_replace( $and, '', $clauses['where'] );
+				if ( ! empty( $clauses['where'] ) ) {
+					$where['meta_query'] = preg_replace( $and, '', $clauses['where'] );
+				}
 			}
 		}
 

--- a/includes/payments/class-payments-query.php
+++ b/includes/payments/class-payments-query.php
@@ -746,24 +746,33 @@ class EDD_Payments_Query extends EDD_Stats {
 			$arguments['status'] = edd_get_payment_status_keys();
 		}
 
-		if ( isset( $this->args['meta_query'] ) && is_array( $this->args['meta_query'] ) ) {
-			foreach ( $this->args['meta_query'] as $meta ) {
+		if ( isset( $arguments['meta_query'] ) && is_array( $arguments['meta_query'] ) ) {
+			foreach ( $arguments['meta_query'] as $meta_index => $meta ) {
 				if ( ! empty( $meta['key'] ) ) {
 					switch ( $meta['key'] ) {
 						case '_edd_payment_customer_id':
 							$arguments['customer_id'] = absint( $meta['value'] );
+							unset( $arguments['meta_query'][ $meta_index ] );
 							break;
 
 						case '_edd_payment_user_id':
 							$arguments['user_id'] = absint( $meta['value'] );
+							unset( $arguments['meta_query'][ $meta_index ] );
 							break;
 
 						case '_edd_payment_user_email':
 							$arguments['email'] = sanitize_email( $meta['value'] );
+							unset( $arguments['meta_query'][ $meta_index ] );
 							break;
 
 						case '_edd_payment_gateway':
 							$arguments['gateway'] = sanitize_text_field( $meta['value'] );
+							unset( $arguments['meta_query'][ $meta_index ] );
+							break;
+
+						case '_edd_payment_purchase_key' :
+							$arguments['payment_key'] = sanitize_text_field( $meta['value'] );
+							unset( $arguments['meta_query'][ $meta_index ] );
 							break;
 					}
 				}


### PR DESCRIPTION
Fixes #8623

Proposed Changes:
1. Add `_edd_payment_purchase_key` to remapping. That will look for it in the orders table instead of meta.
2. After remapping a meta query clause to the orders table, unset that meta query so it doesn't look in meta anymore.
3. BerlinDB: check if `where` is empty before using. See https://github.com/berlindb/core/issues/101