### PR TITLE
Make sure an order object exists before using it in payment actions

### DIFF
--- a/includes/payments/actions.php
+++ b/includes/payments/actions.php
@@ -39,6 +39,10 @@ function edd_complete_purchase( $order_id, $new_status, $old_status ) {
 
 	$order = edd_get_order( $order_id );
 
+	if ( ! $order ) {
+		return;
+	}
+
 	$completed_date = empty( $order->date_completed )
 		? null
 		: $order->date_completed;

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -369,12 +369,12 @@ class EDD_Payment {
 
 		if ( $by_txn ) {
 			$payment_id = edd_get_order_id_from_transaction_id( $payment_or_txn_id );
+
+			if ( empty( $payment_id ) ) {
+				return false;
+			}
 		} else {
 			$payment_id = absint( $payment_or_txn_id );
-		}
-
-		if ( empty( $payment_id ) ) {
-			return false;
 		}
 
 		$this->setup_payment( $payment_id );

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -369,12 +369,12 @@ class EDD_Payment {
 
 		if ( $by_txn ) {
 			$payment_id = edd_get_order_id_from_transaction_id( $payment_or_txn_id );
-
-			if ( empty( $payment_id ) ) {
-				return false;
-			}
 		} else {
 			$payment_id = absint( $payment_or_txn_id );
+		}
+
+		if ( empty( $payment_id ) ) {
+			return false;
 		}
 
 		$this->setup_payment( $payment_id );
@@ -1898,6 +1898,10 @@ class EDD_Payment {
 	 */
 	public function update_status( $status = '' ) {
 
+		if ( ! $this->order ) {
+			return;
+		}
+
 		// Bail if an empty status is passed.
 		if ( empty( $status ) || ! $status ) {
 			return false;
@@ -2155,7 +2159,7 @@ class EDD_Payment {
 	 * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure.
 	 */
 	public function update_meta( $meta_key = '', $meta_value = '', $prev_value = '' ) {
-		if ( empty( $meta_key ) ) {
+		if ( empty( $meta_key ) || empty( $this->ID ) ) {
 			return false;
 		}
 

--- a/includes/payments/class-edd-payment.php
+++ b/includes/payments/class-edd-payment.php
@@ -1899,7 +1899,7 @@ class EDD_Payment {
 	public function update_status( $status = '' ) {
 
 		if ( ! $this->order ) {
-			return;
+			return false;
 		}
 
 		// Bail if an empty status is passed.


### PR DESCRIPTION
Fixes #8843

Proposed Changes:
1. If `edd_get_order` does not return an order in `edd_complete_purchase`, this prevents the rest of the function from running.
2. If there is not an order object/property in `check_status` in the payment class, this does an early return.
3. And the `update_meta` method now returns early if there is not a payment ID/property.

Basically I started with trying to create a subscription improperly in 3.0 and kept fixing errors until they stopped occurring. Note that in 3.0, creating a subscription without a customer attached fails to create an order at all. However, the same steps in 2.11.1 do create a new payment, although there is no customer attached. I'm not sure which behavior is preferable, to be honest, so putting the PR up as it is for now.
