### PR TITLE
Continue instead of return #8867

### DIFF
--- a/assets/js/paypal-checkout.js
+++ b/assets/js/paypal-checkout.js
@@ -237,12 +237,12 @@ jQuery( document ).ready( function( $ ) {
 		var element = buyButtons[ i ];
 		// Skip if "Free Downloads" is enabled for this download.
 		if ( element.classList.contains( 'edd-free-download' ) ) {
-			return;
+			continue;
 		}
 
 		var wrapper = element.closest( '.edd_purchase_submit_wrapper' );
 		if ( ! wrapper ) {
-			return;
+			continue;
 		}
 
 		// Clear contents of the wrapper.


### PR DESCRIPTION
Fixes #8867

Proposed Changes:
1. Change `return` statements to `continue`. The issue was that it was successfully running the first, then any later failures prevented the next buttons from loading.