### PR TITLE
Update PayPal inactive gateway line item

### DIFF
--- a/includes/gateways/paypal/admin/connect.php
+++ b/includes/gateways/paypal/admin/connect.php
@@ -399,12 +399,15 @@ function get_account_info() {
 		$account_status .= ob_get_clean();
 
 		if ( ! edd_is_gateway_active( 'paypal_commerce' ) ) {
-			$account_status .= ' ' . sprintf(
-				/* Translators: %1$s opening anchor tag; %2$s closing anchor tag */
-					__( 'PayPal is not currently active. %1$sEnable PayPal%2$s in the general gateway settings to start using it.', 'easy-digital-downloads' ),
-					'<a href="' . esc_url( admin_url( 'edit.php?post_type=download&page=edd-settings&tab=gateways&section=main' ) ) . '">',
-					'</a>'
-				);
+			$account_status .= sprintf(
+				/* Translators: %1$s opening anchor tag; %2$s closing anchor tag; %3$s: opening line item/status/strong tags; %4$s closing strong tag; %5$s: closing list item tag */
+				__( '%3$sGateway Status: %4$s PayPal is not currently active. %1$sEnable PayPal%2$s in the general gateway settings to start using it.%5$s', 'easy-digital-downloads' ),
+				'<a href="' . esc_url( admin_url( 'edit.php?post_type=download&page=edd-settings&tab=gateways&section=main' ) ) . '">',
+				'</a>',
+				'<li><span class="dashicons dashicons-no"></span><strong>',
+				'</strong>',
+				'</li>'
+			);
 		}
 
 		wp_send_json_success( array(


### PR DESCRIPTION
Fixes #8825 

Proposed Changes:
1. Adds "Gateway Status" prefix to the inactive gateway list item.
2. Also adds a dashicon-no to visually indicate inactive gateway.