### PR TITLE
Use filter_array only to check if an address should be migrated

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -52,10 +52,10 @@ class Data_Migrator {
 			'country' => '',
 		) );
 
-		$address = array_filter( $address );
+		$address_to_check = array_filter( $address );
 
 		// Do not migrate empty addresses.
-		if ( empty( $address ) ) {
+		if ( empty( $address_to_check ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #8729

Proposed Changes:
1. Instead of filtering empty values out from a customer address array, just use the `array_filter` to see if the address is empty.