### PR TITLE
Adjust system info output to make plugins list more readable

### DIFF
--- a/includes/admin/tools.php
+++ b/includes/admin/tools.php
@@ -1386,9 +1386,9 @@ function edd_tools_sysinfo_get() {
 			$plugin_url = $plugin['Author'];
 		}
 		if ( $plugin_url ) {
-			$plugin_url = ' &mdash; ' . $plugin_url;
+			$plugin_url = "\n" . $plugin_url;
 		}
-		$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . $plugin_url . "\n";
+		$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . $plugin_url . "\n\n";
 	}
 
 	$return  = apply_filters( 'edd_sysinfo_after_wordpress_plugins', $return );
@@ -1410,9 +1410,9 @@ function edd_tools_sysinfo_get() {
 			$plugin_url = $plugin['Author'];
 		}
 		if ( $plugin_url ) {
-			$plugin_url = ' &mdash; ' . $plugin_url;
+			$plugin_url = "\n" . $plugin_url;
 		}
-		$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . $plugin_url . "\n";
+		$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . $plugin_url . "\n\n";
 	}
 
 	$return  = apply_filters( 'edd_sysinfo_after_wordpress_plugins_inactive', $return );
@@ -1441,9 +1441,9 @@ function edd_tools_sysinfo_get() {
 				$plugin_url = $plugin['Author'];
 			}
 			if ( $plugin_url ) {
-				$plugin_url = ' &mdash; ' . $plugin_url;
+				$plugin_url = "\n" . $plugin_url;
 			}
-			$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . $plugin_url . "\n";
+			$return .= $plugin['Name'] . ': ' . $plugin['Version'] . $update . $plugin_url . "\n\n";
 		}
 
 		$return  = apply_filters( 'edd_sysinfo_after_wordpress_ms_plugins', $return );


### PR DESCRIPTION
Fixes #8914

Proposed Changes:
1. In the system info output, if a plugin URI (or equivalent) is retrieved for a plugin, add it to the output as a new line.
2. Add an empty line between each plugin in the output.

Milestoning for 2.11.3 as I think this is a lot easier to read and it sounds like our support team would all find it helpful.