### PR TITLE
Introduce Tokenizer to replace some nonce verifications #8714

### DIFF
--- a/assets/js/edd-ajax.js
+++ b/assets/js/edd-ajax.js
@@ -174,6 +174,8 @@ jQuery(document).ready(function ($) {
 			price_ids : item_price_ids,
 			post_data: $(form).serialize(),
 			nonce: nonce,
+			timestamp: $this.data( 'timestamp' ),
+			token: $this.data( 'token' )
 		};
 
 		$.ajax({

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -319,6 +319,7 @@ final class Easy_Digital_Downloads {
 		require_once EDD_PLUGIN_DIR . 'includes/shortcodes.php';
 		require_once EDD_PLUGIN_DIR . 'includes/admin/tracking.php'; // Must be loaded on frontend to ensure cron runs
 		require_once EDD_PLUGIN_DIR . 'includes/privacy-functions.php';
+		require_once EDD_PLUGIN_DIR . 'includes/utils/class-tokenizer.php';
 
 		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/add-ons.php';

--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -186,76 +186,78 @@ add_action( 'wp_ajax_nopriv_edd_remove_from_cart', 'edd_ajax_remove_from_cart' )
  * @return void
  */
 function edd_ajax_add_to_cart() {
-	if ( ! isset( $_POST['nonce'] ) ) {
-		edd_debug_log( __( 'Missing nonce when adding an item to the cart. Please read the following for more information: https://easydigitaldownloads.com/development/2018/07/05/important-update-to-ajax-requests-in-easy-digital-downloads-2-9-4', 'easy-digital-downloads' ), true );
+	if ( ! isset( $_POST['download_id'] ) ) {
+		edd_die();
 	}
 
-	if ( isset( $_POST['download_id'] ) && isset( $_POST['nonce'] ) ) {
-		$download_id = absint( $_POST['download_id'] );
-		$nonce       = sanitize_text_field( $_POST['nonce'] );
+	$download_id = absint( $_POST['download_id'] );
+	$request_validated = false;
+	if ( isset( $_POST['timestamp'] ) && isset( $_POST['token'] ) && EDD\Utils\Tokenizer::is_token_valid( $_POST['token'], $_POST['timestamp'] ) ) {
+		$request_validated = true;
+	} elseif ( isset( $_POST['nonce'] ) && wp_verify_nonce( $_POST['nonce'], 'edd-add-to-cart-' . $download_id ) ) {
+		$request_validated = true;
+	}
 
-		$nonce_verified = wp_verify_nonce( $nonce, 'edd-add-to-cart-' . $download_id );
+	if ( ! $request_validated ) {
+		edd_debug_log( __( 'Missing nonce when adding an item to the cart. Please read the following for more information: https://easydigitaldownloads.com/development/2018/07/05/important-update-to-ajax-requests-in-easy-digital-downloads-2-9-4', 'easy-digital-downloads' ), true );
+		edd_die( '', '', 403 );
+	}
 
-		if ( false === $nonce_verified ) {
-			edd_die( '', '', 403 );
+	$to_add = array();
+
+	if ( isset( $_POST['price_ids'] ) && is_array( $_POST['price_ids'] ) ) {
+		foreach ( $_POST['price_ids'] as $price ) {
+			$to_add[] = array( 'price_id' => $price );
+		}
+	}
+
+	$items = '';
+
+	foreach ( $to_add as $options ) {
+
+		if( $_POST['download_id'] == $options['price_id'] ) {
+			$options = array();
 		}
 
-		$to_add = array();
+		parse_str( $_POST['post_data'], $post_data );
 
-		if ( isset( $_POST['price_ids'] ) && is_array( $_POST['price_ids'] ) ) {
-			foreach ( $_POST['price_ids'] as $price ) {
-				$to_add[] = array( 'price_id' => $price );
-			}
-		}
+		if( isset( $options['price_id'] ) && isset( $post_data['edd_download_quantity_' . $options['price_id'] ] ) ) {
 
-		$items = '';
+			$options['quantity'] = absint( $post_data['edd_download_quantity_' . $options['price_id'] ] );
 
-		foreach ( $to_add as $options ) {
+		} else {
 
-			if( $_POST['download_id'] == $options['price_id'] ) {
-				$options = array();
-			}
-
-			parse_str( $_POST['post_data'], $post_data );
-
-			if( isset( $options['price_id'] ) && isset( $post_data['edd_download_quantity_' . $options['price_id'] ] ) ) {
-
-				$options['quantity'] = absint( $post_data['edd_download_quantity_' . $options['price_id'] ] );
-
-			} else {
-
-				$options['quantity'] = isset( $post_data['edd_download_quantity'] ) ? absint( $post_data['edd_download_quantity'] ) : 1;
-
-			}
-
-			$key = edd_add_to_cart( $_POST['download_id'], $options );
-
-			$item = array(
-				'id'      => $_POST['download_id'],
-				'options' => $options
-			);
-
-			$item   = apply_filters( 'edd_ajax_pre_cart_item_template', $item );
-			$items .= html_entity_decode( edd_get_cart_item_template( $key, $item, true ), ENT_COMPAT, 'UTF-8' );
+			$options['quantity'] = isset( $post_data['edd_download_quantity'] ) ? absint( $post_data['edd_download_quantity'] ) : 1;
 
 		}
 
-		$return = array(
-			'subtotal'      => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_subtotal() ) ), ENT_COMPAT, 'UTF-8' ),
-			'total'         => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' ),
-			'cart_item'     => $items,
-			'cart_quantity' => html_entity_decode( edd_get_cart_quantity() )
+		$key = edd_add_to_cart( $_POST['download_id'], $options );
+
+		$item = array(
+			'id'      => $_POST['download_id'],
+			'options' => $options
 		);
 
-		if ( edd_use_taxes() ) {
-			$cart_tax = (float) edd_get_cart_tax();
-			$return['tax'] = html_entity_decode( edd_currency_filter( edd_format_amount( $cart_tax ) ), ENT_COMPAT, 'UTF-8' );
-		}
+		$item   = apply_filters( 'edd_ajax_pre_cart_item_template', $item );
+		$items .= html_entity_decode( edd_get_cart_item_template( $key, $item, true ), ENT_COMPAT, 'UTF-8' );
 
-		$return = apply_filters( 'edd_ajax_add_to_cart_response', $return );
-
-		echo json_encode( $return );
 	}
+
+	$return = array(
+		'subtotal'      => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_subtotal() ) ), ENT_COMPAT, 'UTF-8' ),
+		'total'         => html_entity_decode( edd_currency_filter( edd_format_amount( edd_get_cart_total() ) ), ENT_COMPAT, 'UTF-8' ),
+		'cart_item'     => $items,
+		'cart_quantity' => html_entity_decode( edd_get_cart_quantity() )
+	);
+
+	if ( edd_use_taxes() ) {
+		$cart_tax = (float) edd_get_cart_tax();
+		$return['tax'] = html_entity_decode( edd_currency_filter( edd_format_amount( $cart_tax ) ), ENT_COMPAT, 'UTF-8' );
+	}
+
+	$return = apply_filters( 'edd_ajax_add_to_cart_response', $return );
+
+	echo json_encode( $return );
 	edd_die();
 }
 add_action( 'wp_ajax_edd_add_to_cart', 'edd_ajax_add_to_cart' );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -183,8 +183,8 @@ function edd_get_purchase_link( $args = array() ) {
 			$class = implode( ' ', array( $args['style'], $args['color'], trim( $args['class'] ) ) );
 
 			if ( ! edd_is_ajax_disabled() ) {
-
-				echo '<a href="#" class="edd-add-to-cart ' . esc_attr( $class ) . '" data-nonce="' .  wp_create_nonce( 'edd-add-to-cart-' . $download->ID ) . '" data-action="edd_add_to_cart" data-download-id="' . esc_attr( $download->ID ) . '" ' . $data_variable . ' ' . $type . ' ' . $data_price . ' ' . $button_display . '><span class="edd-add-to-cart-label">' . $args['text'] . '</span> <span class="edd-loading" aria-label="' . esc_attr__( 'Loading', 'easy-digital-downloads' ) . '"></span></a>';
+				$timestamp = time();
+				echo '<a href="#" class="edd-add-to-cart ' . esc_attr( $class ) . '" data-nonce="' .  wp_create_nonce( 'edd-add-to-cart-' . $download->ID ) . '" data-timestamp="' . esc_attr( $timestamp ) . '" data-token="' . esc_attr( EDD\Utils\Tokenizer::tokenize( $timestamp ) ) . '" data-action="edd_add_to_cart" data-download-id="' . esc_attr( $download->ID ) . '" ' . $data_variable . ' ' . $type . ' ' . $data_price . ' ' . $button_display . '><span class="edd-add-to-cart-label">' . $args['text'] . '</span> <span class="edd-loading" aria-label="' . esc_attr__( 'Loading', 'easy-digital-downloads' ) . '"></span></a>';
 
 			}
 

--- a/includes/utils/class-tokenizer.php
+++ b/includes/utils/class-tokenizer.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tokenizer
+ *
+ * A class for generating tokens as an alternative to nonce verification.
+ * This is designed to work a little better with full page caching.
+ *
+ * @package   easy-digital-downloads
+ * @copyright Copyright (c) 2021, Sandhills Development, LLC
+ * @license   GPL2+
+ * @since     2.11
+ */
+
+namespace EDD\Utils;
+
+class Tokenizer {
+
+	/**
+	 * @var mixed Data to tokenize.
+	 */
+	private $data;
+
+	/**
+	 * Tokenizer constructor.
+	 *
+	 * @param string|int|float $data Data to be tokenized.
+	 */
+	public function __construct( $data ) {
+		$this->data = $data;
+	}
+
+	/**
+	 * Retrieves the signing key.
+	 *
+	 * @since 2.11
+	 *
+	 * @return string
+	 */
+	private function get_signing_key() {
+		$key = get_option( 'edd_tokenizer_signing_key' );
+		if ( empty( $key ) ) {
+			$key = $this->generate_and_save_signing_key();
+		}
+
+		return $key;
+	}
+
+	/**
+	 * Generates and saves a new signing key.
+	 *
+	 * @since 2.11
+	 *
+	 * @return string
+	 */
+	private function generate_and_save_signing_key() {
+		if ( function_exists( 'random_bytes' ) ) {
+			try {
+				$key = bin2hex( random_bytes( 32 ) );
+			} catch ( \Exception $e ) {
+				// If this failed for some reason, we'll generate using the fallback below.
+			}
+		}
+
+		if ( empty( $key ) ) {
+			$key = function_exists( 'openssl_random_pseudo_bytes' ) ? bin2hex( openssl_random_pseudo_bytes( 32 ) ) : md5( uniqid() );
+		}
+
+		update_option( 'edd_tokenizer_signing_key', $key );
+
+		return $key;
+	}
+
+	/**
+	 * Generates a token from the data.
+	 *
+	 * @since 2.11
+	 *
+	 * @return string|false
+	 */
+	public function generate_token() {
+		return hash_hmac( 'sha256', $this->data, $this->get_signing_key() );
+	}
+
+	/**
+	 * Determines whether or not the supplied token is valid for the
+	 * supplied data.
+	 *
+	 * @since 2.11
+	 *
+	 * @param string           $token Token to check.
+	 * @param string|int|float $data  Data that's been tokenized.
+	 *
+	 * @return bool
+	 */
+	public static function is_token_valid( $token, $data ) {
+		$real_token = self::tokenize( $data );
+
+		return hash_equals( $token, $real_token );
+	}
+
+	/**
+	 * Generates a token for the supplied data.
+	 *
+	 * @since 2.11
+	 *
+	 * @param string|int|float $data
+	 *
+	 * @return string|false
+	 */
+	public static function tokenize( $data ) {
+		$generator = new Tokenizer( $data );
+
+		return $generator->generate_token();
+	}
+
+}

--- a/tests/tests-tokenizer.php
+++ b/tests/tests-tokenizer.php
@@ -58,4 +58,21 @@ class TestsTokenizer extends \EDD_UnitTestCase {
 		$this->assertFalse( Tokenizer::is_token_valid( $token, strtotime( '-1 day' ) ) );
 	}
 
+	/**
+	 * If the signing key is regenerated, previously generated tokens should be invalidated.
+	 *
+	 * @covers \EDD\Utils\Tokenizer::is_token_valid
+	 */
+	public function test_regenerating_key_invalidates_token() {
+		$timestamp = time();
+		$token     = Tokenizer::tokenize( $timestamp );
+
+		// This should be valid.
+		$this->assertTrue( Tokenizer::is_token_valid( $token, $timestamp ) );
+
+		// But if we delete the signing key, a new one will be generated, which should then invalidate the above token.
+		delete_option( 'edd_tokenizer_signing_key' );
+		$this->assertFalse( Tokenizer::is_token_valid( $token, $timestamp ) );
+	}
+
 }

--- a/tests/tests-tokenizer.php
+++ b/tests/tests-tokenizer.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * tests-tokenizer.php
+ *
+ * @package   easy-digital-downloads
+ * @copyright Copyright (c) 2021, Sandhills Development, LLC
+ * @license   GPL2+
+ * @since     2.11
+ */
+
+namespace EDD\Tests;
+
+use EDD\Utils\Tokenizer;
+
+/**
+ * Class TestsTokenizer
+ *
+ * @coversDefaultClass \EDD\Utils\Tokenizer
+ *
+ * @package EDD\Tests
+ */
+class TestsTokenizer extends \EDD_UnitTestCase {
+
+	/**
+	 * When a valid token is passed through using the current timestamp, it should be valid.
+	 *
+	 * @covers \EDD\Utils\Tokenizer::is_token_valid
+	 */
+	public function test_token_valid_for_timestamp() {
+		$timestamp = time();
+		$token     = Tokenizer::tokenize( $timestamp );
+
+		$this->assertTrue( Tokenizer::is_token_valid( $token, $timestamp ) );
+	}
+
+	/**
+	 * When a valid token is passed through using a timestamp from 1 day ago, it should be valid.
+	 *
+	 * @covers \EDD\Utils\Tokenizer::is_token_valid
+	 */
+	public function test_token_valid_for_yesterday_timestamp() {
+		$timestamp = strtotime( '-1 day' );
+
+		$token = Tokenizer::tokenize( $timestamp );
+
+		$this->assertTrue( Tokenizer::is_token_valid( $token, $timestamp ) );
+	}
+
+	/**
+	 * Token is generated from current timestamp, but then validated using a timestamp from 1 day ago.
+	 * Because the data being tokenized is different, this should fail.
+	 *
+	 * @covers \EDD\Utils\Tokenizer::is_token_valid
+	 */
+	public function test_token_invalid_when_wrong_token_provided() {
+		$token = Tokenizer::tokenize( time() );
+
+		$this->assertFalse( Tokenizer::is_token_valid( $token, strtotime( '-1 day' ) ) );
+	}
+
+}


### PR DESCRIPTION
Fixes #8714 

Proposed Changes:
1. Introduces a new `Tokenizer` class for hashing a piece of data.
2. A timestamp and a token are now added to the "add to cart" buttons and sent via AJAX.
3. `edd_ajax_add_to_cart()` A few changes have been made here:
    - Exit early if `download_id` is not provided. (This is instead of nesting everything under an `if ( isset() )` check.)
    - If the timestamp + token are provided and the token is valid, consider the request verified.
    - Otherwise, fall back to still using the nonce. This ensures that we don't break anything if the add to cart links have been filtered and the filtered versions don't contain our timestamp + token.
    - If the token isn't valid and the nonce isn't valid, bail.

Security-wise, the one downside this method has over the caching method is that the tokens never actually expire. That's kind of the point, to make them work with caching. However, if a site does have problems with this endpoint being abused, the signing key could be regenerated, which would invalidate existing tokens.

To test:
1. Make sure add to cart links still work.
2. Manually delete `data-timestamp` and `data-token` from the cart buttons ([here](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/63fa0794453e91ad64578085d6f78b43ab95dc53/includes/template-functions.php#L187)) and make sure add to cart links still work.
3. Manually delete `data-nonce`, `data-timestamp`, and `data-token` from the cart buttons, and make sure add to cart links **do not** work.