### PR TITLE
Show fees as negative if the raw subtotal is less than zero

### DIFF
--- a/includes/admin/views/tmpl-order-adjustment.php
+++ b/includes/admin/views/tmpl-order-adjustment.php
@@ -53,7 +53,7 @@ $view_url = edd_get_admin_url(
 </td>
 
 <td class="column-right" data-colname="<?php esc_html_e( 'Amount', 'easy-digital-downloads' ); ?>">
-	<# if ( 'fee' !== data.type ) { #>&ndash;<# } #>{{ data.subtotalCurrency }}
+	<# if ( 'fee' !== data.type || data.subtotal < 0 ) { #>&ndash;<# } #>{{ data.subtotalCurrency }}
 </td>
 
 <input type="hidden" value="{{ data.objectId }}" name="adjustments[{{ data.id }}][object_id]" />


### PR DESCRIPTION
Fixes #8695

Proposed Changes:
1. Add a second check in the order adjustment template to show negative fees as negative based on the original, non-formatted subtotal value.
