### PR TITLE
Set single price mode to true only if download has variable prices

### DIFF
--- a/includes/class-edd-download.php
+++ b/includes/class-edd-download.php
@@ -339,7 +339,7 @@ class EDD_Download {
 	 */
 	public function is_single_price_mode() {
 
-		$ret = get_post_meta( $this->ID, '_edd_price_options_mode', true );
+		$ret = $this->has_variable_prices() && get_post_meta( $this->ID, '_edd_price_options_mode', true );
 
 		/**
 		 * Override the price mode for a download when checking if is in single price mode.


### PR DESCRIPTION
Fixes #8640

Proposed Changes:
1. Adds a `has_variable_prices` check to `is_single_price_mode`.