### PR TITLE
Move amount sanitization to BerlinDB schema settings #8609

### DIFF
--- a/includes/database/schemas/class-order-adjustments.php
+++ b/includes/database/schemas/class-order-adjustments.php
@@ -118,7 +118,8 @@ class Order_Adjustments extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// tax
@@ -127,7 +128,8 @@ class Order_Adjustments extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// total
@@ -136,7 +138,8 @@ class Order_Adjustments extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// date_created

--- a/includes/database/schemas/class-order-items.php
+++ b/includes/database/schemas/class-order-items.php
@@ -138,7 +138,8 @@ class Order_Items extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// subtotal
@@ -147,7 +148,8 @@ class Order_Items extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// discount
@@ -156,7 +158,8 @@ class Order_Items extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// tax
@@ -165,7 +168,8 @@ class Order_Items extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// total
@@ -174,7 +178,8 @@ class Order_Items extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// date_created

--- a/includes/database/schemas/class-orders.php
+++ b/includes/database/schemas/class-orders.php
@@ -162,7 +162,8 @@ class Orders extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// discount
@@ -171,7 +172,8 @@ class Orders extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// tax
@@ -180,7 +182,8 @@ class Orders extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// total
@@ -189,7 +192,8 @@ class Orders extends Schema {
 			'type'       => 'decimal',
 			'length'     => '18,9',
 			'default'    => '0',
-			'sortable'   => true
+			'sortable'   => true,
+			'validate'   => 'edd_sanitize_amount'
 		),
 
 		// date_created

--- a/includes/orders/functions/actions.php
+++ b/includes/orders/functions/actions.php
@@ -186,10 +186,10 @@ function edd_add_manual_order( $args = array() ) {
 			'currency'     => edd_get_currency(),
 			'payment_key'  => $data['payment_key'] ? sanitize_text_field( $data['payment_key'] ) : edd_generate_order_payment_key( $email ),
 			'tax_rate_id'  => ! empty( $tax_rate->id ) ? $tax_rate->id : null,
-			'subtotal'     => round( $order_subtotal, edd_currency_decimal_filter() ),
-			'tax'          => round( $order_tax, edd_currency_decimal_filter() ),
-			'discount'     => round( $order_discount, edd_currency_decimal_filter() ),
-			'total'        => round( $order_total, edd_currency_decimal_filter() ),
+			'subtotal'     => $order_subtotal,
+			'tax'          => $order_tax,
+			'discount'     => $order_discount,
+			'total'        => $order_total,
 			'date_created' => $date,
 		)
 	);
@@ -312,10 +312,10 @@ function edd_add_manual_order( $args = array() ) {
 				'status'       => 'complete',
 				'quantity'     => $quantity,
 				'amount'       => $amount,
-				'subtotal'     => round( $subtotal, edd_currency_decimal_filter() ),
-				'discount'     => round( $discount, edd_currency_decimal_filter() ),
-				'tax'          => round( $tax, edd_currency_decimal_filter() ),
-				'total'        => round( $total, edd_currency_decimal_filter() ),
+				'subtotal'     => $subtotal,
+				'discount'     => $discount,
+				'tax'          => $tax,
+				'total'        => $total,
 			) );
 
 			if ( false !== $order_item_id ) {
@@ -343,9 +343,9 @@ function edd_add_manual_order( $args = array() ) {
 							'type'        => sanitize_text_field( $order_item_adjustment['type'] ),
 							'type_key'    => $type_key,
 							'description' => sanitize_text_field( $order_item_adjustment['description'] ),
-							'subtotal'    => round( $order_item_adjustment_subtotal, edd_currency_decimal_filter() ),
-							'tax'         => round( $order_item_adjustment_tax, edd_currency_decimal_filter() ),
-							'total'       => round( $order_item_adjustment_total, edd_currency_decimal_filter() ),
+							'subtotal'    => $order_item_adjustment_subtotal,
+							'tax'         => $order_item_adjustment_tax,
+							'total'       => $order_item_adjustment_total,
 						) );
 					}
 				}
@@ -382,9 +382,9 @@ function edd_add_manual_order( $args = array() ) {
 				'type'        => sanitize_text_field( $adjustment['type'] ),
 				'type_key'    => $type_key,
 				'description' => sanitize_text_field( $adjustment['description'] ),
-				'subtotal'    => round( $adjustment_subtotal, edd_currency_decimal_filter() ),
-				'tax'         => round( $adjustment_tax, edd_currency_decimal_filter() ),
-				'total'       => round( $adjustment_total, edd_currency_decimal_filter() ),
+				'subtotal'    => $adjustment_subtotal,
+				'tax'         => $adjustment_tax,
+				'total'       => $adjustment_total,
 			) );
 		}
 	}
@@ -410,8 +410,8 @@ function edd_add_manual_order( $args = array() ) {
 				'type_id'     => intval( $discount['type_id'] ),
 				'type'        => 'discount',
 				'description' => sanitize_text_field( $discount['code'] ),
-				'subtotal'    => round( $discount_subtotal, edd_currency_decimal_filter() ),
-				'total'       => round( $discount_total, edd_currency_decimal_filter() ),
+				'subtotal'    => $discount_subtotal,
+				'total'       => $discount_total,
 			) );
 
 			// Increase discount usage.
@@ -427,7 +427,7 @@ function edd_add_manual_order( $args = array() ) {
 			'transaction_id' => sanitize_text_field( $data['transaction_id'] ),
 			'gateway'        => sanitize_text_field( $data['gateway'] ),
 			'status'         => 'complete',
-			'total'          => round( $order_total, edd_currency_decimal_filter() ),
+			'total'          => $order_total,
 		) );
 	}
 

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -982,9 +982,9 @@ function edd_build_order( $order_data = array() ) {
 						'type_key'    => $fee_id,
 						'type'        => 'fee',
 						'description' => $fee['label'],
-						'subtotal'    => round( $adjustment_subtotal, $decimal_filter ),
-						'tax'         => round( $tax, $decimal_filter ),
-						'total'       => round( $adjustment_total, $decimal_filter ),
+						'subtotal'    => $adjustment_subtotal,
+						'tax'         => $tax,
+						'total'       => $adjustment_total,
 					);
 
 					// Add the adjustment.
@@ -1033,9 +1033,9 @@ function edd_build_order( $order_data = array() ) {
 				'type_key'    => $fee_id,
 				'type'        => 'fee',
 				'description' => $fee['label'],
-				'subtotal'    => round( $fee_subtotal, $decimal_filter ),
-				'tax'         => round( $tax, $decimal_filter ),
-				'total'       => round( $fee_total, $decimal_filter ),
+				'subtotal'    => $fee_subtotal,
+				'tax'         => $tax,
+				'total'       => $fee_total,
 			);
 
 			// Add the adjustment.
@@ -1082,8 +1082,8 @@ function edd_build_order( $order_data = array() ) {
 					'type_id'     => $discount->id,
 					'type'        => 'discount',
 					'description' => $discount->code,
-					'subtotal'    => round( $discount_amount, $decimal_filter ),
-					'total'       => round( $discount_amount, $decimal_filter ),
+					'subtotal'    => $discount_amount,
+					'total'       => $discount_amount,
 				)
 			);
 		}
@@ -1120,10 +1120,10 @@ function edd_build_order( $order_data = array() ) {
 	// Update the order with all of the newly computed values.
 	edd_update_order( $order_id, array(
 		'order_number' => $order_args['order_number'],
-		'subtotal'     => round( $subtotal, $decimal_filter ),
-		'tax'          => round( $total_tax, $decimal_filter ),
-		'discount'     => round( $total_discount, $decimal_filter ),
-		'total'        => round( $order_total, $decimal_filter ),
+		'subtotal'     => $subtotal,
+		'tax'          => $total_tax,
+		'discount'     => $total_discount,
+		'total'        => $order_total,
 	) );
 
 	if ( edd_get_option( 'show_agree_to_terms', false ) && ! empty( $_POST['edd_agree_to_terms'] ) ) { // WPCS: CSRF ok.


### PR DESCRIPTION
Fixes #8609 

Proposed Changes:
1. Moves amount sanitization logic to BerlinDB, which means it will _always_ run prior to database insertion. This ensures payments created outside the normal checkout flow also get the same sanitization.

I chose `edd_sanitize_amount` amount for this, which handles rounding, but it also does a bunch of other stuff to strip thousand separators and whatnot. We should test this with non-standard decimal separators to make sure nothing breaks. Example:

- Set decimal separator to be a comma instead of a period.
- Make a purchase for $10.50.
- Make sure it shows up for the customer on the receipt, etc. as `10,50`, but it should be stored in the database as `10.50` (with more zeros at the end).

Other tests to run:

- The original issue: https://github.com/easydigitaldownloads/easy-digital-downloads/issues/8599
- Also, purchase a subscription for a non-standard amount like that. Then [trigger a Stripe renewal](https://github.com/easydigitaldownloads/edd-recurring/wiki/Stripe---Manually-Triggering-an-Automatic-Renewal) and make sure the amounts on the renewal payment are rounded.