### PR TITLE
Fix price_id parameter for CLI payments

### DIFF
--- a/includes/class-edd-cli.php
+++ b/includes/class-edd-cli.php
@@ -538,7 +538,7 @@ class EDD_CLI extends WP_CLI_Command {
 		if( count( $assoc_args ) > 0 ) {
 			$number     = ( array_key_exists( 'number', $assoc_args ) )   ? absint( $assoc_args['number'] )             : $number;
 			$id         = ( array_key_exists( 'id', $assoc_args ) )       ? absint( $assoc_args['id'] )                 : $id;
-			$price_id   = ( array_key_exists( 'price_id', $assoc_args ) ) ? absint( $assoc_args['id'] )                 : $price_id;
+			$price_id   = ( array_key_exists( 'price_id', $assoc_args ) ) ? absint( $assoc_args['price_id'] )           : $price_id;
 			$tax        = ( array_key_exists( 'tax', $assoc_args ) )      ? floatval( $assoc_args['tax'] )              : $tax;
 			$email      = ( array_key_exists( 'email', $assoc_args ) )    ? sanitize_email( $assoc_args['email'] )      : $email;
 			$fname      = ( array_key_exists( 'fname', $assoc_args ) )    ? sanitize_text_field( $assoc_args['fname'] ) : $fname;


### PR DESCRIPTION
Fixes #8859

Proposed Changes:
1. Changes the `$price_id` variable to be properly assigned from `$assoc_args['price_id']`.

Submitting a PR now because I'm actively using this.
