### PR TITLE
#8524 Remove deprecation notice 

### DIFF
--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1942,7 +1942,7 @@ class EDD_Payment {
 			unset( $update_fields['ID'] );
 
 			/**
-			 * As per the new refund API introduce in 3.0, the order is only
+			 * As per the new refund API introduced in 3.0, the order is only
 			 * marked as refunded when `EDD_Payment::process_refund()` has called
 			 * `edd_refund_order()` and a new order has been generated with a
 			 * type of `refund`.
@@ -1992,10 +1992,6 @@ class EDD_Payment {
 
 			if ( 'complete' === $old_status ) {
 				// Trigger the action again to account for add-ons listening for status changes from "publish".
-
-				if ( apply_filters( 'edd_show_deprecated_notices', ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) ) {
-					_edd_generic_deprecated( 'edd_update_payment_status', '3.0', __( 'The "publish" payment status has been replaced with "complete". Please check for both when listening for status changes.', 'easy-digital-downloads' ) );
-				}
 
 				do_action( 'edd_update_payment_status', $this->ID, $status, 'publish' );
 			}


### PR DESCRIPTION
Fixes #8524 

Proposed Changes:
1. Remove deprecation notice when changing order status to prevent excessive notifications
2. Fix typo in comment

> I wonder if we should just remove the notice completely and convey deprecation through the blog (which we may have already done anyway).

I checked the dev blog and found this from the [beta-1 post](https://easydigitaldownloads.com/development/2021/02/16/edd-3-0-beta1/):

```
Querying for payment/order records
...
// Valid in both 2.9 and 3.0
$payments = edd_get_payments( array(
    'status' => 'publish'
) );

// Valid in 3.0 only
$payments = edd_get_orders( array(
    'status' => 'complete'
) );
```
I'm not sure if this is enough of a notice, but it was mentioned on the blog.