### PR TITLE
Fix property type in PHPDoc

### DIFF
--- a/includes/adjustments/class-adjustment.php
+++ b/includes/adjustments/class-adjustment.php
@@ -96,7 +96,7 @@ class Adjustment extends Base_Object {
 	 *
 	 * @since  3.0
 	 * @access protected
-	 * @var    bool
+	 * @var    string
 	 */
 	protected $scope;
 


### PR DESCRIPTION
In [`EDD\Adjustments\Adjustment` documentation](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/289400c2f83d792c6ea645ef9eb2962fae1455a1/includes/adjustments/class-adjustment.php#L29) it says that it's `string`, however in property documentation it says that it's `boolean`.