### PR TITLE
Add edd_post_insert_discount hook to edd_add_discount

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -29,6 +29,7 @@ function edd_add_discount( $data = array() ) {
 	$product_requirements = isset( $data['product_reqs'] )      ? $data['product_reqs']      : null;
 	$excluded_products    = isset( $data['excluded_products'] ) ? $data['excluded_products'] : null;
 	$product_condition    = isset( $data['product_condition'] ) ? $data['product_condition'] : null;
+	$pre_convert_args     = $data;
 	unset( $data['product_reqs'], $data['excluded_products'], $data['product_condition'] );
 
 	if ( isset( $data['expiration'] ) ) {
@@ -81,6 +82,18 @@ function edd_add_discount( $data = array() ) {
 		}
 
 	}
+
+	/**
+	 * Fires after the discount code is inserted. This hook exists for
+	 * backwards compatibility purposes. It uses the $pre_convert_args variable
+	 * to ensure the arguments maintain backwards compatible array keys.
+	 *
+	 * @since 2.7
+	 *
+	 * @param array $pre_convert_args Discount args.
+	 * @param int   $return Discount  ID.
+	 */
+	do_action( 'edd_post_insert_discount', $pre_convert_args, $discount_id );
 
 	// Return the new discount ID.
 	return $discount_id;

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -440,9 +440,6 @@ function edd_store_discount( $details, $discount_id = 0 ) {
 	 */
 	do_action( 'edd_pre_insert_discount', $details );
 
-	// Necessary for edd_post_insert_discount action.
-	$pre_convert_args = $details;
-
 	// Convert legacy arguments to new ones accepted by `edd_add_discount()`.
 	$details = EDD_Discount::convert_legacy_args( $details );
 
@@ -452,18 +449,6 @@ function edd_store_discount( $details, $discount_id = 0 ) {
 		edd_update_discount( $discount_id, $details );
 		$return = $discount_id;
 	}
-
-	/**
-	 * Fires after the discount code is inserted. This hook exists for
-	 * backwards compatibility purposes. It uses the $pre_convert_args variable
-	 * to ensure the arguments maintain backwards compatible array keys
-	 *
-	 * @since 2.7
-	 *
-	 * @param array $pre_convert_args Discount args.
-	 * @param int   $return           Discount ID.
-	 */
-	do_action( 'edd_post_insert_discount', $pre_convert_args, $return );
 
 	return $return;
 }


### PR DESCRIPTION
Fixes #8718

Proposed Changes:
1. Sets the original `$data` to a variable for use in the `edd_post_insert_discount` hook and adds it to `edd_add_discount`. (Pulled from `edd_store_discount`.
