### PR TITLE
Update discount metadata checks to empty instead of isset

### DIFF
--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -52,7 +52,7 @@ function edd_add_discount( $data = array() ) {
 	if ( ! empty( $discount_id ) ) {
 
 		// Product requirements.
-		if ( ! is_null( $product_requirements ) ) {
+		if ( ! empty( $product_requirements ) ) {
 			if ( is_string( $product_requirements ) ) {
 				$product_requirements = maybe_unserialize( $product_requirements );
 			}
@@ -65,7 +65,7 @@ function edd_add_discount( $data = array() ) {
 		}
 
 		// Excluded products.
-		if ( ! is_null( $excluded_products ) ) {
+		if ( ! empty( $excluded_products ) ) {
 			if ( is_string( $excluded_products ) ) {
 				$excluded_products = maybe_unserialize( $excluded_products );
 			}
@@ -77,7 +77,7 @@ function edd_add_discount( $data = array() ) {
 			}
 		}
 
-		if ( ! is_null( $product_condition ) ) {
+		if ( ! empty( $product_condition ) ) {
 			edd_add_adjustment_meta( $discount_id, 'product_condition', $product_condition );
 		}
 

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -26,9 +26,9 @@ defined( 'ABSPATH' ) || exit;
 function edd_add_discount( $data = array() ) {
 
 	// Juggle requirements and products.
-	$product_requirements = isset( $data['product_reqs'] )      ? $data['product_reqs']      : null;
-	$excluded_products    = isset( $data['excluded_products'] ) ? $data['excluded_products'] : null;
-	$product_condition    = isset( $data['product_condition'] ) ? $data['product_condition'] : null;
+	$product_requirements = ! empty( $data['product_reqs'] ) ? $data['product_reqs'] : null;
+	$excluded_products    = ! empty( $data['excluded_products'] ) ? $data['excluded_products'] : null;
+	$product_condition    = ! empty( $data['product_condition'] ) ? $data['product_condition'] : null;
 	$pre_convert_args     = $data;
 	unset( $data['product_reqs'], $data['excluded_products'], $data['product_condition'] );
 

--- a/includes/discount-functions.php
+++ b/includes/discount-functions.php
@@ -26,9 +26,9 @@ defined( 'ABSPATH' ) || exit;
 function edd_add_discount( $data = array() ) {
 
 	// Juggle requirements and products.
-	$product_requirements = ! empty( $data['product_reqs'] ) ? $data['product_reqs'] : null;
-	$excluded_products    = ! empty( $data['excluded_products'] ) ? $data['excluded_products'] : null;
-	$product_condition    = ! empty( $data['product_condition'] ) ? $data['product_condition'] : null;
+	$product_requirements = isset( $data['product_reqs'] )      ? $data['product_reqs']      : null;
+	$excluded_products    = isset( $data['excluded_products'] ) ? $data['excluded_products'] : null;
+	$product_condition    = isset( $data['product_condition'] ) ? $data['product_condition'] : null;
 	$pre_convert_args     = $data;
 	unset( $data['product_reqs'], $data['excluded_products'], $data['product_condition'] );
 


### PR DESCRIPTION
Fixes #8885

Proposed Changes:
1. This changes the checks for the product condition, product requirements, and excluded products metadata to be an `empty` check instead of `isset`, to prevent empty metadata rows being saved to the new database tables during migration.

Additionally this will impact any use of `edd_store_discount` and `edd_add_discount`.

In the database I'm migrating, the existing discount posts had this data saved as empty post meta rows.