### PR TITLE
Set currency validation to strtoupper

### DIFF
--- a/includes/database/schemas/class-orders.php
+++ b/includes/database/schemas/class-orders.php
@@ -135,7 +135,8 @@ class Orders extends Schema {
 		array(
 			'name'       => 'currency',
 			'type'       => 'varchar',
-			'length'     => '20'
+			'length'     => '20',
+			'validate'   => 'strtoupper',
 		),
 
 		// payment_key


### PR DESCRIPTION
Fixes #8646

Proposed Changes:
1. Add `validation` to order currencies in BerlinDB to cast currencies to uppercase.
