### PR TITLE
Set default order gateway to manual

### DIFF
--- a/includes/database/schemas/class-orders.php
+++ b/includes/database/schemas/class-orders.php
@@ -122,6 +122,7 @@ class Orders extends Schema {
 			'type'       => 'varchar',
 			'length'     => '100',
 			'sortable'   => true,
+			'default'    => 'manual',
 		),
 
 		// mode

--- a/includes/database/tables/class-orders.php
+++ b/includes/database/tables/class-orders.php
@@ -38,7 +38,7 @@ final class Orders extends Table {
 	 * @since  3.0
 	 * @var    int
 	 */
-	protected $version = 202103261;
+	protected $version = 202108040;
 
 	/**
 	 * Array of upgrade versions and methods.
@@ -53,6 +53,7 @@ final class Orders extends Table {
 		'202012041' => 202012041,
 		'202102161' => 202102161,
 		'202103261' => 202103261,
+		'202108040' => 202108040,
 	);
 
 	/**
@@ -236,5 +237,21 @@ final class Orders extends Table {
 		" );
 
 		return $this->is_success( $result );
+	}
+
+	/**
+	 * Upgrade to version 202108040
+	 * - Set any empty gateway items to 'manual'.
+	 *
+	 * @since 3.0
+	 *
+	 * @return boolean
+	 */
+	protected function __202108040() {
+		$this->get_db()->query( "
+			UPDATE {$this->table_name} set `gateway` = 'manual' WHERE `gateway` = '';
+		" );
+
+		return $this->is_success( true );
 	}
 }

--- a/includes/database/tables/class-orders.php
+++ b/includes/database/tables/class-orders.php
@@ -73,7 +73,7 @@ final class Orders extends Table {
 			customer_id bigint(20) unsigned NOT NULL default '0',
 			email varchar(100) NOT NULL default '',
 			ip varchar(60) NOT NULL default '',
-			gateway varchar(100) NOT NULL default '',
+			gateway varchar(100) NOT NULL default 'manual',
 			mode varchar(20) NOT NULL default '',
 			currency varchar(20) NOT NULL default '',
 			payment_key varchar(64) NOT NULL default '',

--- a/includes/database/tables/class-orders.php
+++ b/includes/database/tables/class-orders.php
@@ -38,7 +38,7 @@ final class Orders extends Table {
 	 * @since  3.0
 	 * @var    int
 	 */
-	protected $version = 202108040;
+	protected $version = 202108041;
 
 	/**
 	 * Array of upgrade versions and methods.
@@ -53,7 +53,7 @@ final class Orders extends Table {
 		'202012041' => 202012041,
 		'202102161' => 202102161,
 		'202103261' => 202103261,
-		'202108040' => 202108040,
+		'202108041' => 202108041,
 	);
 
 	/**
@@ -240,18 +240,22 @@ final class Orders extends Table {
 	}
 
 	/**
-	 * Upgrade to version 202108040
+	 * Upgrade to version 202108041
 	 * - Set any empty gateway items to 'manual'.
 	 *
 	 * @since 3.0
 	 *
 	 * @return boolean
 	 */
-	protected function __202108040() {
+	protected function __202108041() {
 		$this->get_db()->query( "
 			UPDATE {$this->table_name} set `gateway` = 'manual' WHERE `gateway` = '';
 		" );
 
-		return $this->is_success( true );
+		$this->get_db()->query( "
+			ALTER TABLE {$this->table_name} MODIFY COLUMN `gateway` varchar(100) NOT NULL default 'manual';
+		" );
+
+		return true;
 	}
 }


### PR DESCRIPTION
Fixes #8792

Proposed Changes:
1. Set the default order gateway to `manual`.
2. Upgrade the orders table to fill any empty gateways.