### PR TITLE
Make use_count sortable for adjustments

### DIFF
--- a/includes/database/schemas/class-adjustments.php
+++ b/includes/database/schemas/class-adjustments.php
@@ -142,7 +142,8 @@ final class Adjustments extends Schema {
 			'type'       => 'bigint',
 			'length'     => '20',
 			'unsigned'   => true,
-			'default'    => '0'
+			'default'    => '0',
+			'sortable'   => true,
 		),
 
 		// once_per_customer


### PR DESCRIPTION
Fixes #7139

Proposed Changes:
1. @JJJ was right; we needed to make the `use_count` sortable.