### PR TITLE
Fix incorrect array key name.

### DIFF
--- a/includes/cart/template.php
+++ b/includes/cart/template.php
@@ -154,7 +154,7 @@ function edd_checkout_cart_columns() {
 
 	if ( ! empty( $wp_filter['edd_checkout_table_header_last'] ) ) {
 		$header_last_count = 0;
-		$callbacks         = $wp_filter['edd_checkout_table_header_first']->callbacks;
+		$callbacks         = $wp_filter['edd_checkout_table_header_last']->callbacks;
 
 		foreach ( $callbacks as $callback ) {
 			$header_last_count += count( $callback );


### PR DESCRIPTION
When there are callbacks added to  `edd_checkout_table_header_last` hook, this bug produces PHP warnings and notices. Introduced in 3a5007c.
