### PR TITLE
Update PayPal Commerce refunds for 3.0 API #8861

### DIFF
--- a/includes/gateways/paypal/deprecated.php
+++ b/includes/gateways/paypal/deprecated.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Deprecated PayPal Functions
+ *
+ * @package    easy-digital-downloads
+ * @subpackage Gateways\PayPal
+ * @copyright  Copyright (c) 2021, Sandhills Development, LLC
+ * @license    GPL2+
+ * @since      3.0
+ */
+
+namespace EDD\Gateways\PayPal;
+
+/**
+ * Adds a "Refund in PayPal" checkbox when switching the payment's status to "Refunded".
+ *
+ * @deprecated 3.0 In favor of a `edd_after_submit_refund_table` hook.
+ *
+ * @param int $payment_id
+ *
+ * @since 2.11
+ * @return void
+ */
+function add_refund_javascript( $payment_id ) {
+	_edd_deprecated_function( __FUNCTION__, '3.0', null, debug_backtrace() );
+
+	$payment = edd_get_payment( $payment_id );
+
+	if ( ! $payment || 'paypal_commerce' !== $payment->gateway ) {
+		return;
+	}
+
+	$mode = ( 'live' === $payment->mode ) ? API::MODE_LIVE : API::MODE_SANDBOX;
+
+	try {
+		$api = new API( $mode );
+	} catch ( Exceptions\Authentication_Exception $e ) {
+		// If we don't have credentials.
+		return;
+	}
+
+	$label = __( 'Refund Transaction in PayPal', 'easy-digital-downloads' );
+	?>
+	<script type="text/javascript">
+		jQuery( document ).ready( function ( $ ) {
+			$( 'select[name=edd-payment-status]' ).change( function () {
+				if ( 'refunded' === $( this ).val() ) {
+					$( this ).parent().parent().append( '<input type="checkbox" id="edd-paypal-commerce-refund" name="edd-paypal-commerce-refund" value="1" style="margin-top:0">' );
+					$( this ).parent().parent().append( '<label for="edd-paypal-commerce-refund"><?php echo esc_html( $label ); ?></label>' );
+				} else {
+					$( '#edd-paypal-commerce-refund' ).remove();
+					$( 'label[for="edd-paypal-commerce-refund"]' ).remove();
+				}
+			} );
+		} );
+	</script>
+	<?php
+}
+
+/**
+ * Refunds the transaction in PayPal, if the option was selected.
+ *
+ * @deprecated 3.0 In favor of `edd_refund_order` hook.
+ *
+ * @param \EDD_Payment $payment The payment being refunded.
+ *
+ * @since 2.11
+ * @return void
+ */
+function maybe_refund_transaction( \EDD_Payment $payment ) {
+	_edd_deprecated_function( __FUNCTION__, '3.0', null, debug_backtrace() );
+
+	if ( ! current_user_can( 'edit_shop_payments', $payment->ID ) ) {
+		return;
+	}
+
+	if ( 'paypal_commerce' !== $payment->gateway || empty( $_POST['edd-paypal-commerce-refund'] ) ) {
+		return;
+	}
+
+	// Payment status should be coming from "publish" or "revoked".
+	// @todo In 3.0 use `edd_get_refundable_order_statuses()`
+	if ( ! in_array( $payment->old_status, array( 'publish', 'complete', 'revoked', 'edd_subscription' ) ) ) {
+		return;
+	}
+
+	// If the payment has already been refunded, bail.
+	if ( $payment->get_meta( '_edd_paypal_refunded', true ) ) {
+		return;
+	}
+
+	// Process the refund.
+	try {
+		refund_transaction( $payment );
+	} catch ( \Exception $e ) {
+		edd_insert_payment_note( $payment->ID, sprintf(
+		/* Translators: %s - The error message */
+			__( 'Failed to refund transaction in PayPal. Error Message: %s', 'easy-digital-downloads' ),
+			$e->getMessage()
+		) );
+	}
+}

--- a/includes/gateways/paypal/paypal.php
+++ b/includes/gateways/paypal/paypal.php
@@ -56,6 +56,7 @@ require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/class-account-status-val
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/class-merchant-account.php';
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/class-paypal-api.php';
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/class-token.php';
+require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/deprecated.php';
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/functions.php';
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/gateway-filters.php';
 require_once EDD_PLUGIN_DIR . 'includes/gateways/paypal/refunds.php';

--- a/includes/gateways/paypal/refunds.php
+++ b/includes/gateways/paypal/refunds.php
@@ -13,117 +13,161 @@ namespace EDD\Gateways\PayPal;
 
 use EDD\Gateways\PayPal\Exceptions\API_Exception;
 use EDD\Gateways\PayPal\Exceptions\Authentication_Exception;
+use EDD\Orders\Order;
 
 /**
- * Adds a "Refund in PayPal" checkbox when switching the payment's status to "Refunded".
+ * Shows a checkbox to automatically refund payments in PayPal.
  *
- * @param int $payment_id
+ * @param Order $order
  *
- * @since 2.11
- * @return void
+ * @since 3.0
  */
-function add_refund_javascript( $payment_id ) {
-	$payment = edd_get_payment( $payment_id );
-
-	if ( ! $payment || 'paypal_commerce' !== $payment->gateway ) {
+add_action( 'edd_after_submit_refund_table', function( Order $order ) {
+	if ( 'paypal_commerce' !== $order->gateway ) {
 		return;
 	}
 
-	$mode = ( 'live' === $payment->mode ) ? API::MODE_LIVE : API::MODE_SANDBOX;
+	$mode = ( 'live' === $order->mode ) ? API::MODE_LIVE : API::MODE_SANDBOX;
 
 	try {
-		$api = new API( $mode );
+		new API( $mode );
 	} catch ( Exceptions\Authentication_Exception $e ) {
 		// If we don't have credentials.
 		return;
 	}
-
-	$label = __( 'Refund Transaction in PayPal', 'easy-digital-downloads' );
 	?>
-	<script type="text/javascript">
-		jQuery( document ).ready( function ( $ ) {
-			$( 'select[name=edd-payment-status]' ).change( function () {
-				if ( 'refunded' === $( this ).val() ) {
-					$( this ).parent().parent().append( '<input type="checkbox" id="edd-paypal-commerce-refund" name="edd-paypal-commerce-refund" value="1" style="margin-top:0">' );
-					$( this ).parent().parent().append( '<label for="edd-paypal-commerce-refund"><?php echo esc_html( $label ); ?></label>' );
-				} else {
-					$( '#edd-paypal-commerce-refund' ).remove();
-					$( 'label[for="edd-paypal-commerce-refund"]' ).remove();
-				}
-			} );
-		} );
-	</script>
+	<div class="edd-form-group edd-paypal-refund-transaction">
+		<div class="edd-form-group__control">
+			<input type="checkbox" id="edd-paypal-commerce-refund" name="edd-paypal-commerce-refund" class="edd-form-group__input" value="1">
+			<label for="edd-paypal-commerce-refund" class="edd-form-group__label">
+				<?php esc_html_e( 'Refund transaction in PayPal', 'easy-digital-downloads' ); ?>
+			</label>
+		</div>
+	</div>
 	<?php
-}
-
-add_action( 'edd_view_order_details_before', __NAMESPACE__ . '\add_refund_javascript', 100 );
+} );
 
 /**
- * Refunds the transaction in PayPal, if the option was selected.
+ * If selected, refunds a transaction in PayPal when creating a new refund record.
  *
- * @param \EDD_Payment $payment The payment being refunded.
+ * @param int $order_id ID of the order we're processing a refund for.
+ * @param int $refund_id ID of the newly created refund record.
+ * @param bool $all_refunded Whether or not this was a full refund.
  *
- * @since 2.11
- * @return void
+ * @since 3.0
  */
-function maybe_refund_transaction( \EDD_Payment $payment ) {
-	if ( ! current_user_can( 'edit_shop_payments', $payment->ID ) ) {
+add_action( 'edd_refund_order', function( $order_id, $refund_id, $all_refunded ) {
+	if ( ! current_user_can( 'edit_shop_payments', $order_id ) ) {
 		return;
 	}
 
-	if ( 'paypal_commerce' !== $payment->gateway || empty( $_POST['edd-paypal-commerce-refund'] ) ) {
+	if ( empty( $_POST['data'] ) ) {
 		return;
 	}
 
-	// Payment status should be coming from "publish" or "revoked".
-	// @todo In 3.0 use `edd_get_refundable_order_statuses()`
-	if ( ! in_array( $payment->old_status, array( 'publish', 'complete', 'revoked', 'edd_subscription' ) ) ) {
+	$order = edd_get_order( $order_id );
+	if ( empty( $order->gateway ) || 'paypal_commerce' !== $order->gateway ) {
 		return;
 	}
 
-	// If the payment has already been refunded, bail.
-	if ( $payment->get_meta( '_edd_paypal_refunded', true ) ) {
+	// Get our data out of the serialized string.
+	parse_str( $_POST['data'], $form_data );
+
+	if ( empty( $form_data['edd-paypal-commerce-refund'] ) ) {
+		edd_add_note( array(
+			'object_id'   => $order_id,
+			'object_type' => 'order',
+			'user_id'     => is_admin() ? get_current_user_id() : 0,
+			'content'     => __( 'Transaction not refunded in PayPal, as checkbox was not selected.', 'easy-digital-downloads' )
+		) );
+
 		return;
 	}
 
-	// Process the refund.
+	$refund = edd_get_order( $refund_id );
+	if ( empty( $refund->total ) ) {
+		return;
+	}
+
 	try {
-		refund_transaction( $payment );
+		refund_transaction( $order, $refund );
 	} catch ( \Exception $e ) {
-		edd_insert_payment_note( $payment->ID, sprintf(
-		/* Translators: %s - The error message */
-			__( 'Failed to refund transaction in PayPal. Error Message: %s', 'easy-digital-downloads' ),
+		edd_debug_log( sprintf(
+			'Failure when processing refund #%d. Message: %s',
+			$refund->id,
 			$e->getMessage()
+		), true );
+
+		edd_add_note( array(
+			'object_id'   => $order->id,
+			'object_type' => 'order',
+			'user_id'     => is_admin() ? get_current_user_id() : 0,
+			'content'     => sprintf(
+				/* Translators: %d - ID of the refund; %s - error message from PayPal */
+				__( 'Failure when processing PayPal refund #%d: %s', 'easy-digital-downloads' ),
+				$refund->id,
+				$e->getMessage()
+			)
 		) );
 	}
-}
-
-add_action( 'edd_pre_refund_payment', __NAMESPACE__ . '\maybe_refund_transaction', 999 );
+}, 10, 3 );
 
 /**
  * Refunds a transaction in PayPal.
  *
  * @link  https://developer.paypal.com/docs/api/payments/v2/#captures_refund
  *
- * @param \EDD_Payment $payment
+ * @param \EDD_Payment|Order $payment_or_order
+ * @param Order|null         $refund_object
  *
  * @since 2.11
  * @throws Authentication_Exception
  * @throws API_Exception
  * @throws \Exception
  */
-function refund_transaction( \EDD_Payment $payment ) {
-	$transaction_id = $payment->transaction_id;
+function refund_transaction( $payment_or_order, Order $refund_object = null ) {
+	/*
+	 * Internally we want to work with an Order object, but we also need
+	 * an EDD_Payment object for backwards compatibility in the hooks.
+	 */
+	$order = $payment = false;
+	if ( $payment_or_order instanceof Order ) {
+		$order = $payment_or_order;
+		$payment = edd_get_payment( $order->id );
+	} elseif ( $payment_or_order instanceof \EDD_Payment ) {
+		$payment = $payment_or_order;
+		$order   = edd_get_order( $payment->ID );
+	}
+
+	if ( empty( $order ) || ! $order instanceof Order ) {
+		return;
+	}
+
+	$transaction_id = $order->get_transaction_id();
 
 	if ( empty( $transaction_id ) ) {
 		throw new \Exception( __( 'Missing transaction ID.', 'easy-digital-downloads' ) );
 	}
 
-	$mode = ( 'live' === $payment->mode ) ? API::MODE_LIVE : API::MODE_SANDBOX;
+	$mode = ( 'live' === $order->mode ) ? API::MODE_LIVE : API::MODE_SANDBOX;
 
 	$api = new API( $mode );
 
-	$response = $api->make_request( 'v2/payments/captures/' . urlencode( $transaction_id ) . '/refund' );
+	$args = $refund_object instanceof Order ? array( 'invoice_id' => $refund_object->id ) : array();
+	if ( $refund_object instanceof Order && abs( $refund_object->total ) !== abs( $order->total ) ) {
+		$args['amount'] = array(
+			'value'         => abs( $refund_object->total ),
+			'currency_code' => $refund_object->currency,
+		);
+	}
+
+	$response = $api->make_request(
+		'v2/payments/captures/' . urlencode( $transaction_id ) . '/refund',
+		$args,
+		array(
+			'Prefer' => 'return=representation',
+		)
+	);
 
 	if ( 201 !== $api->last_response_code ) {
 		throw new API_Exception( sprintf(
@@ -143,14 +187,50 @@ function refund_transaction( \EDD_Payment $payment ) {
 	}
 
 	// At this point we can assume it was successful.
-	$payment->update_meta( '_edd_paypal_refunded', true );
+	edd_update_order_meta( $order->id, '_edd_paypal_refunded', true );
 
 	if ( ! empty( $response->id ) ) {
-		$payment->add_note( sprintf(
-		/* Translators: %s - ID of the refund in PayPal */
-			__( 'Successfully refunded in PayPal. Refund transaction ID: %s', 'easy-digital-downloads' ),
-			esc_html( $response->id )
-		) );
+		// Add a note to the original order, and, if provided, the new refund object.
+		if ( isset( $response->amount->value ) ) {
+			$note_message = sprintf(
+				/* Translators: %1$s - amount refunded; %$2$s - transaction ID. */
+				__( '%1$s refunded in PayPal. Refund transaction ID: %2$s', 'easy-digital-downloads' ),
+				edd_currency_filter( edd_format_amount( $response->amount->value ), $order->currency ),
+				esc_html( $response->id )
+			);
+		} else {
+			$note_message = sprintf(
+				/* Translators: %s - ID of the refund in PayPal */
+				__( 'Successfully refunded in PayPal. Refund transaction ID: %s', 'easy-digital-downloads' ),
+				esc_html( $response->id )
+			);
+		}
+
+		$note_object_ids = array( $order->id );
+		if ( $refund_object instanceof Order ) {
+			$note_object_ids[] = $refund_object->id;
+		}
+
+		foreach ( $note_object_ids as $note_object_id ) {
+			edd_add_note( array(
+				'object_id'   => $note_object_id,
+				'object_type' => 'order',
+				'user_id'     => is_admin() ? get_current_user_id() : 0,
+				'content'     => $note_message
+			) );
+		}
+
+		// Add a negative transaction.
+		if ( $refund_object instanceof Order && isset( $response->amount->value ) ) {
+			edd_add_order_transaction( array(
+				'object_id'      => $refund_object->id,
+				'object_type'    => 'order',
+				'transaction_id' => sanitize_text_field( $response->id ),
+				'gateway'        => 'paypal_commerce',
+				'status'         => 'complete',
+				'total'          => edd_negate_amount( $response->amount->value ),
+			) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8861

Proposed Changes:
1. Deprecate old hook callbacks.
2. Integrate with new refunds API and partial refunds.

For testing, test both a full refund and multiple partial refunds.