### PR TITLE
Check if hour by hour first & check array key exists #8770

### DIFF
--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -2241,17 +2241,17 @@ function edd_register_discounts_report( $reports ) {
 								'orderby' => 'YEAR(edd_oa.date_created), MONTH(edd_oa.date_created), DAY(edd_oa.date_created)',
 							);
 
-							if ( ! $day_by_day ) {
-								$sql_clauses = array(
-									'select'  => 'YEAR(edd_oa.date_created) AS year, MONTH(edd_oa.date_created) AS month',
-									'groupby' => 'YEAR(edd_oa.date_created), MONTH(edd_oa.date_created)',
-									'orderby' => 'YEAR(edd_oa.date_created), MONTH(edd_oa.date_created)',
-								);
-							} elseif ( $hour_by_hour ) {
+							if ( $hour_by_hour ) {
 								$sql_clauses = array(
 									'select'  => 'YEAR(edd_oa.date_created) AS year, MONTH(edd_oa.date_created) AS month, DAY(edd_oa.date_created) AS day, HOUR(edd_oa.date_created) AS hour',
 									'groupby' => 'YEAR(edd_oa.date_created), MONTH(edd_oa.date_created), DAY(edd_oa.date_created), HOUR(edd_oa.date_created)',
 									'orderby' => 'YEAR(edd_oa.date_created), MONTH(edd_oa.date_created), DAY(edd_oa.date_created), HOUR(edd_oa.date_created)',
+								);
+							} elseif ( ! $day_by_day ) {
+								$sql_clauses = array(
+									'select'  => 'YEAR(edd_oa.date_created) AS year, MONTH(edd_oa.date_created) AS month',
+									'groupby' => 'YEAR(edd_oa.date_created), MONTH(edd_oa.date_created)',
+									'orderby' => 'YEAR(edd_oa.date_created), MONTH(edd_oa.date_created)',
 								);
 							}
 
@@ -2310,7 +2310,9 @@ function edd_register_discounts_report( $reports ) {
 									$timestamp = \Carbon\Carbon::create( $result->year, $result->month, $day, 0, 0, 0, 'UTC' )->setTimezone( edd_get_timezone_id() )->timestamp;
 								}
 
-								$discount_usage[ $timestamp ][1] += $result->total;
+								if ( array_key_exists( $timestamp, $discount_usage ) ) {
+									$discount_usage[ $timestamp ][1] += $result->total;
+								}
 							}
 
 							$discount_usage = array_values( $discount_usage );


### PR DESCRIPTION
Fixes #8770

Proposed Changes:
1. Reverse the conditional so we check `$hour_by_hour` first (because if it is hour by hour, then it's not day by day..).
2. Check if the timestamp array key exists before setting the value. This caused a problem I was running into where the SQL query was returning more results than the date range specified. (Query was returning results from today, but the original "set up the defaults" loop stopped on October 18th. I didn't dig too far into why this was happening, as that felt like separate issue territory. I just fixed the PHP notice.)