### PR TITLE
Only start session when adding an item to the cart #8813

### DIFF
--- a/includes/cart/class-edd-cart.php
+++ b/includes/cart/class-edd-cart.php
@@ -512,6 +512,10 @@ class EDD_Cart {
 		$this->contents = $cart;
 		$this->update_cart();
 
+		if ( $this->is_empty() && ! $this->has_discounts() ) {
+			EDD()->session->close_session();
+		}
+
 		do_action( 'edd_post_remove_from_cart', $key, $item_id );
 
 		edd_clear_errors();
@@ -584,6 +588,9 @@ class EDD_Cart {
 		// Remove any active discounts
 		$this->remove_all_discounts();
 		$this->contents = array();
+
+		// Close session.
+		EDD()->session->close_session();
 
 		do_action( 'edd_empty_cart' );
 	}

--- a/includes/class-edd-session.php
+++ b/includes/class-edd-session.php
@@ -235,17 +235,6 @@ class EDD_Session {
 	}
 
 	/**
-	 * Determines whether or not there's at least one item in the cart.
-	 *
-	 * @since 3.x
-	 *
-	 * @return bool
-	 */
-	public function has_items_in_cart() {
-		return isset( $_COOKIE['edd_items_in_cart'] );
-	}
-
-	/**
 	 * Force the cookie expiration variant time to 23 hours.
 	 *
 	 * @since 2.0
@@ -346,7 +335,7 @@ class EDD_Session {
 	public function should_start_session() {
 
 		// Set default return value to whether or not items are in the cart.
-		$start_session = $this->has_items_in_cart();
+		$start_session = isset( $_COOKIE['edd_items_in_cart'] );
 
 		if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
 			$blacklist = $this->get_blacklist();


### PR DESCRIPTION
Fixes #8813

Proposed Changes:
1. `EDD_Session::should_start_session()`
    - The default value used to be `true`, but now it defaults to whether or not there's an item in the cart. To figure that out, we use the `edd_items_in_cart` cookie. If that is set, we assume the session should start. If that's not set, we assume it shouldn't be.
    - Added a `$force` parameter. When set to `true`, we bypass the `should_start_session()` check.
    - Removed PHP `< 5.4` logic
2. Introduced `EDD_Session::force_start_session()`. When called, this sets the `edd_items_in_cart` cookie and forcibly starts the session.
3. Introduced `EDD_Session::close_session()`. When called, this unsets the `edd_items_in_cart` cookie. There's an opt in filter to also completely terminate the session. Off by default because maybe other plugins are using sessions and we don't want to mess with that. :shrug: 
4. `EDD_Session::set()` now always calls `force_start_session()` if the value being set isn't empty. This is how we start the session when an item is being added to the cart. (Adding to cart calls `set()`, which then calls `force_start_session()`.
5. `EDD_Cart` - Emptying the cart completely triggers the `EDD_Session::close_session()`.

---

Testing this is a low priority for now. (In other words: don't yet. :stuck_out_tongue: ) Just felt like experimenting with it to get a basic proof of concept.