### PR TITLE
Add EDD 3.0 rollback handling #8805

### DIFF
--- a/easy-digital-downloads.php
+++ b/easy-digital-downloads.php
@@ -356,6 +356,7 @@ final class Easy_Digital_Downloads {
 			require_once EDD_PLUGIN_DIR . 'includes/admin/settings/contextual-help.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/tools.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/plugins.php';
+			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/downgrades.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrades.php';
 			require_once EDD_PLUGIN_DIR . 'includes/admin/class-edd-heartbeat.php';

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -13,8 +13,9 @@
  * and updates the version number.
  *
  * @since 2.11
+ * @return bool Whether or not a downgrade was performed.
  */
-add_action( 'admin_init', function() {
+function edd_do_downgrade() {
 	$did_downgrade   = false;
 	$edd_version     = preg_replace( '/[^0-9.].*/', '', get_option( 'edd_version' ) );
 	$downgraded_from = get_option( 'edd_version_downgraded_from' );
@@ -40,7 +41,10 @@ add_action( 'admin_init', function() {
 		update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
 		delete_option( 'edd_version_downgraded_from' );
 	}
-} );
+
+	return $did_downgrade;
+}
+add_action( 'admin_init', 'edd_do_downgrade' );
 
 /**
  * Display downgrade notices.

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -17,7 +17,7 @@
 add_action( 'admin_init', function() {
 	$did_downgrade   = false;
 	$edd_version     = preg_replace( '/[^0-9.].*/', '', get_option( 'edd_version' ) );
-	$downgraded_from = get_option( 'edd_version_upgraded_from' );
+	$downgraded_from = get_option( 'edd_version_downgraded_from' );
 
 	/**
 	 * Check for downgrade from 3.0 to 2.11.
@@ -32,15 +32,13 @@ add_action( 'admin_init', function() {
 			 * @see edd_show_downgrade_notices()
 			 */
 			update_option( 'edd_v3_downgrade', time() );
+			$did_downgrade = true;
 		}
-	}
-
-	if ( version_compare( $downgraded_from, $edd_version, '>' ) ) {
-		$did_downgrade = true;
 	}
 
 	if ( $did_downgrade ) {
 		update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
+		delete_option( 'edd_version_downgraded_from' );
 	}
 } );
 

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -107,7 +107,7 @@ add_action( 'edd_downgrade_v3', function () {
 
 	global $wpdb;
 	$customer_meta_table = EDD()->customer_meta->table_name;
-	$wpdb->query( "ALTER TABLE {$customer_meta_table} CHANGE `edd_customer_id` `edd_customer` bigint(20) unsigned NOT NULL default '0'" );
+	$wpdb->query( "ALTER TABLE {$customer_meta_table} CHANGE `edd_customer_id` `customer_id` bigint(20) unsigned NOT NULL default '0'" );
 	$wpdb->query( "ALTER TABLE {$customer_meta_table} DROP INDEX edd_customer_id" );
 	$wpdb->query( "ALTER TABLE {$customer_meta_table} ADD INDEX customer_id (customer_id)" );
 	EDD()->customer_meta->create_table(); // This re-adds the version number for us.

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -80,6 +80,8 @@ add_action( 'edd_downgrade_v3', function () {
 
 	EDD()->customers->create_table();
 
+	delete_option( 'edd_v3_downgrade' );
+
 	wp_safe_redirect( remove_query_arg( array( '_wpnonce', 'edd_action' ) ) );
 	exit;
 } );

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -9,6 +9,42 @@
  */
 
 /**
+ * Checks if the current site has downgraded, and if so, sets any necessary flags
+ * and updates the version number.
+ *
+ * @since 2.11
+ */
+add_action( 'admin_init', function() {
+	$did_downgrade   = false;
+	$edd_version     = preg_replace( '/[^0-9.].*/', '', get_option( 'edd_version' ) );
+	$downgraded_from = get_option( 'edd_version_upgraded_from' );
+
+	/**
+	 * Check for downgrade from 3.0 to 2.11.
+	 */
+	if ( version_compare( EDD_VERSION, '3.0-beta1', '<' ) ) {
+		if (
+			version_compare( $edd_version, '3.0-beta1', '>=' ) ||
+			( $downgraded_from && version_compare( $downgraded_from, '3.0-beta1', '>=' ) )
+		) {
+			/*
+			 * This site probably just downgraded from EDD 3.0. Let's store a flag so we can give them the option to properly roll back.
+			 * @see edd_show_downgrade_notices()
+			 */
+			update_option( 'edd_v3_downgrade', time() );
+		}
+	}
+
+	if ( version_compare( $downgraded_from, $edd_version, '>' ) ) {
+		$did_downgrade = true;
+	}
+
+	if ( $did_downgrade ) {
+		update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
+	}
+} );
+
+/**
  * Display downgrade notices.
  *
  * @since 2.11

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Downgrades
+ *
+ * @package   easy-digital-downloads
+ * @copyright Copyright (c) 2021, Sandhills Development, LLC
+ * @license   GPL2+
+ * @since     2.11
+ */
+
+/**
+ * Display downgrade notices.
+ *
+ * @since 2.11
+ */
+function edd_show_downgrade_notices() {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
+
+	/**
+	 * EDD 3.0 downgrade.
+	 */
+	if ( get_option( 'edd_v3_downgrade' ) ) {
+		$downgrade_url = wp_nonce_url( add_query_arg( 'edd_action', 'downgrade_v3' ), 'edd_downgrade_v3' );
+		$dismiss_url   = wp_nonce_url( add_query_arg( 'edd_action', 'dismiss_v3_downgrade' ), 'edd_dismiss_v3_downgrade' );
+		?>
+		<div class="notice notice-warning">
+			<h2><?php esc_html_e( 'Did you downgrade from Easy Digital Downloads 3.0?', 'easy-digital-downloads' ); ?></h2>
+			<p>
+				<?php _e( 'We\'ve detected that your site may have just downgraded from Easy Digital Downloads version 3.0. If that is correct, please click the "Complete Downgrade" button below to complete this process.', 'easy-digital-downloads' ); ?>
+			</p>
+			<p>
+				<?php _e( 'If you believe this message to be in error, please click "Dismiss Notice" instead, which will remove this notice with no further action.', 'easy-digital-downloads' ); ?>
+			</p>
+			<p>
+				<a href="<?php echo esc_url( $downgrade_url ); ?>" class="button button-primary"><?php esc_html_e( 'Complete Downgrade', 'easy-digital-downloads' ); ?></a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button"><?php esc_html_e( 'Dismiss Notice', 'easy-digital-downloads' ); ?></a>
+			</p>
+		</div>
+		<?php
+	}
+}
+
+add_action( 'admin_notices', 'edd_show_downgrade_notices' );
+
+/**
+ * Handles the downgrade from EDD 3.0.
+ *
+ * @since 2.11
+ */
+add_action( 'edd_downgrade_v3', function () {
+	if ( empty( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'edd_downgrade_v3' ) ) {
+		wp_die(
+			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
+			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
+		);
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die(
+			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
+			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
+		);
+	}
+
+	if ( ! get_option( 'edd_v3_downgrade' ) ) {
+		wp_die(
+			__( 'Unexpected rollback operation.', 'easy-digital-downloads' ),
+			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 400 )
+		);
+	}
+
+	global $wpdb;
+	$customer_meta_table = EDD()->customer_meta->table_name;
+	$wpdb->query( "ALTER TABLE {$customer_meta_table} CHANGE `edd_customer_id` `edd_customer` bigint(20) unsigned NOT NULL default '0'" );
+	$wpdb->query( "ALTER TABLE {$customer_meta_table} DROP INDEX edd_customer_id" );
+	$wpdb->query( "ALTER TABLE {$customer_meta_table} ADD INDEX customer_id (customer_id)" );
+	EDD()->customer_meta->create_table(); // This re-adds the version number for us.
+
+	EDD()->customers->create_table();
+
+	wp_safe_redirect( remove_query_arg( array( '_wpnonce', 'edd_action' ) ) );
+	exit;
+} );
+
+/**
+ * Handles dismissing the downgrade notice.
+ *
+ * @since 2.11
+ */
+add_action( 'edd_dismiss_v3_downgrade', function () {
+	if ( empty( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'edd_dismiss_v3_downgrade' ) ) {
+		wp_die(
+			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
+			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
+		);
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_die(
+			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
+			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
+		);
+	}
+
+	delete_option( 'edd_v3_downgrade' );
+
+	wp_safe_redirect( remove_query_arg( array( '_wpnonce', 'edd_action' ) ) );
+	exit;
+} );

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -29,11 +29,9 @@ function edd_do_downgrade() {
 			( $downgraded_from && version_compare( $downgraded_from, '3.0-beta1', '>=' ) )
 		) {
 			/*
-			 * This site probably just downgraded from EDD 3.0. Let's store a flag so we can give them the option to properly roll back.
-			 * @see edd_show_downgrade_notices()
+			 * This site probably just downgraded from EDD 3.0. Let's perform a downgrade.
 			 */
-			update_option( 'edd_v3_downgrade', time() );
-			$did_downgrade = true;
+			$did_downgrade = edd_maybe_downgrade_from_v3();
 		}
 	}
 
@@ -47,105 +45,30 @@ function edd_do_downgrade() {
 add_action( 'admin_init', 'edd_do_downgrade' );
 
 /**
- * Display downgrade notices.
+ * Performs a database downgrade from EDD 3.0 to 2.11 if one is needed.
+ * The main operation here is changing the customer meta column from `edd_customer_id` (v3.0 version)
+ * back to `customer_id` for v2.x.
  *
  * @since 2.11
+ * @return bool Whether the downgrade was performed.
  */
-function edd_show_downgrade_notices() {
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return;
-	}
-
-	/**
-	 * EDD 3.0 downgrade.
-	 */
-	if ( get_option( 'edd_v3_downgrade' ) ) {
-		$downgrade_url = wp_nonce_url( add_query_arg( 'edd_action', 'downgrade_v3' ), 'edd_downgrade_v3' );
-		$dismiss_url   = wp_nonce_url( add_query_arg( 'edd_action', 'dismiss_v3_downgrade' ), 'edd_dismiss_v3_downgrade' );
-		?>
-		<div class="notice notice-warning">
-			<h2><?php esc_html_e( 'Did you downgrade from Easy Digital Downloads 3.0?', 'easy-digital-downloads' ); ?></h2>
-			<p>
-				<?php _e( 'We\'ve detected that your site may have just downgraded from Easy Digital Downloads version 3.0. If that is correct, please click the "Complete Downgrade" button below to complete this process.', 'easy-digital-downloads' ); ?>
-			</p>
-			<p>
-				<?php esc_html_e( 'If you believe this message to be in error, please click "Dismiss Notice" instead, which will remove this notice with no further action.', 'easy-digital-downloads' ); ?>
-			</p>
-			<p>
-				<a href="<?php echo esc_url( $downgrade_url ); ?>" class="button button-primary"><?php esc_html_e( 'Complete Downgrade', 'easy-digital-downloads' ); ?></a>
-				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button"><?php esc_html_e( 'Dismiss Notice', 'easy-digital-downloads' ); ?></a>
-			</p>
-		</div>
-		<?php
-	}
-}
-
-add_action( 'admin_notices', 'edd_show_downgrade_notices' );
-
-/**
- * Handles the downgrade from EDD 3.0.
- *
- * @since 2.11
- */
-add_action( 'edd_downgrade_v3', function () {
-	if ( empty( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'edd_downgrade_v3' ) ) {
-		wp_die(
-			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
-			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
-		);
-	}
-
-	if ( ! current_user_can( 'manage_options' ) ) {
-		wp_die(
-			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
-			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
-		);
-	}
-
-	if ( ! get_option( 'edd_v3_downgrade' ) ) {
-		wp_die(
-			__( 'Unexpected rollback operation.', 'easy-digital-downloads' ),
-			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 400 )
-		);
-	}
-
+function edd_maybe_downgrade_from_v3() {
 	global $wpdb;
 	$customer_meta_table = EDD()->customer_meta->table_name;
+
+	// If there is no column called `edd_customer_id`, then we don't need to downgrade.
+	$columns = $wpdb->query( "SHOW COLUMNS FROM {$customer_meta_table} LIKE 'edd_customer_id'");
+	if ( empty( $columns ) ) {
+		return false;
+	}
+
 	$wpdb->query( "ALTER TABLE {$customer_meta_table} CHANGE `edd_customer_id` `customer_id` bigint(20) unsigned NOT NULL default '0'" );
 	$wpdb->query( "ALTER TABLE {$customer_meta_table} DROP INDEX edd_customer_id" );
 	$wpdb->query( "ALTER TABLE {$customer_meta_table} ADD INDEX customer_id (customer_id)" );
-	EDD()->customer_meta->create_table(); // This re-adds the version number for us.
 
+	// These two calls re-add the table version numbers for us.
+	EDD()->customer_meta->create_table();
 	EDD()->customers->create_table();
 
-	delete_option( 'edd_v3_downgrade' );
-
-	wp_safe_redirect( remove_query_arg( array( '_wpnonce', 'edd_action' ) ) );
-	exit;
-} );
-
-/**
- * Handles dismissing the downgrade notice.
- *
- * @since 2.11
- */
-add_action( 'edd_dismiss_v3_downgrade', function () {
-	if ( empty( $_GET['_wpnonce'] ) || ! wp_verify_nonce( $_GET['_wpnonce'], 'edd_dismiss_v3_downgrade' ) ) {
-		wp_die(
-			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
-			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
-		);
-	}
-
-	if ( ! current_user_can( 'manage_options' ) ) {
-		wp_die(
-			__( 'You do not have permission to perform this action.', 'easy-digital-downloads' ),
-			__( 'Error', 'easy-digital-downloads' ), array( 'response' => 403 )
-		);
-	}
-
-	delete_option( 'edd_v3_downgrade' );
-
-	wp_safe_redirect( remove_query_arg( array( '_wpnonce', 'edd_action' ) ) );
-	exit;
-} );
+	return true;
+}

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -9,8 +9,7 @@
  */
 
 /**
- * Checks if the current site has downgraded, and if so, sets any necessary flags
- * and updates the version number.
+ * Checks if the current site has downgraded, and if so, performs any necessary actions.
  *
  * @since 2.11
  * @return bool Whether or not a downgrade was performed.

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -70,5 +70,7 @@ function edd_maybe_downgrade_from_v3() {
 	EDD()->customer_meta->create_table();
 	EDD()->customers->create_table();
 
+	edd_debug_log( 'Completed downgrade from EDD 3.0.', true );
+
 	return true;
 }

--- a/includes/admin/upgrades/downgrades.php
+++ b/includes/admin/upgrades/downgrades.php
@@ -69,7 +69,7 @@ function edd_show_downgrade_notices() {
 				<?php _e( 'We\'ve detected that your site may have just downgraded from Easy Digital Downloads version 3.0. If that is correct, please click the "Complete Downgrade" button below to complete this process.', 'easy-digital-downloads' ); ?>
 			</p>
 			<p>
-				<?php _e( 'If you believe this message to be in error, please click "Dismiss Notice" instead, which will remove this notice with no further action.', 'easy-digital-downloads' ); ?>
+				<?php esc_html_e( 'If you believe this message to be in error, please click "Dismiss Notice" instead, which will remove this notice with no further action.', 'easy-digital-downloads' ); ?>
 			</p>
 			<p>
 				<a href="<?php echo esc_url( $downgrade_url ); ?>" class="button button-primary"><?php esc_html_e( 'Complete Downgrade', 'easy-digital-downloads' ); ?></a>

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -21,13 +21,16 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 */
 function edd_do_automatic_upgrades() {
 
-	$did_upgrade = false;
+	$did_upgrade = $did_downgrade = false;
 	$edd_version = preg_replace( '/[^0-9.].*/', '', get_option( 'edd_version' ) );
 
-	if( version_compare( $edd_version, '2.6', '<' ) ) {
-
+	if ( version_compare( $edd_version, '2.6', '<' ) ) {
 		edd_v26_upgrades();
-
+	}
+	if ( version_compare( $edd_version, '3.0-beta1', '>=' ) && version_compare( EDD_VERSION, '3.0-beta1', '<' ) ) {
+		// This site probably just downgraded from EDD 3.0. Let's store a flag so we can give them the option to properly roll back.
+		update_option( 'edd_v3_downgrade', time() );
+		$did_downgrade = true;
 	}
 
 	if( version_compare( $edd_version, EDD_VERSION, '<' ) ) {
@@ -37,7 +40,7 @@ function edd_do_automatic_upgrades() {
 
 	}
 
-	if( $did_upgrade ) {
+	if ( $did_upgrade || $did_downgrade ) {
 
 		update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
 

--- a/includes/admin/upgrades/upgrade-functions.php
+++ b/includes/admin/upgrades/upgrade-functions.php
@@ -21,16 +21,11 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 */
 function edd_do_automatic_upgrades() {
 
-	$did_upgrade = $did_downgrade = false;
+	$did_upgrade = false;
 	$edd_version = preg_replace( '/[^0-9.].*/', '', get_option( 'edd_version' ) );
 
 	if ( version_compare( $edd_version, '2.6', '<' ) ) {
 		edd_v26_upgrades();
-	}
-	if ( version_compare( $edd_version, '3.0-beta1', '>=' ) && version_compare( EDD_VERSION, '3.0-beta1', '<' ) ) {
-		// This site probably just downgraded from EDD 3.0. Let's store a flag so we can give them the option to properly roll back.
-		update_option( 'edd_v3_downgrade', time() );
-		$did_downgrade = true;
 	}
 
 	if( version_compare( $edd_version, EDD_VERSION, '<' ) ) {
@@ -40,7 +35,7 @@ function edd_do_automatic_upgrades() {
 
 	}
 
-	if ( $did_upgrade || $did_downgrade ) {
+	if ( $did_upgrade ) {
 
 		update_option( 'edd_version', preg_replace( '/[^0-9.].*/', '', EDD_VERSION ) );
 

--- a/includes/install.php
+++ b/includes/install.php
@@ -73,8 +73,10 @@ function edd_run_install() {
 
 	// Add Upgraded/Downgraded From Option
 	$current_version = get_option( 'edd_version' );
+	$downgraded      = false;
 	if ( $current_version ) {
 		if ( version_compare( $current_version, EDD_VERSION, '>' ) ) {
+			$downgraded = true;
 			update_option( 'edd_version_downgraded_from', $current_version );
 		}
 
@@ -200,9 +202,14 @@ function edd_run_install() {
 	$api = new EDD_API;
 	update_option( 'edd_default_api_version', 'v' . $api->get_version() );
 
-	// Create the customer databases
-	@EDD()->customers->create_table();
-	@EDD()->customer_meta->create_table();
+	if ( ! $downgraded || ! edd_do_downgrade() ) {
+		/*
+		 * Create the customer databases.
+		 * This should only run if a downgrade _wasn't_ performed.
+		 */
+		@EDD()->customers->create_table();
+		@EDD()->customer_meta->create_table();
+	}
 
 	// Check for PHP Session support, and enable if available
 	EDD()->session->use_php_sessions();

--- a/includes/install.php
+++ b/includes/install.php
@@ -71,9 +71,13 @@ function edd_run_install() {
 	// Clear the permalinks
 	flush_rewrite_rules( false );
 
-	// Add Upgraded From Option
+	// Add Upgraded/Downgraded From Option
 	$current_version = get_option( 'edd_version' );
 	if ( $current_version ) {
+		if ( version_compare( $current_version, EDD_VERSION, '>' ) ) {
+			update_option( 'edd_version_downgraded_from', $current_version );
+		}
+
 		update_option( 'edd_version_upgraded_from', $current_version );
 	}
 


### PR DESCRIPTION
Fixes #8805

Proposed Changes:
1. Detects a downgrade from EDD 3.0. This is done by checking if the _database_ version number is >= 3.0, but the _constant_ within the plugin is < 3.0.
2. If a downgrade has been detected, show the user a notice asking if that's correct and if they want to proceed.
3. Completing a downgrade rolls back the database changes.
4. Dismissing the notice just removes the downgrade flag with no other action.

## Testing

- Make sure a site that has only ever been on EDD 2.x doesn't see any new notices.
- Do a fresh EDD 3.0 install. Make sure you don't see any new notices.
- Migrate from EDD 2.x to 3.0. Then downgrade. Make sure notice appears.
    - Before clicking Upgrade, confirm that your `wp_edd_customermeta` table has a column called `edd_customer_id`.
    - Click Upgrade.
    - Confirm that your `wp_edd_customermeta` table now has a column called `customer_id` instead. (And should have the same values as before, just different column name.)
    - Do a couple test purchases, make sure new customers get created okay and customer meta gets added okay. (A good way to test the meta is to checkout via Stripe, which should add a piece of Stripe meta, I think).
    - Then upgrade to 3.0 once again. Make sure that meta column gets changed from `customer_id` to `edd_customer_id`.
    - Do a few test purchases, make sure new customers + meta get created okay.
- Start on a new 2.x test site. Migrate to 3.0. Then downgrade. Make sure notice appears.
    - Click the dismiss button and make sure the notice goes away.

Feedback on the notice content is welcome!