### PR TITLE
Add Product filter to orders table & remove Sales Log #8658

### DIFF
--- a/includes/admin/downloads/dashboard-columns.php
+++ b/includes/admin/downloads/dashboard-columns.php
@@ -77,7 +77,12 @@ function edd_render_download_columns( $column_name, $post_id ) {
 			break;
 		case 'sales':
 			if ( current_user_can( 'view_product_stats', $post_id ) ) {
-				echo '<a href="' . esc_url( admin_url( 'edit.php?post_type=download&page=edd-tools&tab=logs&view=sales&download=' . $post_id ) ) . '">';
+				$sales_url = add_query_arg( array(
+					'page'       => 'edd-payment-history',
+					'product-id' => urlencode( $post_id )
+				), edd_get_admin_base_url() );
+
+				echo '<a href="' . esc_url( $sales_url ) . '">';
 					echo edd_get_download_sales_stats( $post_id );
 				echo '</a>';
 			} else {

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -1318,11 +1318,17 @@ function edd_render_stats_meta_box() {
 	}
 
 	$earnings = edd_get_download_earnings_stats( $post_id );
-	$sales    = edd_get_download_sales_stats( $post_id ); ?>
+	$sales    = edd_get_download_sales_stats( $post_id );
+
+	$sales_url = add_query_arg( array(
+		'page'       => 'edd-payment-history',
+		'product-id' => urlencode( $post_id )
+	), edd_get_admin_base_url() );
+	?>
 
 	<p class="product-sales-stats">
 		<span class="label"><?php _e( 'Sales:', 'easy-digital-downloads' ); ?></span>
-		<span><a href="<?php echo admin_url( '/edit.php?page=edd-tools&view=sales&post_type=download&tab=logs&download=' . $post_id ); ?>"><?php echo $sales; ?></a></span>
+		<span><a href="<?php echo esc_url( $sales_url ); ?>"><?php echo $sales; ?></a></span>
 	</p>
 
 	<p class="product-earnings-stats">

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -1328,7 +1328,7 @@ function edd_render_stats_meta_box() {
 
 	<p class="product-sales-stats">
 		<span class="label"><?php _e( 'Sales:', 'easy-digital-downloads' ); ?></span>
-		<span><a href="<?php echo esc_url( $sales_url ); ?>"><?php echo $sales; ?></a></span>
+		<span><a href="<?php echo esc_url( $sales_url ); ?>"><?php echo esc_html( $sales ); ?></a></span>
 	</p>
 
 	<p class="product-earnings-stats">

--- a/includes/admin/payments/class-payments-table.php
+++ b/includes/admin/payments/class-payments-table.php
@@ -130,6 +130,7 @@ class EDD_Payment_History_Table extends List_Table {
 		$order_total_filter_amount = isset( $_GET['order-amount-filter-value'] ) ? sanitize_text_field( $_GET['order-amount-filter-value'] ) : '';
 		$country                   = isset( $_GET['order-country-filter-value'] ) ? sanitize_text_field( $_GET['order-country-filter-value'] ) : '';
 		$region                    = isset( $_GET['order-region-filter-value'] ) ? sanitize_text_field( $_GET['order-region-filter-value'] ) : '';
+		$product_id                = ! empty( $_GET['product-id'] ) ? sanitize_text_field( $_GET['product-id'] ) : false;
 
 		$status     = $this->get_status();
 		$clear_url  = $this->base_url;
@@ -137,10 +138,6 @@ class EDD_Payment_History_Table extends List_Table {
 		// Filters
 		$all_modes    = edd_get_payment_modes();
 		$all_gateways = edd_get_payment_gateways();
-
-		// Advanced filters
-		$advanced_filters_applied = (bool) ! empty( $order_total_filter_amount ) || ! empty( $country ) || ! empty( $region );
-		$advanced_filters_applied = apply_filters( 'edd_orders_table_advanced_filters_applied', $advanced_filters_applied );
 
 		// No modes
 		if ( empty( $all_modes ) ) {
@@ -245,6 +242,19 @@ class EDD_Payment_History_Table extends List_Table {
 					?>
 
 					<input type="number" name="order-amount-filter-value" min="0" step="0.01" value="<?php echo esc_attr( $order_total_filter_amount ); ?>"/>
+				</fieldset>
+
+				<fieldset>
+					<legend><?php esc_html_e( 'Product', 'easy-digital-downloads' ); ?></legend>
+					<?php
+					echo EDD()->html->product_dropdown( array(
+						'id'         => 'orders-filter-product-id',
+						'name'       => 'product-id',
+						'chosen'     => true,
+						'selected'   => $product_id,
+						'variations' => true
+					) );
+					?>
 				</fieldset>
 
 				<fieldset>
@@ -867,6 +877,17 @@ class EDD_Payment_History_Table extends List_Table {
 						'compare' => $filter_type,
 					),
 				);
+			}
+		}
+
+		// Maybe filter by product.
+		if ( ! empty( $_GET['product-id'] ) ) {
+			if ( false !== strpos( $_GET['product-id'], '_' ) ) {
+				$product_pieces           = explode( '_', $_GET['product-id'] );
+				$args['product_id']       = absint( $product_pieces[0] );
+				$args['product_price_id'] = absint( $product_pieces[1] );
+			} else {
+				$args['product_id'] = absint( $_GET['product-id'] );
 			}
 		}
 

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1637,7 +1637,7 @@ function edd_redirect_sales_log() {
 			}
 		}
 
-		wp_safe_redirect( esc_url_raw( add_query_arg( $query_args ), edd_get_admin_base_url() ) );
+		wp_safe_redirect( esc_url_raw( add_query_arg( $query_args, edd_get_admin_base_url() ) ) );
 		exit;
 	}
 }

--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1615,6 +1615,35 @@ function edd_tools_sysinfo_download() {
 add_action( 'edd_download_sysinfo', 'edd_tools_sysinfo_download' );
 
 /**
+ * Redirects requests to the old sales log to the orders page.
+ *
+ * @since 3.0
+ */
+function edd_redirect_sales_log() {
+	if ( edd_is_admin_page( 'tools', 'logs' ) && ! empty( $_GET['view'] ) && 'sales' === $_GET['view'] ) {
+		$query_args = array(
+			'page' => 'edd-payment-history'
+		);
+
+		$args_to_remap = array(
+			'download'   => 'product-id',
+			'start-date' => 'start-date',
+			'end-date'   => 'end-date'
+		);
+
+		foreach( $args_to_remap as $old_arg => $new_arg ) {
+			if ( ! empty( $_GET[ $old_arg ] ) ) {
+				$query_args[ $new_arg ] = urlencode( $_GET[ $old_arg ] );
+			}
+		}
+
+		wp_safe_redirect( esc_url_raw( add_query_arg( $query_args ), edd_get_admin_base_url() ) );
+		exit;
+	}
+}
+add_action( 'admin_init', 'edd_redirect_sales_log' );
+
+/**
  * Renders the Logs tab in the Tools screen.
  *
  * @since 3.0

--- a/includes/admin/tools/logs.php
+++ b/includes/admin/tools/logs.php
@@ -88,6 +88,8 @@ function edd_logs_view_page( $logs_table, $tag = '' ) {
 /**
  * Sales Log View
  *
+ * @deprecated 3.0
+ *
  * @since 1.4
  * @uses EDD_Sales_Log_Table::prepare_items()
  * @uses EDD_Sales_Log_Table::display()
@@ -184,13 +186,13 @@ function edd_log_default_views() {
 	 * Filters the default logs views.
 	 *
 	 * @since 1.4
+	 * @since 3.0 Removed sales log.
 	 *
 	 * @param array $views Logs views. Each key/value pair represents the view slug
 	 *                     and label, respectively.
 	 */
 	return apply_filters( 'edd_log_views', array(
 		'file_downloads'  => __( 'File Downloads', 'easy-digital-downloads' ),
-		'sales' 		  => __( 'Sales',          'easy-digital-downloads' ),
 		'gateway_errors'  => __( 'Payment Errors', 'easy-digital-downloads' ),
 		'api_requests'    => __( 'API Requests',   'easy-digital-downloads' )
 	) );

--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -1355,7 +1355,7 @@ class Query extends Base {
 		if ( empty( $fields ) && ! empty( $this->query_vars['count'] ) ) {
 
 			// Possible fields to group by
-			$groupby_names = $this->parse_groupby( $this->query_vars['groupby'], true );
+			$groupby_names = $this->parse_groupby( $this->query_vars['groupby'], $alias );
 			$groupby_names = ! empty( $groupby_names )
 				? "{$groupby_names}"
 				: '';

--- a/includes/database/engine/class-query.php
+++ b/includes/database/engine/class-query.php
@@ -1355,7 +1355,7 @@ class Query extends Base {
 		if ( empty( $fields ) && ! empty( $this->query_vars['count'] ) ) {
 
 			// Possible fields to group by
-			$groupby_names = $this->parse_groupby( $this->query_vars['groupby'], false );
+			$groupby_names = $this->parse_groupby( $this->query_vars['groupby'], true );
 			$groupby_names = ! empty( $groupby_names )
 				? "{$groupby_names}"
 				: '';

--- a/includes/database/queries/class-order.php
+++ b/includes/database/queries/class-order.php
@@ -172,6 +172,8 @@ class Order extends Query {
 	 *     @type bool         $update_cache          Whether to prime the cache for found orders. Default false.
 	 *     @type string       $country               Limit results to those affiliated with a given country. Default empty.
 	 *     @type string       $region                Limit results to those affiliated with a given region. Default empty.
+	 *     @type int          $product_id            Filter by product ID. Default empty.
+	 *     @type int          $product_price_id      Filter by product price ID. Default empty.
 	 * }
 	 */
 	public function __construct( $query = array() ) {


### PR DESCRIPTION
Fixes #8658

Proposed Changes:
1. Updates old "Sales" links to point to orders page with a product filter.
2. `class-payments-table.php`
    - Removed unused variables.
    - Add support for product ID filter.
    - Add new "Product" filter in advanced filters.
3. Redirects page requests from the old sales log to the orders page (supporting 3 existing query args in the redirect).
4. BerlinDB (`database/engine/class-query.php`) - Set the second `parse_groupby()` parameter to `true`, which just prefixes the column name with the table alias. This fixes an ambiguous column error when doing a join and groupby at the same time.
5. `database/queries/class-order.php`
    - Adds new `query_by_product()` parameter, and adds support for two new query args: `product_id` and `product_price_id`. If either of these are set, we join on the order items table to get that information.
    - Reworked the `query_by_country()` logic to stop merging the WHERE clause onto the JOIN. This was a bad idea and doesn't work when you have multiple joins (querying by product + country at the same time).

## Testing

- Test new product filter.
    - Test a regular product.
    - Test a variable priced product.
    - Test combining a product filter with a country filter.
- Attempt to visit old sales log manually and check that you are redirected to orders. (Might be easiest to visit it on `release/3.0`, set it up how you want, then check out this branch and refresh.)