### PR TITLE
Use a zip for the nginx rules test #8744

### DIFF
--- a/includes/misc-functions.php
+++ b/includes/misc-functions.php
@@ -1018,7 +1018,7 @@ function edd_is_uploads_url_protected() {
 		if ( wp_is_writable( $upload_path ) ) {
 
 			// Get the file path
-			$file_name = wp_unique_filename( $upload_path, 'edd-temp.jpg' );
+			$file_name = wp_unique_filename( $upload_path, 'edd-temp.zip' );
 			$file_path = trailingslashit( $upload_path ) . $file_name;
 
 			// Save a temporary file - we will try to access it


### PR DESCRIPTION
Fixes #8744 

Proposed Changes:
1. Changes the extension to `.zip` to line up with our default nginx rules as per the docs.