### PR TITLE
issue/8604 - 3.0 Exclude `_edd_payment_transaction_id` From Order Meta Migration

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1105,6 +1105,7 @@ class Data_Migrator {
 			'_edd_completed_date',
 			'_edd_payment_unlimited_downloads',
 			'_edd_payment_number',
+			'_edd_payment_transaction_id',
 		);
 
 		// Determine what main payment meta keys were from core and what were custom...


### PR DESCRIPTION
Fixes #8604

Proposed Changes:
1. Ensure `_edd_payment_transaction_id` is not unnecesarily migrated to `wp_edd_ordermeta`