### PR TITLE
Update refund validation to work more precisely

### DIFF
--- a/includes/orders/classes/class-refund-validator.php
+++ b/includes/orders/classes/class-refund-validator.php
@@ -264,7 +264,7 @@ class Refund_Validator {
 
 		// Overall refund total cannot be over total refundable amount.
 		$order_total = edd_get_order_total( $this->order->id );
-		if ( $this->total > $order_total ) {
+		if ( 1 === bccomp( $this->total, $order_total, 2 ) ) {
 			throw new Exception( sprintf(
 				/* Translators: %s - maximum refund amount as formatted currency */
 				__( 'The maximum refund amount is %s.', 'easy-digital-downloads' ),
@@ -346,6 +346,7 @@ class Refund_Validator {
 
 			// This is our fallback.
 			$attempted_amount = isset( $original_item->{$column_name} ) ? $original_item->{$column_name} : 0.00;
+			$maximum_amount   = floatval( $maximum_refundable_amounts[ $column_name ] );
 
 			// Only order items are included in the subtotal.
 			if ( ! $original_item instanceof Order_Item && 'subtotal' === $column_name ) {
@@ -357,7 +358,7 @@ class Refund_Validator {
 				$attempted_amount = $amounts_to_refund[ $column_name ];
 			}
 
-			if ( $attempted_amount > $maximum_refundable_amounts[ $column_name ] ) {
+			if ( 1 === bccomp( $attempted_amount, $maximum_amount, 2 ) ) {
 				if ( $original_item instanceof Order_Item ) {
 					$error_message = sprintf(
 						/*

--- a/includes/orders/classes/class-refund-validator.php
+++ b/includes/orders/classes/class-refund-validator.php
@@ -491,10 +491,6 @@ class Refund_Validator {
 
 	/**
 	 * Checks if the attempted refund amount is over the maximum allowed refund amount.
-	 * The calculation has to be done using a machine epsilon because when rational numbers
-	 * are converted to base 2, there is a small loss of precision.
-	 *
-	 * @see https://www.php.net/manual/en/language.types.float.php
 	 *
 	 * @since 3.0
 	 * @param float $attempted_amount The amount to refund.
@@ -502,15 +498,7 @@ class Refund_Validator {
 	 * @return boolean
 	 */
 	private function is_over_refund_amount( $attempted_amount, $maximum_amount ) {
-		/**
-		 * The machine epsilon, or unit roundoff--the smallest acceptable difference in calculations.
-		 * See https://www.php.net/manual/en/language.types.float.php
-		 *
-		 * @var float
-		 */
-		$epsilon = 0.00000001;
-
-		return ( ( $attempted_amount - $maximum_amount ) / $maximum_amount ) > $epsilon;
+		return edd_sanitize_amount( $attempted_amount ) > edd_sanitize_amount( $maximum_amount );
 	}
 }
 

--- a/includes/orders/classes/class-refund-validator.php
+++ b/includes/orders/classes/class-refund-validator.php
@@ -345,8 +345,8 @@ class Refund_Validator {
 			}
 
 			// This is our fallback.
-			$attempted_amount = isset( $original_item->{$column_name} ) ? floatval( $original_item->{$column_name} ) : 0.00;
-			$maximum_amount   = floatval( $maximum_refundable_amounts[ $column_name ] );
+			$attempted_amount = isset( $original_item->{$column_name} ) ? $original_item->{$column_name} : 0.00;
+			$maximum_amount   = $maximum_refundable_amounts[ $column_name ];
 
 			// Only order items are included in the subtotal.
 			if ( ! $original_item instanceof Order_Item && 'subtotal' === $column_name ) {
@@ -355,7 +355,7 @@ class Refund_Validator {
 
 			// But grab from specified amounts if available. It should always be available.
 			if ( isset( $amounts_to_refund[ $column_name ] ) ) {
-				$attempted_amount = floatval( $amounts_to_refund[ $column_name ] );
+				$attempted_amount = $amounts_to_refund[ $column_name ];
 			}
 
 			if ( $this->is_over_refund_amount( $attempted_amount, $maximum_amount ) ) {


### PR DESCRIPTION
Fixes #8634

Proposed Changes:
1. Use `bccomp` to compare the attempted refund amounts with the maximum refund amounts, because computers think in binary. See the related issue for more details.