### PR TITLE
Update SendWP account link

### DIFF
--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -2173,7 +2173,10 @@ function edd_sendwp_callback($args) {
 
 	// Connection status partial label based on the state of the SendWP email sending setting (Tools -> SendWP)
 	$connected    = sprintf(
-		__( '<a href="https://app.sendwp.com/dashboard" target="_blank" rel="noopener noreferrer">Access your SendWP account</a>.', 'easy-digital-downloads' )
+		'%1$s%2$s%3$s.',
+		'<a href="https://app.sendwp.com/dashboard" target="_blank" rel="noopener noreferrer">',
+		__( 'Access your SendWP account', 'easy-digital-downloads' ),
+		'</a>'
 	);
 	$disconnected = sprintf(
 		__( '<em><strong>Note:</strong> Email sending is currently disabled. <a href="' . admin_url( '/tools.php?page=sendwp' ) . '">Click here</a> to enable it.</em>', 'easy-digital-downloads' )

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -2172,12 +2172,10 @@ function edd_shop_states_callback($args) {
 function edd_sendwp_callback($args) {
 
 	// Connection status partial label based on the state of the SendWP email sending setting (Tools -> SendWP)
-	$connected    = sprintf(
-		'%1$s%2$s%3$s.',
-		'<a href="https://app.sendwp.com/dashboard" target="_blank" rel="noopener noreferrer">',
-		__( 'Access your SendWP account', 'easy-digital-downloads' ),
-		'</a>'
-	);
+	$connected  = '<a href="https://app.sendwp.com/dashboard" target="_blank" rel="noopener noreferrer">';
+	$connected .= __( 'Access your SendWP account', 'easy-digital-downloads' );
+	$connected .= '</a>.';
+
 	$disconnected = sprintf(
 		__( '<em><strong>Note:</strong> Email sending is currently disabled. <a href="' . admin_url( '/tools.php?page=sendwp' ) . '">Click here</a> to enable it.</em>', 'easy-digital-downloads' )
 	);

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -2173,7 +2173,7 @@ function edd_sendwp_callback($args) {
 
 	// Connection status partial label based on the state of the SendWP email sending setting (Tools -> SendWP)
 	$connected    = sprintf(
-		__( '<a href="https://sendwp.com/account/" target="_blank" rel="noopener noreferrer">Access your SendWP account</a>.', 'easy-digital-downloads' )
+		__( '<a href="https://app.sendwp.com/dashboard" target="_blank" rel="noopener noreferrer">Access your SendWP account</a>.', 'easy-digital-downloads' )
 	);
 	$disconnected = sprintf(
 		__( '<em><strong>Note:</strong> Email sending is currently disabled. <a href="' . admin_url( '/tools.php?page=sendwp' ) . '">Click here</a> to enable it.</em>', 'easy-digital-downloads' )


### PR DESCRIPTION
Fixes #8857

Proposed changes:
1. Update the SendWP account link.
2. Reorganize the `sprintf` so that the string for translation does not include the link.