### PR TITLE
Move admin notice dismissal back to user meta

### DIFF
--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -215,7 +215,7 @@ class EDD_Notices {
 
 		// Checkout page is missing
 		$purchase_page = edd_get_option( 'purchase_page', '' );
-		if ( empty( $purchase_page ) || ( 'trash' === get_post_status( $purchase_page ) ) && ! edd_get_option( 'dismissed_notice_checkout' ) ) {
+		if ( empty( $purchase_page ) || ( 'trash' === get_post_status( $purchase_page ) ) ) {
 			$this->add_notice( array(
 				'id'             => 'edd-no-purchase-page',
 				'message'        => sprintf( __( 'No checkout page is configured. Set one in <a href="%s">Settings</a>.', 'easy-digital-downloads' ), admin_url( 'edit.php?post_type=download&page=edd-settings&tab=general&section=pages' ) ),
@@ -253,11 +253,6 @@ class EDD_Notices {
 
 		// Bail if uploads directory is protected
 		if ( edd_is_uploads_url_protected() ) {
-			return;
-		}
-
-		// Bail if already permanently dismissed
-		if ( edd_get_option( 'dismissed_notice_uploads', false ) ) {
 			return;
 		}
 

--- a/includes/admin/class-edd-notices.php
+++ b/includes/admin/class-edd-notices.php
@@ -170,7 +170,7 @@ class EDD_Notices {
 		}
 
 		// Dismiss notice
-		edd_update_option( $key, 1 );
+		update_user_meta( get_current_user_id(), "_edd_{$key}_dismissed", 1 );
 		edd_redirect( remove_query_arg( array( 'edd_action', 'edd_notice', '_wpnonce' ) ) );
 		exit;
 	}


### PR DESCRIPTION
Fixes #8633

Proposed Changes:
1. Changes dismissal notice back to user meta instead of a site option to be consistent with EDD 2.x.
