### PR TITLE
Update discount expiration/active checks

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -369,7 +369,7 @@ function edd_has_active_discounts() {
 
 	// Query for active discounts.
 	$discounts = edd_get_discounts( array(
-		'number' => 1,
+		'number' => 10,
 		'status' => 'active'
 	) );
 

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -81,6 +81,8 @@ function edd_add_discount( $data = array() ) {
 			edd_add_adjustment_meta( $discount_id, 'product_condition', $product_condition );
 		}
 
+		// If the end date has passed, mark the discount as expired.
+		edd_is_discount_expired( $discount_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8756

Proposed Changes:
1. Adds a check when creating a new discount (using `edd_add_discount`) to mark the discount as expired if the end date has passed.
2. When checking the store for active discounts, retrieve 10 `active` discount objects instead of just 1.
