### PR TITLE
Move `edd_update_payment_status` to a transition hook

### DIFF
--- a/includes/emails/functions.php
+++ b/includes/emails/functions.php
@@ -226,12 +226,16 @@ function edd_get_email_names( $user_info, $payment = false ) {
 
 	if ( $payment instanceof EDD_Payment ) {
 
+		$email_names['name']     = $payment->email;
+		$email_names['username'] = $payment->email;
 		if ( $payment->user_id > 0 ) {
 
-			$user_data = get_userdata( $payment->user_id );
-			$email_names['name']      = $payment->first_name;
-			$email_names['fullname']  = trim( $payment->first_name . ' ' . $payment->last_name );
-			$email_names['username']  = $user_data->user_login;
+			$user_data               = get_userdata( $payment->user_id );
+			$email_names['name']     = $payment->first_name;
+			$email_names['fullname'] = trim( $payment->first_name . ' ' . $payment->last_name );
+			if ( ! empty( $user_data->user_login ) ) {
+				$email_names['username'] = $user_data->user_login;
+			}
 
 		} elseif ( ! empty( $payment->first_name ) ) {
 
@@ -239,13 +243,7 @@ function edd_get_email_names( $user_info, $payment = false ) {
 			$email_names['fullname'] = trim( $payment->first_name . ' ' . $payment->last_name );
 			$email_names['username'] = $payment->first_name;
 
-		} else {
-
-			$email_names['name']     = $payment->email;
-			$email_names['username'] = $payment->email;
-
 		}
-
 	} else {
 
 		if ( is_serialized( $user_info ) ) {

--- a/includes/emails/template.php
+++ b/includes/emails/template.php
@@ -184,13 +184,14 @@ function edd_get_sale_notification_body_content( $payment_id = 0, $payment_data 
 	$payment = edd_get_payment( $payment_id );
 	$order   = edd_get_order( $payment_id );
 
-	if( $payment->user_id > 0 ) {
+	$name = $payment->email;
+	if ( $payment->user_id > 0 ) {
 		$user_data = get_userdata( $payment->user_id );
-		$name = $user_data->display_name;
-	} elseif( ! empty( $payment->first_name ) && ! empty( $payment->last_name ) ) {
+		if ( ! empty( $user_data->display_name ) ) {
+			$name = $user_data->display_name;
+		}
+	} elseif ( ! empty( $payment->first_name ) && ! empty( $payment->last_name ) ) {
 		$name = $payment->first_name . ' ' . $payment->last_name;
-	} else {
-		$name = $payment->email;
 	}
 
 	$download_list = '';

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -342,8 +342,6 @@ function edd_refund_order( $order_id, $order_items = 'all', $adjustments = 'all'
 		if ( ! empty( $order_item['parent'] ) && ! empty( $order_item['original_item_status'] ) ) {
 			edd_update_order_item( $order_item['parent'], array( 'status' => $order_item['original_item_status'] ) );
 		}
-		edd_decrease_earnings( $order_item['product_id'], $order_item['amount'] );
-		edd_decrease_purchase_count( $order_item['product_id'], $order_item['quantity'] );
 	}
 
 	/** Insert order adjustments **********************************************/

--- a/includes/orders/functions/refunds.php
+++ b/includes/orders/functions/refunds.php
@@ -342,6 +342,8 @@ function edd_refund_order( $order_id, $order_items = 'all', $adjustments = 'all'
 		if ( ! empty( $order_item['parent'] ) && ! empty( $order_item['original_item_status'] ) ) {
 			edd_update_order_item( $order_item['parent'], array( 'status' => $order_item['original_item_status'] ) );
 		}
+		edd_decrease_earnings( $order_item['product_id'], $order_item['amount'] );
+		edd_decrease_purchase_count( $order_item['product_id'], $order_item['quantity'] );
 	}
 
 	/** Insert order adjustments **********************************************/

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -280,6 +280,25 @@ function edd_record_order_status_change( $old_status, $new_status, $order_id ) {
 add_action( 'edd_transition_order_status', 'edd_record_order_status_change', 100, 3 );
 
 /**
+ * Triggers `edd_update_payment_status` hook when an order status changes
+ * for backwards compatibility.
+ *
+ * @since 3.0
+ * @param string $old_status the status of the order prior to this change.
+ * @param string $new_status The new order status.
+ * @param int    $order_id the ID number of the order.
+ * @return void
+ */
+add_action( 'edd_transition_order_status', function( $old_status, $new_status, $order_id ) {
+	// Trigger the payment status action hook for backwards compatibility.
+	do_action( 'edd_update_payment_status', $order_id, $new_status, $old_status );
+	if ( 'complete' === $old_status ) {
+		// Trigger the action again to account for add-ons listening for status changes from "publish".
+		do_action( 'edd_update_payment_status', $order_id, $status, 'publish' );
+	}
+}, 10, 3 );
+
+/**
  * Flushes the current user's purchase history transient when a payment status
  * is updated
  *

--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -294,7 +294,7 @@ add_action( 'edd_transition_order_status', function( $old_status, $new_status, $
 	do_action( 'edd_update_payment_status', $order_id, $new_status, $old_status );
 	if ( 'complete' === $old_status ) {
 		// Trigger the action again to account for add-ons listening for status changes from "publish".
-		do_action( 'edd_update_payment_status', $order_id, $status, 'publish' );
+		do_action( 'edd_update_payment_status', $order_id, $new_status, 'publish' );
 	}
 }, 10, 3 );
 

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1987,14 +1987,6 @@ class EDD_Payment {
 					$this->process_pending();
 					break;
 			}
-
-			do_action( 'edd_update_payment_status', $this->ID, $status, $old_status );
-
-			if ( 'complete' === $old_status ) {
-				// Trigger the action again to account for add-ons listening for status changes from "publish".
-
-				do_action( 'edd_update_payment_status', $this->ID, $status, 'publish' );
-			}
 		}
 
 		return $updated;

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1979,6 +1979,7 @@ class EDD_Payment {
 			switch ( $status ) {
 				case 'refunded':
 					$this->process_refund();
+					do_action( 'edd_update_payment_status', $this->ID, $status, $old_status );
 					break;
 				case 'failed':
 					$this->process_failure();

--- a/tests/orders/tests-edd-payment.php
+++ b/tests/orders/tests-edd-payment.php
@@ -481,6 +481,7 @@ class EDD_Payment_Tests extends \EDD_UnitTestCase {
 		$earnings = $download->earnings;
 		$sales    = $download->sales;
 
+		delete_option( 'edd_earnings_total' );
 		$store_earnings = edd_get_total_earnings();
 		$store_sales    = edd_get_total_sales();
 
@@ -706,6 +707,7 @@ class EDD_Payment_Tests extends \EDD_UnitTestCase {
 		$download_sales    = $download->sales;
 		$download_earnings = $download->earnings;
 
+		delete_option( 'edd_earnings_total' );
 		$store_earnings = edd_get_total_earnings();
 		$store_sales    = edd_get_total_sales();
 


### PR DESCRIPTION
Fixes #8804

Proposed Changes:
1. Move the `edd_update_payment_status` hook to an anonymous function hooked into `edd_transition_order_status`.
2. Decrease download earnings/sales as part of `edd_refund_order`. I believe this is consistent with how the download earnings are handled when adding a new order (both via cart and admin). These stats were not being updated when the hook was moved.
3. Oddly, with these changes, unit tests are experiencing errors in `edd_get_sale_notification_body_content` and `edd_get_email_names`. Although not technically related to this issue, I updated the logic in both of these to start with the fallback values, and only use the user data if it's available. Not sure why it would magically start failing with the  changes I made, but the extra checks seem reasonable to me.

At this point, unit tests related to refunds are failing. As far as I can tell, logging the data, what's happening (for example) in `test_refund_payment` is that the download earnings are being updated twice in the refund process. I think we want to remove the [decrease functions](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/issue/8804/includes/payments/functions.php#L306-L318) from `edd_undo_purchase`, maybe, but at this point I'm just putting this up as a draft for further discussion.