### PR TITLE
Update plugin row notice to account for auto-updates

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -246,6 +246,7 @@ final class EDD_Requirements_Check {
 	 * @since 3.0
 	 */
 	public function plugin_row_notice() {
+		// wp_is_auto_update_enabled_for_type was introduced in WordPress 5.5.
 		$colspan = function_exists( 'wp_is_auto_update_enabled_for_type' ) && wp_is_auto_update_enabled_for_type( 'plugin' ) ? 2 : 1;
 		?>
 		<tr class="active <?php echo esc_attr( $this->unmet_requirements_name() ); ?>-row">

--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -246,17 +246,20 @@ final class EDD_Requirements_Check {
 	 * @since 3.0
 	 */
 	public function plugin_row_notice() {
-		?><tr class="active <?php echo esc_attr( $this->unmet_requirements_name() ); ?>-row">
-		<th class="check-column">
-			<span class="dashicons dashicons-warning"></span>
-		</th>
-		<td class="column-primary">
-			<?php $this->unmet_requirements_text(); ?>
-		</td>
-		<td class="column-description">
-			<?php $this->unmet_requirements_description(); ?>
-		</td>
-		</tr><?php
+		$colspan = function_exists( 'wp_is_auto_update_enabled_for_type' ) && wp_is_auto_update_enabled_for_type( 'plugin' ) ? 2 : 1;
+		?>
+		<tr class="active <?php echo esc_attr( $this->unmet_requirements_name() ); ?>-row">
+			<th class="check-column">
+				<span class="dashicons dashicons-warning"></span>
+			</th>
+			<td class="column-primary">
+				<?php $this->unmet_requirements_text(); ?>
+			</td>
+			<td class="column-description" colspan="<?php echo esc_attr( $colspan ); ?>">
+				<?php $this->unmet_requirements_description(); ?>
+			</td>
+		</tr>
+		<?php
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8778

Proposed Changes:
1. Add a `colspan` to the plugin row notice `column-description` and define it by whether auto updates are enabled (for plugins) or not. Use `function_exists` to account for versions of WP prior to 5.5.