### PR TITLE
Add support for old get_x() methods #8655

### DIFF
--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -432,12 +432,6 @@ class EDD_Discount extends Adjustment {
 	public function __call( $method, $args ) {
 		$property = str_replace( array( 'setup_', 'get_' ), '', $method );
 		if ( ! method_exists( $this, $method ) ) {
-			// If a function exists for the determined property, use that.
-			if ( method_exists( $this, $property ) ) {
-				return call_user_func( array( $this, $property ), $args );
-			}
-
-			// Otherwise, use the property directly.
 			return $this->{$property};
 		}
 	}

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -430,7 +430,7 @@ class EDD_Discount extends Adjustment {
 	 * @return mixed
 	 */
 	public function __call( $method, $args ) {
-		$property = str_replace( array( 'setup_', 'get_' ), '', $method );
+		$property = strtolower( str_replace( array( 'setup_', 'get_' ), '', $method ) );
 		if ( ! method_exists( $this, $method ) && property_exists( $this, $property ) ) {
 			return $this->{$property};
 		}

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -430,9 +430,15 @@ class EDD_Discount extends Adjustment {
 	 * @return mixed
 	 */
 	public function __call( $method, $args ) {
-		$property = str_replace( 'setup_', '', $method );
-		if ( ! method_exists( $this, $method ) && property_exists( $this, $property ) ) {
-			return $this->{$property( $args )};
+		$property = str_replace( array( 'setup_', 'get_' ), '', $method );
+		if ( ! method_exists( $this, $method ) ) {
+			// If a function exists for the determined property, use that.
+			if ( method_exists( $this, $property ) ) {
+				return call_user_func( array( $this, $property ), $args );
+			}
+
+			// Otherwise, use the property directly.
+			return $this->{$property};
 		}
 	}
 

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -425,7 +425,7 @@ class EDD_Discount extends Adjustment {
 	 * Handle method dispatch dynamically.
 	 *
 	 * @param string $method Method name.
-	 * @param array $args Arguments to be passed to method.
+	 * @param array  $args   Arguments to be passed to method.
 	 *
 	 * @return mixed
 	 */

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -431,7 +431,7 @@ class EDD_Discount extends Adjustment {
 	 */
 	public function __call( $method, $args ) {
 		$property = str_replace( array( 'setup_', 'get_' ), '', $method );
-		if ( ! method_exists( $this, $method ) ) {
+		if ( ! method_exists( $this, $method ) && property_exists( $this, $property ) ) {
 			return $this->{$property};
 		}
 	}


### PR DESCRIPTION
Fixes #8655 

Proposed Changes:
1. Strip `get_` on incoming method calls. So `get_name()` becomes `name`. Then it falls into case 2 (below).
2. If a method doesn't exist but a property does, call the method. I updated the existing call for this logic. Previously it was passing `$args` to the property, which... doesn't work. It was treating the property like a method instead of a property. My fix actually treats it like a property.

To test:

See original issue. Test both `get_ID()` and `get_name()` methods.