### PR TITLE
Check if post_data exists before using & move outside foreach #8918

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -213,13 +213,17 @@ function edd_ajax_add_to_cart() {
 
 	$items = '';
 
+	if ( isset( $_POST['post_data'] ) ) {
+		parse_str( $_POST['post_data'], $post_data );
+	} else {
+		$post_data = array();
+	}
+
 	foreach ( $to_add as $options ) {
 
 		if( $_POST['download_id'] == $options['price_id'] ) {
 			$options = array();
 		}
-
-		parse_str( $_POST['post_data'], $post_data );
 
 		if( isset( $options['price_id'] ) && isset( $post_data['edd_download_quantity_' . $options['price_id'] ] ) ) {
 


### PR DESCRIPTION
Fixes #8918

Proposed Changes:
1. Check if `$_POST['post_data']` exists before using. If it doesn't, set `$post_data` to an empty array.
2. Moves the logic outside the `foreach()` as we only actually need to run this once -- not every time for each item in `$to_add`.