### PR TITLE
Drop payment_ids column when legacy data is removed #8798

### DIFF
--- a/includes/admin/upgrades/v3/class-remove-legacy-data.php
+++ b/includes/admin/upgrades/v3/class-remove-legacy-data.php
@@ -50,8 +50,15 @@ class Remove_Legacy_Data extends Base {
 	 * @return bool True if data was migrated, false otherwise.
 	 */
 	public function get_data() {
-		// Delete meta on first step.
+		// Perform some database operations on the first step.
 		if ( 1 === $this->step ) {
+			// Drop custoemr `payment_ids` column. It's no longer needed.
+			$customer_table = edd_get_component_interface( 'customer', 'table' );
+			if ( $customer_table instanceof \EDD\Database\Tables\Customers && $customer_table->column_exists( 'payment_ids' ) ) {
+				$this->get_db()->query( "ALTER TABLE {$this->get_db()->edd_customers} DROP `payment_ids`" );
+			}
+
+			// Delete unneede meta.
 			$this->get_db()->query( $this->get_db()->prepare( "DELETE FROM {$this->get_db()->edd_customermeta} WHERE meta_key = %s", esc_sql( 'additional_email' ) ) );
 			$this->get_db()->query( $this->get_db()->prepare( "DELETE FROM {$this->get_db()->usermeta} WHERE meta_key = %s", esc_sql( '_edd_user_address' ) ) );
 		}

--- a/includes/admin/upgrades/v3/class-remove-legacy-data.php
+++ b/includes/admin/upgrades/v3/class-remove-legacy-data.php
@@ -52,7 +52,7 @@ class Remove_Legacy_Data extends Base {
 	public function get_data() {
 		// Perform some database operations on the first step.
 		if ( 1 === $this->step ) {
-			// Drop custoemr `payment_ids` column. It's no longer needed.
+			// Drop customer `payment_ids` column. It's no longer needed.
 			$customer_table = edd_get_component_interface( 'customer', 'table' );
 			if ( $customer_table instanceof \EDD\Database\Tables\Customers && $customer_table->column_exists( 'payment_ids' ) ) {
 				$this->get_db()->query( "ALTER TABLE {$this->get_db()->edd_customers} DROP `payment_ids`" );

--- a/includes/admin/upgrades/v3/class-remove-legacy-data.php
+++ b/includes/admin/upgrades/v3/class-remove-legacy-data.php
@@ -58,7 +58,7 @@ class Remove_Legacy_Data extends Base {
 				$this->get_db()->query( "ALTER TABLE {$this->get_db()->edd_customers} DROP `payment_ids`" );
 			}
 
-			// Delete unneede meta.
+			// Delete unneeded meta.
 			$this->get_db()->query( $this->get_db()->prepare( "DELETE FROM {$this->get_db()->edd_customermeta} WHERE meta_key = %s", esc_sql( 'additional_email' ) ) );
 			$this->get_db()->query( $this->get_db()->prepare( "DELETE FROM {$this->get_db()->usermeta} WHERE meta_key = %s", esc_sql( '_edd_user_address' ) ) );
 		}

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1442,6 +1442,16 @@ class EDD_CLI extends WP_CLI_Command {
 		}
 
 		/**
+		 * Customers
+		 *
+		 * @var \EDD\Database\Tables\Customers|false $customer_table
+		 */
+		$customer_table = edd_get_component_interface( 'customer', 'table' );
+		if ( $customer_table instanceof \EDD\Database\Tables\Customers && $customer_table->column_exists( 'payment_ids' ) ) {
+			$wpdb->query( "ALTER TABLE {$wpdb->edd_customers} DROP `payment_ids`" );
+		}
+
+		/**
 		 * Customer emails
 		 */
 		if ( ! $force && edd_has_upgrade_completed( 'remove_legacy_customer_emails' ) ) {

--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -1448,6 +1448,8 @@ class EDD_CLI extends WP_CLI_Command {
 		 */
 		$customer_table = edd_get_component_interface( 'customer', 'table' );
 		if ( $customer_table instanceof \EDD\Database\Tables\Customers && $customer_table->column_exists( 'payment_ids' ) ) {
+			WP_CLI::line( __( 'Updating customers database table.', 'easy-digital-downloads' ) );
+
 			$wpdb->query( "ALTER TABLE {$wpdb->edd_customers} DROP `payment_ids`" );
 		}
 

--- a/includes/database/tables/class-customers.php
+++ b/includes/database/tables/class-customers.php
@@ -101,9 +101,6 @@ final class Customers extends Table {
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `purchase_count` bigint(20) unsigned NOT NULL default '0'" );
 			$this->get_db()->query( "ALTER TABLE {$this->table_name} MODIFY `date_created` datetime NOT NULL default CURRENT_TIMESTAMP" );
 
-			// Remove unneeded columns.
-			$this->get_db()->query( "ALTER TABLE {$this->table_name} DROP `payment_ids`" );
-
 			if ( ! $this->column_exists( 'status' ) ) {
 				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD COLUMN `status` varchar(20) NOT NULL default 'active' AFTER `name`;" );
 				$this->get_db()->query( "ALTER TABLE {$this->table_name} ADD INDEX status (status(20))" );


### PR DESCRIPTION
Fixes #8798

Proposed Changes:
1. Removes the column drop from the database upgrade routine. (This was run immediately upon upgrading to 3.0.)
2. Add the column drop to both the CLI legacy removal and the UI legacy removal.

## Testing

1. Upgrade to release/3.0 & migrate.
2. Ensure the `wp_edd_customers` table still has the `payment_ids` column.
3. Maybe make a new order with a brand new account, which will create a new customer, just to make sure that all still works okay.
4. Remove legacy data via the UI. Ensure the `payment_ids` column is gone.

Repeat steps 1 and 2 (skip 3), but this time remove legacy data via CLI. Ensure the `payment_ids` column is gone.