### PR TITLE
Do not unset the discount query arg during an API request

### DIFF
--- a/includes/query-filters.php
+++ b/includes/query-filters.php
@@ -57,7 +57,7 @@ add_action( 'template_redirect', 'edd_block_attachments' );
  */
 function edd_unset_discount_query_arg( $query ) {
 
-	if ( is_admin() || ! $query->is_main_query() ) {
+	if ( is_admin() || ! $query->is_main_query() || ! empty( $query->query_vars['edd-api'] ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #8711

Proposed Changes:
1. Check for `edd-api` in the `query_vars` and include in the early return before unsetting the discount query arg.