### PR TITLE
Create tag label from tag if label is empty

### DIFF
--- a/includes/emails/class-edd-email-tags.php
+++ b/includes/emails/class-edd-email-tags.php
@@ -57,7 +57,7 @@ class EDD_Email_Template_Tags {
 		if ( is_callable( $func ) ) {
 			$this->tags[ $tag ] = array(
 				'tag'         => $tag,
-				'label'       => $label,
+				'label'       => ! empty( $label ) ? $label : ucwords( str_replace( '_', ' ', $tag ) ),
 				'description' => $description,
 				'func'        => $func,
 			);

--- a/includes/emails/tags-inserter.php
+++ b/includes/emails/tags-inserter.php
@@ -125,16 +125,10 @@ function edd_email_tags_inserter_thickbox_content() {
 		</div>
 
 		<ul class="edd-email-tags-list">
-			<?php
-			foreach ( $tags as $tag ) :
-				$label = $tag['label'];
-				if ( empty( $label ) ) {
-					$label = ucwords( str_replace( '_', ' ', $tag['tag'] ) );
-				}
-				?>
+			<?php foreach ( $tags as $tag ) : ?>
 			<li id="<?php echo esc_attr( $tag['tag'] ); ?>" data-tag="<?php echo esc_attr( $tag['tag'] ); ?>" class="edd-email-tags-list-item">
 				<button class="edd-email-tags-list-button" data-to_insert="{<?php echo esc_attr( $tag['tag'] ); ?>}">
-					<strong><?php echo esc_html( $label ); ?></strong><code><?php echo '{' . esc_html( $tag['tag'] ) . '}'; ?></code>
+					<strong><?php echo esc_html( $tag['label'] ); ?></strong><code><?php echo '{' . esc_html( $tag['tag'] ) . '}'; ?></code>
 					<span><?php echo esc_html( $tag['description'] ); ?></span>
 				</button>
 			</li>

--- a/includes/emails/tags-inserter.php
+++ b/includes/emails/tags-inserter.php
@@ -125,10 +125,16 @@ function edd_email_tags_inserter_thickbox_content() {
 		</div>
 
 		<ul class="edd-email-tags-list">
-			<?php foreach ( $tags as $tag ) : ?>
+			<?php
+			foreach ( $tags as $tag ) :
+				$label = $tag['label'];
+				if ( empty( $label ) ) {
+					$label = ucwords( str_replace( '_', ' ', $tag['tag'] ) );
+				}
+				?>
 			<li id="<?php echo esc_attr( $tag['tag'] ); ?>" data-tag="<?php echo esc_attr( $tag['tag'] ); ?>" class="edd-email-tags-list-item">
 				<button class="edd-email-tags-list-button" data-to_insert="{<?php echo esc_attr( $tag['tag'] ); ?>}">
-					<strong><?php echo esc_html( $tag['label'] ); ?></strong><code><?php echo '{' . esc_html( $tag['tag'] ) . '}'; ?></code>
+					<strong><?php echo esc_html( $label ); ?></strong><code><?php echo '{' . esc_html( $tag['tag'] ) . '}'; ?></code>
 					<span><?php echo esc_html( $tag['description'] ); ?></span>
 				</button>
 			</li>


### PR DESCRIPTION
Fixes #8829

Proposed Changes:
1. If the email `$tag['label']` is empty, then the label will be created from the `$tag['tag']` instead.