### PR TITLE
Update order migration for orders missing payment total

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -479,13 +479,13 @@ class Data_Migrator {
 			$order_tax = (float) $meta_tax[0];
 		}
 
+		$meta_total = false;
 		// Retrieve the total amount from metadata if available.
-		$meta_total = isset( $meta['_edd_payment_total'] )
-			? $meta['_edd_payment_total']
-			: false;
-
-		if ( false !== $meta_total ) {
-			$meta_total  = maybe_unserialize( $meta_total );
+		if ( isset( $meta['_edd_payment_total'] ) ) {
+			$meta_total  = maybe_unserialize( $meta['_edd_payment_total'] );
+			$order_total = (float) $meta_total[0];
+		} elseif ( isset( $payment_meta['amount'] ) ) {
+			$meta_total  = maybe_unserialize( $payment_meta['amount'] );
 			$order_total = (float) $meta_total[0];
 		}
 

--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -486,7 +486,7 @@ class Data_Migrator {
 			$order_total = (float) $meta_total[0];
 		} elseif ( isset( $payment_meta['amount'] ) ) {
 			$meta_total  = maybe_unserialize( $payment_meta['amount'] );
-			$order_total = (float) $meta_total[0];
+			$order_total = (float) $meta_total;
 		}
 
 		// In some cases (very few) there is no cart details...so we have to just avoid this part.


### PR DESCRIPTION
Fixes #8780

Proposed Changes:
1. Add an additional payment metadata check for looking for the order total during migration.