### PR TITLE
Only calculate diff if dates are not equal & catch exceptions #8816

### DIFF
--- a/includes/admin/upgrades/v3/class-data-migrator.php
+++ b/includes/admin/upgrades/v3/class-data-migrator.php
@@ -534,25 +534,31 @@ class Data_Migrator {
 			$modified_time     = new \DateTime( $data->post_modified );
 			$modified_time_gmt = new \DateTime( $data->post_modified_gmt );
 
-			$diff = $modified_time_gmt->diff( $modified_time );
+			if ( $modified_time != $modified_time_gmt ) {
+				$diff = $modified_time_gmt->diff( $modified_time );
 
-			$time_diff = 'PT';
+				$time_diff = 'PT';
 
-			// Add hours to the offset string.
-			if ( ! empty( $diff->h ) ) {
-				$time_diff .= $diff->h . 'H';
-			}
+				// Add hours to the offset string.
+				if ( ! empty( $diff->h ) ) {
+					$time_diff .= $diff->h . 'H';
+				}
 
-			// Add minutes to the offset string.
-			if ( ! empty( $diff->i ) ) {
-				$time_diff .= $diff->i . 'M';
-			}
+				// Add minutes to the offset string.
+				if ( ! empty( $diff->i ) ) {
+					$time_diff .= $diff->i . 'M';
+				}
 
-			// Account for -/+ GMT offsets.
-			if ( 1 === $diff->invert ) {
-				$date_created_gmt->add( new \DateInterval( $time_diff ) );
-			} else {
-				$date_created_gmt->sub( new \DateInterval( $time_diff ) );
+				// Account for -/+ GMT offsets.
+				try {
+					if ( 1 === $diff->invert ) {
+						$date_created_gmt->add( new \DateInterval( $time_diff ) );
+					} else {
+						$date_created_gmt->sub( new \DateInterval( $time_diff ) );
+					}
+				} catch ( \Exception $e ) {
+
+				}
 			}
 
 			$date_created_gmt = $date_created_gmt->format('Y-m-d H:i:s');


### PR DESCRIPTION
Fixes #8816

Proposed Changes:
1. Only calculate the time difference if `$modified_time` is different from `$modified_time_gmt`
2. Catch exceptions from `DateInterval` operations. Worst case scenario here we end up with `$date_created_gmt` unmodified, which is no biggie.

See issue for steps to reproduce this problem. If you use my data, then post-migration you should see the date like this:

![Screenshot from 2021-08-16 13-28-22](https://user-images.githubusercontent.com/6324272/129563830-2425ccff-6e5e-4564-b7a4-0cab78cdd938.png)

(Note my store time zone is UTC+0)