### PR TITLE
issue/8671 - 3.0 - Migration - Use Tax and Total Metadata Values in Order Migration

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -458,10 +458,10 @@ class Data_Migrator {
 			return;
 		}
 
-		$subtotal    = 0;
-		$order_tax   = 0;
-		$discount    = 0;
-		$order_total = 0;
+		$order_subtotal = 0;
+		$order_tax      = 0;
+		$order_discount = 0;
+		$order_total    = 0;
 
 		// Track the total value of added fees in case the Order was initially migrated
 		// without _edd_payment_total or _edd_payment_tax and manual calculation was needed.
@@ -494,14 +494,14 @@ class Data_Migrator {
 
 			// Loop through the items in the purchase to build the totals.
 			foreach ( $cart_details as $cart_item ) {
-				$subtotal += $cart_item['subtotal'];
+				$order_subtotal += $cart_item['subtotal'];
 
 				// Add the cart line item tax amount if a total is not available on the order.
 				if ( false === $meta_tax ) {
 					$order_tax += $cart_item['tax'];
 				}
 
-				$discount += $cart_item['discount'];
+				$order_discount += $cart_item['discount'];
 
 				// Add the cart line item price amount (includes tax, order item fee, _but not order item fee tax_)
 				// if a total is not available on the order.
@@ -666,9 +666,9 @@ class Data_Migrator {
 			'currency'       => ! empty( $payment_meta['currency'] ) ? $payment_meta['currency'] : edd_get_currency(),
 			'payment_key'    => $purchase_key,
 			'tax_rate_id'    => $tax_rate_id,
-			'subtotal'       => $subtotal,
+			'subtotal'       => $order_subtotal,
 			'tax'            => $order_tax,
-			'discount'       => $discount,
+			'discount'       => $order_discount,
 			'total'          => $order_total,
 		);
 
@@ -697,9 +697,9 @@ class Data_Migrator {
 			$refund_data['status']       = 'complete';
 
 			// Negate the amounts
-			$refund_data['subtotal'] = edd_negate_amount( $subtotal );
+			$refund_data['subtotal'] = edd_negate_amount( $order_subtotal );
 			$refund_data['tax']      = edd_negate_amount( $order_tax );
-			$refund_data['discount'] = edd_negate_amount( $discount );
+			$refund_data['discount'] = edd_negate_amount( $order_discount );
 			$refund_data['total']    = edd_negate_amount( $order_total );
 
 

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -1239,8 +1239,9 @@ class Data_Migrator {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array $cart_details Cart details.
-	 * @return array
+	 * @param array|string $cart_details Cart details. No action is performed if a string
+	 *                                   (array cannot be unserialized) is provided.
+	 * @return array|string
 	 */
 	private static function normalize_cart_details( $cart_details ) {
 		if ( ! is_array( $cart_details ) ) {

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -465,10 +465,9 @@ class Data_Migrator {
 
 		// Track the total value of added fees in case the Order was initially migrated
 		// without _edd_payment_total or _edd_payment_tax and manual calculation was needed.
-		$order_fees_tax         = 0;
-		$order_fees_total       = 0;
-		$order_items_fees_tax   = 0;
-		$order_items_fees_total = 0;
+		$order_fees_tax       = 0;
+		$order_fees_total     = 0;
+		$order_items_fees_tax = 0;
 
 		// Retrieve the tax amount from metadata if available.
 		$meta_tax = isset( $meta['_edd_payment_tax'] )

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -511,15 +511,6 @@ class Data_Migrator {
 				}
 			}
 
-			// Cart details cannot be retrieved.
-		} else {
-
-			// We lose the discount amount at this point... it remains 0.
-
-			// Calculate the subtotal if we have a total and tax amount.
-			if ( false !== $meta_tax && false !== $meta_total ) {
-				$subtotal = $order_total - $order_tax;
-			}
 		}
 
 		// Account for a situation where the post_date_gmt is set to 0000-00-00 00:00:00


### PR DESCRIPTION
Fixes #8671

Proposed Changes:
1. Use tax and total metadata values (if available) in order migration.