### PR TITLE
Switch from edd_die() to die() on API responses #8250

### DIFF
--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1917,7 +1917,7 @@ class EDD_API {
 
 		do_action( 'edd_api_output_after', $this->data, $this, $format );
 
-		edd_die();
+		die();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #8250 

Proposed Changes:
1. Switch `edd_die` to `die` after outputting API Data.

This will avoid the `edd_die` from calling `wp_die` which is where the output from Query Monitor comes in.