### PR TITLE
Sync the purchase shortcode with the purchase button

### DIFF
--- a/includes/admin/downloads/metabox.php
+++ b/includes/admin/downloads/metabox.php
@@ -1044,11 +1044,18 @@ function edd_render_meta_box_shortcode() {
 		return;
 	}
 
-	$purchase_text = edd_get_option( 'add_to_cart_text', __( 'Purchase', 'easy-digital-downloads' ) );
+	$behavior      = get_post_meta( $post->ID, '_edd_button_behavior', true );
+	if ( 'direct' == $behavior ) {
+		$purchase_text = edd_get_option( 'buy_now_text', __( 'Buy Now', 'easy-digital-downloads' ) );
+		$behavior      = ' direct=true';
+	} else {
+		$purchase_text = edd_get_option( 'add_to_cart_text', __( 'Purchase', 'easy-digital-downloads' ) );
+		$behavior      = '';
+	}
 	$style         = edd_get_option( 'button_style', 'button' );
 	$color         = edd_get_option( 'checkout_color', 'blue' );
 	$color         = ( $color == 'inherit' ) ? '' : $color;
-	$shortcode     = '[purchase_link id="' . absint( $post->ID ) . '" text="' . esc_html( $purchase_text ) . '" style="' . $style . '" color="' . esc_attr( $color ) . '"]';
+	$shortcode     = '[purchase_link id="' . absint( $post->ID ) . '" text="' . esc_html( $purchase_text ) . '" style="' . $style . '" color="' . esc_attr( $color ) . $behavior . '"]';
 ?>
 	<p>
 		<strong><?php _e( 'Purchase Shortcode:', 'easy-digital-downloads' ); ?></strong>


### PR DESCRIPTION
The purchase shortcode showing on the download admin page doesn't synchronize with the purchase button. 
If the shortcode synchronizes with the purchase button, it's useful for users who want to use the buy now button shortcode.

Proposed Changes:
1. Get the status of the purchase button
2. Declare the variables for the button text and the button behavior
3. Add the button behavior to the shortcode
<img width="1018" alt="pr_edd_shortcode" src="https://user-images.githubusercontent.com/1398164/134833672-30ed04ac-4918-411d-895b-c22bea4a4436.png">

