### PR TITLE
Remove extra serialization on order item meta

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -866,10 +866,6 @@ class Data_Migrator {
 					unset( $cart_item['item_number']['options']['quantity'] );
 
 					foreach ( $cart_item['item_number']['options'] as $option_key => $value ) {
-						if ( is_array( $value ) ) {
-							$value = maybe_serialize( $value );
-						}
-
 						$option_key = '_option_' . sanitize_key( $option_key );
 
 						edd_add_order_item_meta( $order_item_id, $option_key, $value );
@@ -909,10 +905,6 @@ class Data_Migrator {
 						unset( $cart_item['item_number']['options']['quantity'] );
 
 						foreach ( $cart_item['item_number']['options'] as $option_key => $value ) {
-							if ( is_array( $value ) ) {
-								$value = maybe_serialize( $value );
-							}
-
 							$option_key = '_option_' . sanitize_key( $option_key );
 
 							edd_add_order_item_meta( $refund_order_item_id, $option_key, $value );

--- a/includes/orders/functions/orders.php
+++ b/includes/orders/functions/orders.php
@@ -958,10 +958,6 @@ function edd_build_order( $order_data = array() ) {
 				unset( $item['item_number']['options']['quantity'] );
 
 				foreach ( $item['item_number']['options'] as $option_key => $value ) {
-					if ( is_array( $value ) ) {
-						$value = maybe_serialize( $value );
-					}
-
 					$option_key = '_option_' . sanitize_key( $option_key );
 
 					edd_add_order_item_meta( $order_item_id, $option_key, $value );


### PR DESCRIPTION
Fix #8422

Proposed Changes:
1. Remove extra serialization on order item meta during migration and new order creation.

To Test:
1. Run a migration on a data set with Recurring active (subscriptions). Check the order item meta table to make sure any `_option_recurring` metadata is saved as a serialized array, not a string.
2. Create a new order with a subscription. Check the order item meta.
