### PR TITLE
Add fallback for retrieving transaction ID via comments #8668

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -726,12 +726,16 @@ class Data_Migrator {
 		}
 
 		// Transaction IDs are no longer meta, and have their own table and data set, so we need to add the transactions.
-		// @TODO: Add support for multiple transaction IDs (from things like Stripe).
-		if ( isset( $meta['_edd_payment_transaction_id'] ) && ! empty( $meta['_edd_payment_transaction_id'][0] ) ) {
+		$transaction_id = ! empty( $meta['_edd_payment_transaction_id'][0] ) ? $meta['_edd_payment_transaction_id'][0] : false;
+		// If we have no transaction ID & the gateway was PayPal, let's check in old payment notes.
+		if ( empty( $transaction_id ) && false !== strpos( $gateway, 'paypal' ) ) {
+			$transaction_id = self::find_transaction_id_from_notes( $order_id );
+		}
+		if ( ! empty( $transaction_id ) ) {
 			edd_add_order_transaction( array(
 				'object_id'      => $order_id,
 				'object_type'    => 'order',
-				'transaction_id' => $meta['_edd_payment_transaction_id'][0],
+				'transaction_id' => $transaction_id,
 				'gateway'        => $gateway,
 				'status'         => 'complete',
 				'total'          => $total,
@@ -1122,6 +1126,36 @@ class Data_Migrator {
 		 * @param array $meta         All post meta associated with the payment.
 		 */
 		do_action( 'edd_30_migrate_order', $order_id, $payment_meta, $meta );
+	}
+
+	/**
+	 * Attempts to locate a PayPal transaction ID from legacy payment notes.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $payment_id
+	 *
+	 * @return string|false Transaction ID on success, false if not found.
+	 */
+	private static function find_transaction_id_from_notes( $payment_id ) {
+		global $wpdb;
+
+		$payment_notes = $wpdb->get_col( $wpdb->prepare(
+			"SELECT comment_content FROM {$wpdb->comments} WHERE comment_post_ID = %d",
+			$payment_id
+		) );
+
+		if ( empty( $payment_notes ) || ! is_array( $payment_notes ) ) {
+			return false;
+		}
+
+		foreach ( $payment_notes as $note ) {
+			if ( preg_match( '/^PayPal Transaction ID: ([^\s]+)/', $note, $match ) ) {
+				return $match[1];
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8668 

Proposed Changes:
1. If a transaction ID isn't found via `_edd_payment_transaction_id` meta, check in legacy payment notes (comments) instead.