### PR TITLE
Update Date constructor to match Carbon's #8586

### DIFF
--- a/includes/utils/class-date.php
+++ b/includes/utils/class-date.php
@@ -30,7 +30,7 @@ final class Date extends \Carbon\Carbon {
 	 * @since 3.0
 	 * @throws \Exception
 	 */
-	public function __construct( $time = 'now', \DateTimeZone $timezone = null ) {
+	public function __construct( $time = null, $timezone = null ) {
 		if ( null === $timezone ) {
 			$timezone = new \DateTimeZone( edd_get_timezone_id() );
 		}


### PR DESCRIPTION
Fixes #8586

Proposed Changes:
1. Updates the `Date` constructor to match's `Carbon`. This should not impact functionality, as `Carbon` treats both `now` and `null` as the same.