### PR TITLE
Update number settings sanitization

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1293,12 +1293,12 @@ function edd_settings_sanitize( $input = array() ) {
 					}
 
 					$setting_details = edd_get_registered_setting_details( $tab, $section, $key );
-					$number_type = false !== strpos( $setting_details['step'], '.' ) ? 'floatval' : 'intval';
-					$minimum   = $number_type( $setting_details['min'] );
-					$maximum   = $number_type( $setting_details['max'] );
-					$new_value = $number_type( $input[ $key ] );
+					$number_type     = ! empty( $setting_details['step'] ) && false !== strpos( $setting_details['step'], '.' ) ? 'floatval' : 'intval';
+					$minimum         = ! empty( $setting_details['min'] ) ? $number_type( $setting_details['min'] ) : false;
+					$maximum         = ! empty( $setting_details['max'] ) ? $number_type( $setting_details['max'] ) : false;
+					$new_value       = $number_type( $input[ $key ] );
 
-					if ( $minimum > $new_value || $maximum < $new_value ) {
+					if ( ( $minimum && $minimum > $new_value ) || ( $maximum && $maximum < $new_value ) ) {
 						unset( $output[ $key ] );
 					}
 					break;

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1298,7 +1298,7 @@ function edd_settings_sanitize( $input = array() ) {
 					$maximum         = ! empty( $setting_details['max'] ) ? $number_type( $setting_details['max'] ) : false;
 					$new_value       = $number_type( $input[ $key ] );
 
-					if ( ( $minimum && $minimum > $new_value ) || ( $maximum && $maximum < $new_value ) ) {
+					if ( ( false !== $minimum && $minimum > $new_value ) || ( false !== $maximum && $maximum < $new_value ) ) {
 						unset( $output[ $key ] );
 					}
 					break;

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -1294,8 +1294,8 @@ function edd_settings_sanitize( $input = array() ) {
 
 					$setting_details = edd_get_registered_setting_details( $tab, $section, $key );
 					$number_type     = ! empty( $setting_details['step'] ) && false !== strpos( $setting_details['step'], '.' ) ? 'floatval' : 'intval';
-					$minimum         = ! empty( $setting_details['min'] ) ? $number_type( $setting_details['min'] ) : false;
-					$maximum         = ! empty( $setting_details['max'] ) ? $number_type( $setting_details['max'] ) : false;
+					$minimum         = isset( $setting_details['min'] ) ? $number_type( $setting_details['min'] ) : false;
+					$maximum         = isset( $setting_details['max'] ) ? $number_type( $setting_details['max'] ) : false;
 					$new_value       = $number_type( $input[ $key ] );
 
 					if ( ( false !== $minimum && $minimum > $new_value ) || ( false !== $maximum && $maximum < $new_value ) ) {


### PR DESCRIPTION
Fixes #8612

Proposed Changes:
1. Make sure `step`, `min`, and `max` are available for using when sanitizing a number setting.
