### PR TITLE
Apply count_where() to ensure date range is respected & query sales only #8727

### DIFF
--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -55,6 +55,9 @@ class EDD_Payment_Stats extends EDD_Stats {
 		}
 
 		if ( empty( $download_id ) ) {
+			// Global sale stats
+			add_filter( 'edd_count_payments_where', array( $this, 'count_where' ) );
+
 			if ( is_array( $status ) ) {
 				$count = 0;
 				foreach ( $status as $payment_status ) {
@@ -63,6 +66,8 @@ class EDD_Payment_Stats extends EDD_Stats {
 			} else {
 				$count = edd_count_payments()->$status;
 			}
+
+			remove_filter( 'edd_count_payments_where', array( $this, 'count_where' ) );
 		} else {
 			$this->timestamp = false;
 
@@ -146,8 +151,6 @@ class EDD_Payment_Stats extends EDD_Stats {
 		}
 
 		if ( empty( $download_id ) ) {
-			$statuses = array( 'complete', 'publish', 'revoked', 'refunded', 'partially_refunded' );
-
 			/**
 			 * Filters Order statuses that should be included when calculating stats.
 			 *
@@ -155,7 +158,7 @@ class EDD_Payment_Stats extends EDD_Stats {
 			 *
 			 * @param array $statuses Order statuses to include when generating stats.
 			 */
-			$statuses = apply_filters( 'edd_payment_stats_post_statuses', $statuses );
+			$statuses = apply_filters( 'edd_payment_stats_post_statuses', edd_get_gross_order_statuses() );
 
 			// Global earning stats
 			$args = array(

--- a/includes/payments/class-payment-stats.php
+++ b/includes/payments/class-payment-stats.php
@@ -180,6 +180,7 @@ class EDD_Payment_Stats extends EDD_Stats {
 
 			if ( ! isset( $cached[ $key ] ) ) {
 				$orders = edd_get_orders( array(
+					'type'          => 'sale',
 					'status__in'    => $args['post_status'],
 					'date_query'    => array(
 						array(


### PR DESCRIPTION
Fixes #8727

Proposed Changes:
1. Re-adds the filter on `edd_count_payments_where`, which should make the date range apply correctly.
2. Updates an array of statuses to use `edd_get_gross_order_statuses()`.
3. Query sales only (no refunds).