### PR TITLE
Bypass user verification when importing payments

### DIFF
--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -485,12 +485,19 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 				}
 
 			}
-
-
 		}
 
-		if( $email && $email != $customer->email ) {
-			$customer->add_email( $email );
+		if ( $email ) {
+			if ( $email !== $customer->email ) {
+				$customer->add_email( $email );
+			}
+
+			if ( empty( $customer->user_id ) ) {
+				$user = get_user_by( 'email', $email );
+				if ( $user ) {
+					$customer->update( array( 'user_id' => $user->ID ) );
+				}
+			}
 		}
 
 		return $customer->id;

--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -60,6 +60,8 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 			'zip'               => '',
 			'country'           => '',
 		);
+
+		remove_action( 'edd_customer_post_attach_payment', 'edd_connect_guest_customer_to_existing_user', 10, 4 );
 	}
 
 	/**

--- a/includes/admin/import/class-batch-import-payments.php
+++ b/includes/admin/import/class-batch-import-payments.php
@@ -393,7 +393,8 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 
 		global $wpdb;
 
-		if( ! empty( $this->field_mapping['email'] ) && ! empty( $row[ $this->field_mapping['email'] ] ) ) {
+		$email = false;
+		if ( ! empty( $this->field_mapping['email'] ) && ! empty( $row[ $this->field_mapping['email'] ] ) ) {
 
 			$email = sanitize_text_field( $row[ $this->field_mapping['email'] ] );
 
@@ -407,13 +408,16 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 
 		}
 
+		$customer = false;
 		if( ! empty( $mapped_id ) ) {
 
 			$customer = new EDD_Customer( $mapped_id );
 
 		}
 
-		if( empty( $mapped_id ) || ! $customer->id > 0 ) {
+		$customer_by_id    = false;
+		$customer_by_email = false;
+		if ( empty( $mapped_id ) || ! $customer->id > 0 ) {
 
 			// Look for a customer based on provided ID, if any
 
@@ -434,26 +438,24 @@ class EDD_Batch_Payments_Import extends EDD_Batch_Import {
 			}
 
 			// Now compare customer records. If they don't match, customer_id will be stored in meta and we will use the customer that matches the email
-
-			if( ( empty( $customer_by_id ) || $customer_by_id->id !== $customer_by_email->id ) && ! empty( $customer_by_email ) )  {
+			if ( ! empty( $customer_by_email ) && ( empty( $customer_by_id ) || ( $customer_by_id->id !== $customer_by_email->id ) ) ) {
 
 				$customer = $customer_by_email;
 
-			} else if ( ! empty( $customer_by_id ) ) {
+			} elseif ( ! empty( $customer_by_id ) ) {
 
 				$customer = $customer_by_id;
 
-				if( ! empty( $email ) ) {
+				if ( $customer && ! empty( $email ) ) {
 					$customer->add_email( $email );
 				}
-
 			}
 
 			// Make sure we found a customer. Create one if not.
-			if( empty( $customer->id ) ) {
+			if ( empty( $customer->id ) ) {
 
 				if ( ! $customer instanceof EDD_Customer ) {
-					$customer = new EDD_Customer;
+					$customer = new EDD_Customer();
 				}
 
 				$first_name = '';


### PR DESCRIPTION
Fixes #8690

Proposed Changes:
1. Remove the `edd_connect_guest_customer_to_existing_user` function when importing payments.
2. If a user matching the customer does exist during import, and the customer's `user_id` has not yet been set, set it (previously handled by the `edd_connect_guest_customer_to_existing_user` function and needed to be replaced).
3. Fix some undefined variable errors in the customer creation/checking process.