### PR TITLE
Update post meta 'status' as well as post_status

### DIFF
--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -1917,7 +1917,11 @@ class EDD_API {
 
 		do_action( 'edd_api_output_after', $this->data, $this, $format );
 
-		die();
+		if ( defined( 'EDD_DOING_TESTS' ) && EDD_DOING_TESTS ) {
+			edd_die();
+		} else {
+			die();
+		}
 	}
 
 	/**

--- a/includes/class-edd-discount.php
+++ b/includes/class-edd-discount.php
@@ -1421,6 +1421,7 @@ class EDD_Discount {
 		do_action( 'edd_post_update_discount_status', $this->ID, $new_status, $this->post_status );
 
 		if ( $id == $this->ID ) {
+			$this->update_meta( 'status', $new_status );
 			return true;
 		}
 

--- a/tests/tests-discounts.php
+++ b/tests/tests-discounts.php
@@ -71,12 +71,14 @@ class Tests_Discounts extends EDD_UnitTestCase {
 		$this->assertInternalType( 'int', $updated_post_id );
 	}
 
-	public function test_discount_status_update() {
+	public function test_discount_status_update_inactive() {
 		$this->assertTrue( edd_update_discount_status( $this->_post_id, 'inactive' ) );
-		$this->assertEquals( 'inactive', get_post_meta( $this->_post_id, 'status' ) );
+		$discount = edd_get_discount( $this->_post_id );
+		$this->assertEquals( 'inactive', $discount->status );
 
 		$this->assertTrue( edd_update_discount_status( $this->_post_id, 'active' ) );
-		$this->assertEquals( 'active', get_post_meta( $this->_post_id, 'status' ) );
+		$discount = edd_get_discount( $this->_post_id );
+		$this->assertEquals( 'active', $discount->status );
 	}
 
 	public function test_discount_status_update_fail() {

--- a/tests/tests-discounts.php
+++ b/tests/tests-discounts.php
@@ -72,7 +72,11 @@ class Tests_Discounts extends EDD_UnitTestCase {
 	}
 
 	public function test_discount_status_update() {
+		$this->assertTrue( edd_update_discount_status( $this->_post_id, 'inactive' ) );
+		$this->assertEquals( 'inactive', get_post_meta( $this->_post_id, 'status' ) );
+
 		$this->assertTrue( edd_update_discount_status( $this->_post_id, 'active' ) );
+		$this->assertEquals( 'active', get_post_meta( $this->_post_id, 'status' ) );
 	}
 
 	public function test_discount_status_update_fail() {


### PR DESCRIPTION
Fixes #8908

Proposed Changes:
1. Once verified that we updated the correct post ID, we update the meta as well.