### PR TITLE
Refactor download recount stats tools to exclude refunds #8659

### DIFF
--- a/includes/admin/downloads/dashboard-columns.php
+++ b/includes/admin/downloads/dashboard-columns.php
@@ -28,13 +28,13 @@ function edd_download_columns( $download_columns ) {
 
 	return apply_filters( 'edd_download_columns', array(
 		'cb'                => '<input type="checkbox"/>',
-		'title'             => __( 'Name',     'easy-digital-downloads' ),
+		'title'             => __( 'Name', 'easy-digital-downloads' ),
 		'download_category' => $category_labels['menu_name'],
 		'download_tag'      => $tag_labels['menu_name'],
-		'price'             => __( 'Price',    'easy-digital-downloads' ),
-		'sales'             => __( 'Sales',    'easy-digital-downloads' ),
-		'earnings'          => __( 'Earnings', 'easy-digital-downloads' ),
-		'date'              => __( 'Date',     'easy-digital-downloads' )
+		'price'             => __( 'Price', 'easy-digital-downloads' ),
+		'sales'             => __( 'Sales', 'easy-digital-downloads' ),
+		'earnings'          => __( 'Gross Revenue', 'easy-digital-downloads' ),
+		'date'              => __( 'Date', 'easy-digital-downloads' )
 	) );
 }
 add_filter( 'manage_edit-download_columns', 'edd_download_columns' );

--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -1326,7 +1326,7 @@ function edd_render_stats_meta_box() {
 	</p>
 
 	<p class="product-earnings-stats">
-		<span class="label"><?php _e( 'Earnings:', 'easy-digital-downloads' ); ?></span>
+		<span class="label"><?php esc_html_e( 'Gross Revenue:', 'easy-digital-downloads' ); ?></span>
 		<span><a href="<?php echo admin_url( 'edit.php?post_type=download&page=edd-reports&view=downloads&download-id=' . $post_id ); ?>"><?php echo edd_currency_filter( edd_format_amount( $earnings ) ); ?></a></span>
 	</p>
 

--- a/includes/admin/reporting/export/class-batch-export.php
+++ b/includes/admin/reporting/export/class-batch-export.php
@@ -22,6 +22,13 @@ defined( 'ABSPATH' ) || exit;
 class EDD_Batch_Export extends EDD_Export {
 
 	/**
+	 * Whether or not we're done processing.
+	 *
+	 * @var bool
+	 */
+	public $done;
+
+	/**
 	 * The file the data is stored in
 	 *
 	 * @since 2.4

--- a/includes/admin/tools/class-edd-tools-recount-all-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-all-stats.php
@@ -5,7 +5,7 @@
  * This class handles batch processing of recounting earnings and stats for all downloads and store totals
  *
  * @subpackage  Admin/Tools/EDD_Tools_Recount_All_Stats
- * @copyright   Copyright (c) 2015, Chris Klosowski
+ * @copyright   Copyright (c) 2021, Sandhills Development, LLC
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since       2.5
  */
@@ -13,136 +13,21 @@
 // Exit if accessed directly
 defined( 'ABSPATH' ) || exit;
 
+if ( ! class_exists( 'EDD_Tools_Recount_Download_Stats' ) ) {
+	require_once EDD_PLUGIN_DIR . 'includes/admin/tools/class-edd-tools-recount-download-stats.php';
+}
+
 /**
  * EDD_Tools_Recount_All_Stats Class
  *
  * @since 2.5
  */
-class EDD_Tools_Recount_All_Stats extends EDD_Batch_Export {
+class EDD_Tools_Recount_All_Stats extends EDD_Tools_Recount_Download_Stats {
 
 	/**
-	 * Our export type. Used for export-type specific filters/actions
-	 * @var string
-	 * @since 2.5
+	 * @var int[]
 	 */
-	public $export_type = '';
-
-	/**
-	 * Allows for a non-download batch processing to be run.
-	 * @since  2.5
-	 * @var boolean
-	 */
-	public $is_void = true;
-
-	/**
-	 * Sets the number of items to pull on each step
-	 * @since  2.5
-	 * @var integer
-	 */
-	public $per_step = 30;
-
-	/**
-	 * ID of the download we're recounting stats for
-	 * @var int|false
-	 */
-	protected $download_id = false;
-
-	/**
-	 * Get the Export Data
-	 *
-	 * @since 2.5
-	 * @global object $wpdb Used to query the database using the WordPress
-	 *   Database API
-	 * @return True if results were found for this batch, false if not.
-	 */
-	public function get_data() {
-
-		$totals             = $this->get_stored_data( 'edd_temp_recount_all_stats'  );
-		$payment_items      = $this->get_stored_data( 'edd_temp_payment_items'      );
-		$processed_payments = $this->get_stored_data( 'edd_temp_processed_payments' );
-		$accepted_statuses  = apply_filters( 'edd_recount_accepted_statuses', array( 'complete', 'revoked' ) );
-
-		if ( false === $totals ) {
-			$totals = array();
-		}
-
-		if ( false === $payment_items ) {
-			$payment_items = array();
-		}
-
-		if ( false === $processed_payments ) {
-			$processed_payments = array();
-		}
-
-		$all_downloads = $this->get_stored_data( 'edd_temp_download_ids' );
-
-		$deprecated_args = edd_apply_filters_deprecated( 'edd_recount_download_stats_args', array(
-			array(
-				'post_parent__in' => $all_downloads,
-				'post_type'       => 'edd_log',
-				'posts_per_page'  => $this->per_step,
-				'post_status'     => 'complete',
-				'paged'           => $this->step,
-				'log_type'        => 'sale',
-				'fields'          => 'ids',
-			)
-		), '3.0' );
-
-		$new_args = array(
-			'product_id__in' => $all_downloads,
-			'status__in'     => $accepted_statuses,
-			'number'         => $deprecated_args['posts_per_page'],
-			'offset'         => ( $deprecated_args['paged'] * $deprecated_args['posts_per_page'] ) - $deprecated_args['posts_per_page']
-		);
-
-		$order_items = edd_get_order_items( $new_args );
-
-		if ( $order_items ) {
-			foreach ( $order_items as $order_item ) {
-
-				// Prevent payments that have all ready been retrieved from a previous sales log from counting again.
-				if ( in_array( $order_item->id, $processed_payments ) ) {
-					continue;
-				}
-
-				if ( ! in_array( $order_item->status, $accepted_statuses ) ) {
-					$processed_payments[] = $order_item->id;
-					continue;
-				}
-
-				$download_id = $order_item->product_id;
-
-				if ( ! in_array( $download_id, $all_downloads ) ) {
-					continue;
-				}
-
-				if ( ! array_key_exists( $download_id, $totals ) ) {
-					$totals[ $download_id ] = array(
-						'sales'    => (int) 0,
-						'earnings' => (float) 0,
-					);
-				}
-
-				$totals[ $download_id ]['sales']++;
-				$totals[ $download_id ]['earnings'] += $order_item->total;
-
-				$processed_payments[] = $order_item->id;
-			}
-
-			$this->store_data( 'edd_temp_processed_payments', $processed_payments );
-			$this->store_data( 'edd_temp_recount_all_stats', $totals );
-
-			return true;
-		}
-
-		foreach ( $totals as $key => $stats ) {
-			update_post_meta( $key, '_edd_download_sales'   , $stats['sales'] );
-			update_post_meta( $key, '_edd_download_earnings', $stats['earnings'] );
-		}
-
-		return false;
-
-	}
+	private $download_ids;
 
 	/**
 	 * Return the calculated completion percentage
@@ -151,35 +36,24 @@ class EDD_Tools_Recount_All_Stats extends EDD_Batch_Export {
 	 * @return int
 	 */
 	public function get_percentage_complete() {
-
-		$total = $this->get_stored_data( 'edd_recount_all_total' );
-
-		if ( false === $total ) {
-			$this->pre_fetch();
-			$total = $this->get_stored_data( 'edd_recount_all_total' );
-		}
-
 		$percentage = 100;
 
-		if( $total > 0 ) {
+		$query = new WP_Query( array(
+			'post_status' => 'any',
+			'post_type'   => 'download',
+			'fields'      => 'ids'
+		) );
+		$total = $query->post_count;
+
+		if ( $total > 0 ) {
 			$percentage = ( ( $this->per_step * $this->step ) / $total ) * 100;
 		}
 
-		if( $percentage > 100 ) {
+		if ( $percentage > 100 ) {
 			$percentage = 100;
 		}
 
 		return $percentage;
-	}
-
-	/**
-	 * Set the properties specific to the payments export
-	 *
-	 * @since 2.5
-	 * @param array $request The Form Data passed into the batch processing
-	 */
-	public function set_properties( $request ) {
-		$this->download_id = isset( $request['download_id'] ) ? sanitize_text_field( $request['download_id'] ) : false;
 	}
 
 	/**
@@ -189,14 +63,20 @@ class EDD_Tools_Recount_All_Stats extends EDD_Batch_Export {
 	 * @return bool
 	 */
 	public function process_step() {
-
 		if ( ! $this->can_export() ) {
-			wp_die( __( 'You do not have permission to export data.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+			wp_die( __( 'You do not have permission to perform this action.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 		}
 
-		$had_data = $this->get_data();
+		$download_ids = $this->get_download_ids();
 
-		if( $had_data ) {
+		if ( ! empty( $download_ids ) && is_array( $download_ids ) ) {
+			foreach ( $this->get_download_ids() as $download_id ) {
+				$this->download_id = $download_id;
+				$this->get_data();
+			}
+		}
+
+		if ( ! empty( $download_ids ) ) {
 			$this->done = false;
 			return true;
 		} else {
@@ -211,152 +91,25 @@ class EDD_Tools_Recount_All_Stats extends EDD_Batch_Export {
 		}
 	}
 
-	public function headers() {
-		edd_set_time_limit();
-	}
-
 	/**
-	 * Perform the export
+	 * Returns the download IDs to process during this step.
 	 *
-	 * @since 2.5
-	 * @return void
+	 * @since 3.0
+	 *
+	 * @return int[]
 	 */
-	public function export() {
-
-		// Set headers
-		$this->headers();
-
-		edd_die();
-	}
-
-	public function pre_fetch() {
-
-		if ( $this->step == 1 ) {
-			$this->delete_data( 'edd_temp_recount_all_total' );
-			$this->delete_data( 'edd_temp_recount_all_stats' );
-			$this->delete_data( 'edd_temp_payment_items' );
-			$this->delete_data( 'edd_temp_processed_payments' );
+	private function get_download_ids() {
+		if ( null === $this->download_ids ) {
+			$this->download_ids = get_posts( array(
+				'post_status'    => 'any',
+				'post_type'      => 'download',
+				'posts_per_page' => $this->per_step,
+				'offset'         => ( $this->step - 1 ) * $this->per_step,
+				'fields'         => 'ids',
+			) );
 		}
 
-		$accepted_statuses = apply_filters( 'edd_recount_accepted_statuses', array( 'complete', 'revoked' ) );
-		$total             = $this->get_stored_data( 'edd_temp_recount_all_total' );
-
-		if ( false === $total ) {
-			$total         = 0;
-			$payment_items = $this->get_stored_data( 'edd_temp_payment_items' );
-
-			if ( false === $payment_items ) {
-				$payment_items = array();
-				$this->store_data( 'edd_temp_payment_items', $payment_items );
-			}
-
-			$all_downloads = $this->get_stored_data( 'edd_temp_download_ids' );
-
-			if ( false === $all_downloads ) {
-				$args = array(
-					'post_status'    => 'any',
-					'post_type'      => 'download',
-					'posts_per_page' => -1,
-					'fields'         => 'ids',
-				);
-
-				$all_downloads = get_posts( $args );
-				$this->store_data( 'edd_temp_download_ids', $all_downloads );
-
-				if ( $this->step == 1 ) {
-					foreach ( $all_downloads as $download ) {
-						update_post_meta( $download, '_edd_download_sales'   , 0 );
-						update_post_meta( $download, '_edd_download_earnings', 0 );
-					}
-				}
-			}
-
-			$deprecated_args = edd_apply_filters_deprecated( 'edd_recount_download_stats_total_args', array(
-				array(
-					'post_parent__in' => $all_downloads,
-					'post_type'       => 'edd_log',
-					'post_status'     => 'complete',
-					'log_type'        => 'sale',
-					'fields'          => 'ids',
-					'nopaging'        => true,
-				)
-			), '3.0' );
-
-			$new_args = array(
-				'status__in' => $accepted_statuses,
-			);
-
-			if ( ! empty( $deprecated_args['post_parent__in'] ) && is_array( $deprecated_args['post_parent__in'] ) ) {
-				$new_args['product_id__in'] = $deprecated_args['post_parent__in'];
-			}
-
-			$total = edd_count_order_items( $new_args );
-
-			$this->store_data( 'edd_temp_payment_items', $payment_items );
-			$this->store_data( 'edd_recount_all_total' , $total );
-		}
-
-	}
-
-	/**
-	 * Given a key, get the information from the Database Directly
-	 *
-	 * @since  2.5
-	 * @param  string $key The option_name
-	 * @return mixed       Returns the data from the database
-	 */
-	private function get_stored_data( $key ) {
-		global $wpdb;
-		$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = '%s'", $key ) );
-
-		if ( empty( $value ) ) {
-			return false;
-		}
-
-		$maybe_json = json_decode( $value );
-		if ( ! is_null( $maybe_json ) ) {
-			$value = json_decode( $value, true );
-		}
-
-		return $value;
-	}
-
-	/**
-	 * Give a key, store the value
-	 *
-	 * @since  2.5
-	 * @param  string $key   The option_name
-	 * @param  mixed  $value  The value to store
-	 * @return void
-	 */
-	private function store_data( $key, $value ) {
-		global $wpdb;
-
-		$value = is_array( $value ) ? wp_json_encode( $value ) : esc_attr( $value );
-
-		$data = array(
-			'option_name'  => $key,
-			'option_value' => $value,
-			'autoload'     => 'no',
-		);
-
-		$formats = array(
-			'%s', '%s', '%s',
-		);
-
-		$wpdb->replace( $wpdb->options, $data, $formats );
-	}
-
-	/**
-	 * Delete an option
-	 *
-	 * @since  2.5
-	 * @param  string $key The option_name to delete
-	 * @return void
-	 */
-	private function delete_data( $key ) {
-		global $wpdb;
-		$wpdb->delete( $wpdb->options, array( 'option_name' => $key ) );
+		return $this->download_ids;
 	}
 
 }

--- a/includes/admin/tools/class-edd-tools-recount-all-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-all-stats.php
@@ -37,13 +37,7 @@ class EDD_Tools_Recount_All_Stats extends EDD_Tools_Recount_Download_Stats {
 	 */
 	public function get_percentage_complete() {
 		$percentage = 100;
-
-		$query = new WP_Query( array(
-			'post_status' => 'any',
-			'post_type'   => 'download',
-			'fields'      => 'ids'
-		) );
-		$total = $query->post_count;
+		$total      = array_sum( (array) wp_count_posts( 'download' ) );
 
 		if ( $total > 0 ) {
 			$percentage = ( ( $this->per_step * $this->step ) / $total ) * 100;

--- a/includes/admin/tools/class-edd-tools-recount-download-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-download-stats.php
@@ -102,10 +102,10 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 
 		$results = $wpdb->get_row(
 			"SELECT SUM(oi.total) AS revenue, COUNT(oi.id) AS sales
-					FROM {$wpdb->edd_order_items} oi
-					INNER JOIN {$wpdb->edd_orders} o ON(o.id = oi.order_id)
-					WHERE o.type = 'sale'
-					{$conditions}"
+				FROM {$wpdb->edd_order_items} oi
+				INNER JOIN {$wpdb->edd_orders} o ON(o.id = oi.order_id)
+				WHERE o.type = 'sale'
+				{$conditions}"
 		);
 
 		$sales    = ! empty( $results->sales ) ? intval( $results->sales ) : 0;

--- a/includes/admin/tools/class-edd-tools-recount-download-stats.php
+++ b/includes/admin/tools/class-edd-tools-recount-download-stats.php
@@ -5,7 +5,7 @@
  * This class handles batch processing of recounting earnings and stats
  *
  * @subpackage  Admin/Tools/EDD_Tools_Recount_Stats
- * @copyright   Copyright (c) 2015, Chris Klosowski
+ * @copyright   Copyright (c) 2021, Sandhills Development, LLC
  * @license     http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since       2.5
  */
@@ -42,16 +42,15 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 	public $per_step = 30;
 
 	/**
+	 * @var string
+	 */
+	public $message = '';
+
+	/**
 	 * ID of the download we're recounting stats for
 	 * @var int|false
 	 */
 	protected $download_id = false;
-
-	/**
-	 * Array or order IDs found from the query
-	 * @var array
-	 */
-	protected $_log_ids_debug = array();
 
 	/**
 	 * Get the Export Data
@@ -63,22 +62,9 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 	 */
 	public function get_data() {
 
-		$accepted_statuses  = apply_filters( 'edd_recount_accepted_statuses', array( 'complete', 'revoked' ) );
+		$accepted_statuses = apply_filters( 'edd_recount_accepted_statuses', edd_get_gross_order_statuses() );
 
-		if ( $this->step == 1 ) {
-			$this->delete_data( 'edd_temp_recount_download_stats' );
-		}
-
-		$totals = $this->get_stored_data( 'edd_temp_recount_download_stats' );
-
-		if ( false === $totals ) {
-			$totals = array(
-				'earnings' => (float) 0,
-				'sales'    => 0,
-			);
-			$this->store_data( 'edd_temp_recount_download_stats', $totals );
-		}
-
+		// These arguments are no longer used, but keeping the filter here to apply the deprecation notice.
 		$deprecated_args = edd_apply_filters_deprecated( 'edd_recount_download_stats_args', array(
 			array(
 				'post_parent'    => $this->download_id,
@@ -91,38 +77,42 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 			)
 		), '3.0' );
 
-		$new_args = array(
-			'status__in' => $accepted_statuses,
-			'number'     => $deprecated_args['posts_per_page'],
-			'offset'     => ( $deprecated_args['paged'] * $deprecated_args['posts_per_page'] ) - $deprecated_args['posts_per_page']
-		);
+		global $wpdb;
+
+		/*
+		 * Build up our WHERE clauses.
+		 */
+		$conditions = array();
+
+		if ( ! empty( $accepted_statuses ) && is_array( $accepted_statuses ) ) {
+			$placeholder_string = implode( ', ', array_fill( 0, count( $accepted_statuses ), '%s' ) );
+			$conditions[]       = $wpdb->prepare(
+				"oi.status IN({$placeholder_string})",
+				$accepted_statuses
+			);
+		}
 
 		if ( ! empty( $this->download_id ) && is_numeric( $this->download_id ) ) {
-			$new_args['product_id'] = absint( $this->download_id );
+			$conditions[] = $wpdb->prepare(
+				"oi.product_id = %d",
+				$this->download_id
+			);
 		}
+		$conditions = ! empty( $conditions ) ? ' AND ' . implode( ' AND ', $conditions ) : '';
 
-		$order_items = edd_get_order_items( $new_args );
+		$results = $wpdb->get_row(
+			"SELECT SUM(oi.total) AS revenue, COUNT(oi.id) AS sales
+					FROM {$wpdb->edd_order_items} oi
+					INNER JOIN {$wpdb->edd_orders} o ON(o.id = oi.order_id)
+					WHERE o.type = 'sale'
+					{$conditions}"
+		);
 
-		$this->_log_ids_debug = array();
+		$sales    = ! empty( $results->sales ) ? intval( $results->sales ) : 0;
+		$earnings = ! empty( $results->revenue ) ? edd_sanitize_amount( $results->revenue ) : 0.00;
 
-		if ( $order_items ) {
-			foreach ( $order_items as $order_item ) {
-
-				$this->_log_ids_debug[] = $order_item->order_id;
-
-				$totals['sales']++;
-				$totals['earnings'] += $order_item->total;
-
-			}
-
-			$this->store_data( 'edd_temp_recount_download_stats', $totals );
-
-			return true;
-		}
-
-
-		update_post_meta( $this->download_id, '_edd_download_sales'   , $totals['sales'] );
-		update_post_meta( $this->download_id, '_edd_download_earnings', $totals['earnings'] );
+		update_post_meta( $this->download_id, '_edd_download_sales', $sales );
+		update_post_meta( $this->download_id, '_edd_download_earnings', sanitize_text_field( $earnings ) );
 
 		return false;
 
@@ -135,50 +125,7 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 	 * @return int
 	 */
 	public function get_percentage_complete() {
-
-		if ( $this->step == 1 ) {
-			$this->delete_data( 'edd_recount_total_' . $this->download_id );
-		}
-
-		$accepted_statuses  = apply_filters( 'edd_recount_accepted_statuses', array( 'complete', 'revoked' ) );
-		$total   = $this->get_stored_data( 'edd_recount_total_' . $this->download_id );
-
-		if ( false === $total ) {
-			$deprecated_args = edd_apply_filters_deprecated( 'edd_recount_download_stats_total_args', array(
-				array(
-					'post_parent'    => $this->download_id,
-					'post_type'      => 'edd_log',
-					'post_status'    => 'publish',
-					'log_type'       => 'sale',
-					'fields'         => 'ids',
-					'nopaging'       => true,
-				)
-			), '3.0' );
-
-			$new_args = array(
-				'status__in' => $accepted_statuses,
-			);
-
-			if ( ! empty( $deprecated_args['post_parent'] ) && is_numeric( $deprecated_args['post_parent'] ) ) {
-				$new_args['product_id'] = absint( $deprecated_args['post_parent'] );
-			}
-
-			$total = edd_count_order_items( $new_args );
-
-			$this->store_data( 'edd_recount_total_' . $this->download_id, $total );
-		}
-
-		$percentage = 100;
-
-		if( $total > 0 ) {
-			$percentage = ( ( $this->per_step * $this->step ) / $total ) * 100;
-		}
-
-		if( $percentage > 100 ) {
-			$percentage = 100;
-		}
-
-		return $percentage;
+		return 100;
 	}
 
 	/**
@@ -198,14 +145,13 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 	 * @return bool
 	 */
 	public function process_step() {
-
 		if ( ! $this->can_export() ) {
-			wp_die( __( 'You do not have permission to export data.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
+			wp_die( __( 'You do not have permission to perform this action.', 'easy-digital-downloads' ), __( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 ) );
 		}
 
-		$had_data = $this->get_data();
+		$more_to_do = $this->get_data();
 
-		if( $had_data ) {
+		if( $more_to_do ) {
 			$this->done = false;
 			return true;
 		} else {
@@ -236,62 +182,13 @@ class EDD_Tools_Recount_Download_Stats extends EDD_Batch_Export {
 	}
 
 	/**
-	 * Given a key, get the information from the Database Directly
-	 *
-	 * @since  2.5
-	 * @param  string $key The option_name
-	 * @return mixed       Returns the data from the database
-	 */
-	private function get_stored_data( $key ) {
-		global $wpdb;
-		$value = $wpdb->get_var( $wpdb->prepare( "SELECT option_value FROM $wpdb->options WHERE option_name = '%s'", $key ) );
-
-		if ( empty( $value ) ) {
-			return false;
-		}
-
-		$maybe_json = json_decode( $value );
-		if ( ! is_null( $maybe_json ) ) {
-			$value = json_decode( $value, true );
-		}
-
-		return $value;
-	}
-
-	/**
-	 * Give a key, store the value
-	 *
-	 * @since  2.5
-	 * @param  string $key   The option_name
-	 * @param  mixed  $value  The value to store
-	 * @return void
-	 */
-	private function store_data( $key, $value ) {
-		global $wpdb;
-
-		$value = is_array( $value ) ? wp_json_encode( $value ) : esc_attr( $value );
-
-		$data = array(
-			'option_name'  => $key,
-			'option_value' => $value,
-			'autoload'     => 'no',
-		);
-
-		$formats = array(
-			'%s', '%s', '%s',
-		);
-
-		$wpdb->replace( $wpdb->options, $data, $formats );
-	}
-
-	/**
 	 * Delete an option
 	 *
 	 * @since  2.5
 	 * @param  string $key The option_name to delete
 	 * @return void
 	 */
-	private function delete_data( $key ) {
+	protected function delete_data( $key ) {
 		global $wpdb;
 		$wpdb->delete( $wpdb->options, array( 'option_name' => $key ) );
 	}


### PR DESCRIPTION
Fixes #8659 

## Proposed Changes:

1. Renames the `Earnings` download column to `Gross Revenue`.
2. `EDD_Batch_Export` - add public `$done` property. This was previously being set dynamically and it bugged me.
3. `EDD_Tools_Recount_Download_Stats` This has been heavily refactored.
    - It now just does a direct database query with `SUM` and `COUNT` instead of looping over all items. This means there are no steps; it's all done in one single step.
    - Because there are no steps, all step stashing/retrieving has been removed. I left the delete stuff in, just in case someone still has leftover step data from previous runs. This just cleans them up in case they're still there.
    - For the query itself, order items with a status in `edd_get_gross_order_statuses()` are counted. We join on the orders table to ensure we only pick up **sales** and not refunds.
4. `EDD_Tools_Recount_All_Stats` This class now extends `EDD_Tools_Recount_Download_Stats` to avoid code duplication. The primary thing used for stepping logic is downloads. So each step recounts 30 downloads. The logic for recounting the stats for an individual download is actually done by `EDD_Tools_Recount_Download_Stats`. So essentially the only thing this class now does is loop over the downloads that need processing, then calls the parent class to calculate the stats for that download.

---

## Testing

- Run the recount tool (Downloads > Tools) for a specific download. Check the new numbers and make sure they match what you expect. As a reminder, the numbers should be all sales for that item where the status is one of: `complete`, `refunded`, `partially_refunded`, `revoked`.
- Run the recount tool (Downloads > Tools) for _all_ downloads. Check the new numbers and make sure they match what you expect.