### PR TITLE
Rework PayPal Commerce webhooks to use Order object #8874

### DIFF
--- a/includes/gateways/paypal/webhooks/events/abstract-webhook-event.php
+++ b/includes/gateways/paypal/webhooks/events/abstract-webhook-event.php
@@ -14,6 +14,7 @@ namespace EDD\Gateways\PayPal\Webhooks\Events;
 use EDD\Gateways\PayPal\API;
 use EDD\Gateways\PayPal\Exceptions\API_Exception;
 use EDD\Gateways\PayPal\Exceptions\Authentication_Exception;
+use EDD\Orders\Order;
 
 abstract class Webhook_Event {
 
@@ -65,9 +66,124 @@ abstract class Webhook_Event {
 	abstract protected function process_event();
 
 	/**
+	 * Retrieves an Order record from a capture event.
+	 *
+	 * @since 3.0
+	 *
+	 * @return Order
+	 * @throws \Exception
+	 */
+	protected function get_order_from_capture() {
+		if ( 'capture' !== $this->request->get_param( 'resource_type' ) ) {
+			throw new \Exception( sprintf( 'get_payment_from_capture() - Invalid resource type: %s', $this->request->get_param( 'resource_type' ) ) );
+		}
+
+		if ( empty( $this->event->resource ) ) {
+			throw new \Exception( sprintf( 'get_payment_from_capture() - Missing event resource.' ) );
+		}
+
+		return $this->get_order_from_capture_object( $this->event->resource );
+	}
+
+	/**
+	 * Retrieves an Order record from a capture object.
+	 *
+	 * @param object $resource
+	 *
+	 * @since 3.0
+	 *
+	 * @return Order
+	 * @throws \Exception
+	 */
+	protected function get_order_from_capture_object( $resource ) {
+		$order = false;
+
+		if ( ! empty( $resource->custom_id ) && is_numeric( $resource->custom_id ) ) {
+			$order = edd_get_order( $resource->custom_id );
+		}
+
+		if ( empty( $order ) && ! empty( $resource->id ) ) {
+			$order_id = edd_get_order_id_from_transaction_id( $resource->id );
+			$order    = $order_id ? edd_get_order( $order_id ) : false;
+		}
+
+		if ( ! $order instanceof Order ) {
+			throw new \Exception( 'get_order_from_capture_object() - Failed to locate order.', 200 );
+		}
+
+		/*
+		 * Verify the transaction ID. This covers us in case we fetched the order via `custom_id`, but
+		 * it wasn't actually an EDD-initiated payment.
+		 */
+		$order_transaction_id = $order->get_transaction_id();
+		if ( $order_transaction_id !== $resource->id ) {
+			throw new \Exception( sprintf(
+				'get_order_from_capture_object() - Transaction ID mismatch. Expected: %s; Actual: %s',
+				$order_transaction_id,
+				$resource->id
+			), 200 );
+		}
+
+		return $order;
+	}
+
+	/**
+	 * Retrieves an Order record from a refund event.
+	 *
+	 * @since      3.0
+	 *
+	 * @return Order
+	 * @throws API_Exception
+	 * @throws Authentication_Exception
+	 * @throws \Exception
+	 */
+	protected function get_order_from_refund() {
+		edd_debug_log( sprintf(
+			'PayPal Commerce Webhook - get_payment_from_capture_object() - Resource type: %s; Resource ID: %s',
+			$this->request->get_param( 'resource_type' ),
+			$this->event->resource->id
+		) );
+
+		if ( empty( $this->event->resource->links ) || ! is_array( $this->event->resource->links ) ) {
+			throw new \Exception( 'Missing resources.', 200 );
+		}
+
+		$order_link = current( array_filter( $this->event->resource->links, function ( $link ) {
+			return ! empty( $link->rel ) && 'up' === strtolower( $link->rel );
+		} ) );
+
+		if ( empty( $order_link->href ) ) {
+			throw new \Exception( 'Missing order link.', 200 );
+		}
+
+		// Based on the payment link, determine which mode we should act in.
+		if ( false === strpos( $order_link->href, 'sandbox.paypal.com' ) ) {
+			$mode = API::MODE_LIVE;
+		} else {
+			$mode = API::MODE_SANDBOX;
+		}
+
+		// Look up the full order record in PayPal.
+		$api      = new API( $mode );
+		$response = $api->make_request( $order_link->href, array(), array(), $order_link->method );
+
+		if ( 200 !== $api->last_response_code ) {
+			throw new API_Exception( sprintf( 'Invalid response code when retrieving order record: %d', $api->last_response_code ) );
+		}
+
+		if ( empty( $response->id ) ) {
+			throw new API_Exception( 'Missing order ID from API response.' );
+		}
+
+		return $this->get_order_from_capture_object( $response );
+	}
+
+	/**
 	 * Retrieves an EDD_Payment record from a capture event.
 	 *
-	 * @since 2.11
+	 * @since      2.11
+	 * @deprecated 3.0 In favour of `get_order_from_capture()`
+	 * @see        Webhook_Event::get_order_from_capture()
 	 *
 	 * @return \EDD_Payment
 	 * @throws \Exception
@@ -89,7 +205,9 @@ abstract class Webhook_Event {
 	 *
 	 * @param object $resource
 	 *
-	 * @since 2.11
+	 * @since      2.11
+	 * @deprecated 3.0 In favour of `get_order_from_capture_object()`
+	 * @see        Webhook_Event::get_order_from_capture_object
 	 *
 	 * @return \EDD_Payment
 	 * @throws \Exception
@@ -124,7 +242,9 @@ abstract class Webhook_Event {
 	/**
 	 * Retrieves an EDD_Payment record from a refund event.
 	 *
-	 * @since 2.11
+	 * @since      2.11
+	 * @deprecated 3.0 In favour of `get_order_from_refund`
+	 * @see        Webhook_Event::get_order_from_refund
 	 *
 	 * @return \EDD_Payment
 	 * @throws API_Exception
@@ -132,7 +252,7 @@ abstract class Webhook_Event {
 	 * @throws \Exception
 	 */
 	protected function get_payment_from_refund() {
-		edd_debug_log( sprintf( 'PayPal Commerce Webhook - get_payment_from_resource_link() - Resource type: %s; Resource ID: %s', $this->request->get_param( 'resource_type' ), $this->event->resource->id ) );
+		edd_debug_log( sprintf( 'PayPal Commerce Webhook - get_payment_from_refund() - Resource type: %s; Resource ID: %s', $this->request->get_param( 'resource_type' ), $this->event->resource->id ) );
 
 		if ( empty( $this->event->resource->links ) || ! is_array( $this->event->resource->links ) ) {
 			throw new \Exception( 'Missing resources.', 200 );

--- a/includes/gateways/paypal/webhooks/events/class-payment-capture-completed.php
+++ b/includes/gateways/paypal/webhooks/events/class-payment-capture-completed.php
@@ -11,23 +11,26 @@
 
 namespace EDD\Gateways\PayPal\Webhooks\Events;
 
+use EDD\Gateways\PayPal\Exceptions\API_Exception;
+use EDD\Gateways\PayPal\Exceptions\Authentication_Exception;
+
 class Payment_Capture_Completed extends Webhook_Event {
 
 	/**
 	 * Processes the event.
 	 *
-	 * @throws \EDD\Gateways\PayPal\Exceptions\API_Exception
-	 * @throws \EDD\Gateways\PayPal\Exceptions\Authentication_Exception
+	 * @throws API_Exception
+	 * @throws Authentication_Exception
 	 * @throws \Exception
 	 *
 	 * @since 2.11
 	 */
 	protected function process_event() {
-		$payment = $this->get_payment_from_capture();
+		$order = $this->get_order_from_capture();
 
 		// Bail if the payment has already been completed.
-		if ( in_array( $payment->status, array( 'publish', 'complete' ) ) ) {
-			edd_debug_log( 'PayPal Commerce - Exiting webhook, as payment is already complete.' );
+		if ( 'complete' === $order->status ) {
+			edd_debug_log( 'PayPal Commerce - Exiting webhook, as order is already complete.' );
 
 			return;
 		}
@@ -40,14 +43,14 @@ class Payment_Capture_Completed extends Webhook_Event {
 			throw new \Exception( 'Missing amount value.', 200 );
 		}
 
-		if ( ! isset( $this->event->resource->amount->currency_code ) || strtoupper( $this->event->resource->amount->currency_code ) !== strtoupper( $payment->currency ) ) {
-			throw new \Exception( sprintf( 'Missing or invalid currency code. Expected: %s; PayPal: %s', $payment->currency, esc_html( $this->event->resource->amount->currency_code ) ), 200 );
+		if ( ! isset( $this->event->resource->amount->currency_code ) || strtoupper( $this->event->resource->amount->currency_code ) !== strtoupper( $order->currency ) ) {
+			throw new \Exception( sprintf( 'Missing or invalid currency code. Expected: %s; PayPal: %s', $order->currency, esc_html( $this->event->resource->amount->currency_code ) ), 200 );
 		}
 
-		$paypal_amount  = (float) $this->event->resource->amount->value;
-		$payment_amount = edd_get_payment_amount( $payment->ID );
+		$paypal_amount = (float) $this->event->resource->amount->value;
+		$order_amount  = edd_get_payment_amount( $order->id );
 
-		if ( $paypal_amount < $payment_amount ) {
+		if ( $paypal_amount < $order_amount ) {
 			edd_record_gateway_error(
 				__( 'Webhook Error', 'easy-digital-downloads' ),
 				sprintf(
@@ -57,16 +60,20 @@ class Payment_Capture_Completed extends Webhook_Event {
 				)
 			);
 
-			edd_update_payment_status( $payment->ID, 'failed' );
-			edd_insert_payment_note( $payment->ID, sprintf(
-				__( 'Payment failed due to invalid amount in PayPal webhook. Expected amount: %s; PayPal amount: %s.', 'easy-digital-downloads' ),
-				$payment_amount,
-				esc_html( $paypal_amount )
+			edd_update_order_status( $order->id, 'failed' );
+			edd_add_note( array(
+				'object_type' => 'order',
+				'object_id'   => $order->id,
+				'content'     => sprintf(
+					__( 'Payment failed due to invalid amount in PayPal webhook. Expected amount: %s; PayPal amount: %s.', 'easy-digital-downloads' ),
+					$order_amount,
+					esc_html( $paypal_amount )
+				)
 			) );
 
-			throw new \Exception( sprintf( 'Webhook amount (%s) doesn\'t match payment amount (%s).', esc_html( $paypal_amount ), esc_html( $payment_amount ) ), 200 );
+			throw new \Exception( sprintf( 'Webhook amount (%s) doesn\'t match payment amount (%s).', esc_html( $paypal_amount ), esc_html( $order_amount ) ), 200 );
 		}
 
-		edd_update_payment_status( $payment->ID, 'complete' );
+		edd_update_order_status( $order->id, 'complete' );
 	}
 }

--- a/includes/gateways/paypal/webhooks/events/class-payment-capture-denied.php
+++ b/includes/gateways/paypal/webhooks/events/class-payment-capture-denied.php
@@ -21,10 +21,14 @@ class Payment_Capture_Denied extends Webhook_Event {
 	 * @throws \Exception
 	 */
 	protected function process_event() {
-		$payment = $this->get_payment_from_capture();
+		$order = $this->get_order_from_capture();
 
-		edd_update_payment_status( $payment->ID, 'failed' );
+		edd_update_order_status( $order->id, 'failed' );
 
-		$payment->add_note( __( 'PayPal transaction denied.', 'easy-digital-downloads' ) );
+		edd_add_note( array(
+			'object_type' => 'order',
+			'object_id'   => $order->id,
+			'content'     => __( 'PayPal transaction denied.', 'easy-digital-downloads' ),
+		) );
 	}
 }

--- a/includes/gateways/paypal/webhooks/events/class-payment-capture-refunded.php
+++ b/includes/gateways/paypal/webhooks/events/class-payment-capture-refunded.php
@@ -28,33 +28,41 @@ class Payment_Capture_Refunded extends Webhook_Event {
 	 * @since 2.11
 	 */
 	protected function process_event() {
-		$payment = $this->get_payment_from_refund();
+		$order = $this->get_order_from_refund();
 
-		if ( 'refunded' === $payment->status ) {
+		if ( 'refunded' === $order->status ) {
 			edd_debug_log( 'PayPal Commerce - Exiting webhook, as payment status is already refunded.' );
 
 			return;
 		}
 
-		$payment_amount  = edd_get_payment_amount( $payment->ID );
-		$refunded_amount = isset( $this->event->resource->amount->value ) ? $this->event->resource->amount->value : $payment_amount;
-		$currency        = isset( $this->event->resource->amount->currency_code ) ? $this->event->resource->amount->currency_code : $payment->currency;
+		$order_amount    = edd_get_payment_amount( $order->id );
+		$refunded_amount = isset( $this->event->resource->amount->value ) ? $this->event->resource->amount->value : $order_amount;
+		$currency        = isset( $this->event->resource->amount->currency_code ) ? $this->event->resource->amount->currency_code : $order->currency;
 
 		/* Translators: %1$s - Amount refunded; %2$s - Original payment ID; %3$s - Refund transaction ID */
 		$payment_note = sprintf(
 			esc_html__( 'Amount: %1$s; Payment transaction ID: %2$s; Refund transaction ID: %3$s', 'easy-digital-downloads' ),
 			edd_currency_filter( edd_format_amount( $refunded_amount ), $currency ),
-			esc_html( $payment->transaction_id ),
+			esc_html( $order->get_transaction_id() ),
 			esc_html( $this->event->resource->id )
 		);
 
 		// Partial refund.
-		if ( (float) $refunded_amount < (float) $payment_amount ) {
-			edd_insert_payment_note( $payment->ID, esc_html__( 'Partial refund processed in PayPal.', 'easy-digital-downloads' ) . ' ' . $payment_note );
+		if ( (float) $refunded_amount < (float) $order_amount ) {
+			edd_add_note( array(
+				'object_type' => 'order',
+				'object_id'   => $order->id,
+				'content'     => __( 'Partial refund processed in PayPal.', 'easy-digital-downloads' ) . ' ' . $payment_note,
+			) );
 		} else {
 			// Full refund.
-			edd_insert_payment_note( $payment->ID, esc_html__( 'Full refund processed in PayPal.', 'easy-digital-downloads' ) . ' ' . $payment_note );
-			edd_update_payment_status( $payment->ID, 'refunded' );
+			edd_add_note( array(
+				'object_type' => 'order',
+				'object_id'   => $order->id,
+				'content'     => __( 'Full refund processed in PayPal.', 'easy-digital-downloads' ) . ' ' . $payment_note,
+			) );
+			edd_update_order_status( $order->id, 'refunded' );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8874

Proposed Changes:
1. Deprecate `get_payment_from_capture` methods. I'm not triggering an actual deprecation notice for now, just marking them as deprecated in the docblocks.
2. Implement replacement `get_order_from_capture` methods. Same logic, but returning an `Order` object.
3. Update webhooks to use `Order` objects / methods.
4. Update unit tests to use `Order` objects.