### PR TITLE
BUGFIX: Get price ID of product with variable prices included in Bundle

### DIFF
--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -36,6 +36,10 @@ if ( $purchases ) :
 					<tr class="edd_download_history_row">
 						<?php
 						$price_id       = edd_get_cart_item_price_id( $download );
+						// Get price ID of product with variable prices included in Bundle
+						if ( $download['in_bundle'] && edd_has_variable_prices( $download['id'] ) ) {
+							$price_id = edd_get_bundle_item_price_id( $download['id'] );
+						}
 						$download_files = edd_get_download_files( $download['id'], $price_id );
 						$name           = $download['name'];
 

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -37,7 +37,7 @@ if ( $purchases ) :
 						<?php
 						$price_id       = edd_get_cart_item_price_id( $download );
 						// Get price ID of product with variable prices included in Bundle
-						if ( $download['in_bundle'] && edd_has_variable_prices( $download['id'] ) ) {
+						if ( ! empty( $download['in_bundle'] ) && edd_has_variable_prices( $download['id'] ) ) {
 							$price_id = edd_get_bundle_item_price_id( $download['id'] );
 						}
 						$download_files = edd_get_download_files( $download['id'], $price_id );


### PR DESCRIPTION
For product(s) with variable prices included in Bundle(s) we need to get price ID in a different way. Without this change, customers see all downloadable files for variable pricing products included in the Bundle.