### PR TITLE
Audit Payment Gateways reports for type/status combinations. #8735

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -1234,7 +1234,8 @@ function edd_register_payment_gateways_report( $reports ) {
 							'range'   => $dates['range'],
 							'gateway' => $gateway,
 							'output'  => 'formatted',
-							'status'  => array( 'refunded' ),
+							'type'    => 'refund',
+							'status'  => array( 'complete' ),
 						) );
 					},
 					'display_args'  => array(

--- a/includes/class-stats.php
+++ b/includes/class-stats.php
@@ -277,7 +277,7 @@ class Stats {
 		 * This may be overridden in $query parameters that get passed through.
 		 */
 		$this->query_vars['type']   = 'sale';
-		$this->query_vars['status'] = array( 'complete', 'revoked', 'refunded', 'partially_refunded' );
+		$this->query_vars['status'] = edd_get_gross_order_statuses();
 
 		/**
 		 * Filters Order statuses that should be included when calculating stats.
@@ -1427,6 +1427,11 @@ class Stats {
 	 * @return mixed array|int|float Either a list of payment gateways and counts or just a single value.
 	 */
 	private function get_gateway_data( $query = array() ) {
+		$query = wp_parse_args( $query, array(
+			'type'   => 'sale',
+			'status' => edd_get_gross_order_statuses(),
+		) );
+
 		$this->parse_query( $query );
 
 		// Set up default values.

--- a/includes/reports/data/payment-gateways/class-gateway-stats-list-table.php
+++ b/includes/reports/data/payment-gateways/class-gateway-stats-list-table.php
@@ -73,11 +73,11 @@ class Gateway_Stats extends List_Table {
 	 */
 	public function get_columns() {
 		return array(
-			'label'          => __( 'Gateway',                'easy-digital-downloads' ),
-			'complete_sales' => __( 'Complete Sales',         'easy-digital-downloads' ),
+			'label'          => __( 'Gateway', 'easy-digital-downloads' ),
+			'complete_sales' => __( 'Complete Sales', 'easy-digital-downloads' ),
 			'pending_sales'  => __( 'Pending / Failed Sales', 'easy-digital-downloads' ),
-			'refunded_sales' => __( 'Refunded Sales', 'easy-digital-downloads' ),
-			'total_sales'    => __( 'Total Sales',            'easy-digital-downloads' ),
+			'refunded_sales' => __( 'Refunds Issued', 'easy-digital-downloads' ),
+			'total_sales'    => __( 'Total Sales', 'easy-digital-downloads' ),
 		);
 	}
 


### PR DESCRIPTION
Fixes #8735

Proposed Changes:
1. Payment Gateways "Refunds" report - set type to `'refund'` and status to `'complete'`. This ensure we retrieve all refunded amounts.
2. Stats `get_order_count()`, replace status list with `edd_get_gross_order_statuses()`. (Same status array, just using the new function.)
3. `get_gateway_data()` - Set the default type to `'sale'` and default status to `edd_get_gross_order_statuses()`. So unless overridden (such as the Refunds one), all Payment Gateways reports will use these settings.
4. Payment Gateways Table - change `Refunded Sales` to `Refunds Issued`.