### PR TITLE
Update edd_has_purchases to check if user ID is empty

### DIFF
--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -249,6 +249,10 @@ function edd_has_purchases( $user_id = null ) {
 		$user_id = get_current_user_id();
 	}
 
+	if ( empty( $user_id ) ) {
+		return false;
+	}
+
 	$count = edd_count_orders( array( 'user_id' => $user_id ) );
 
 	return (bool) $count;

--- a/tests/customers/tests-customers.php
+++ b/tests/customers/tests-customers.php
@@ -214,6 +214,20 @@ class Tests_Customers extends \EDD_UnitTestCase {
 		$this->assertFalse( edd_get_users_purchases( 0 ) );
 	}
 
+	public function test_user_has_purchases_not_logged_in_should_return_false() {
+		$current_user = get_current_user_id();
+		wp_set_current_user( 0 );
+		edd_update_order(
+			self::$order,
+			array(
+				'user_id' => 0,
+			)
+		);
+
+		$this->assertFalse( edd_has_purchases() );
+		wp_set_current_user( $current_user );
+	}
+
 	public function test_user_has_purchases_should_return_true() {
 		self::$customers[0]->attach_payment( self::$order );
 


### PR DESCRIPTION
Fixes #9264

Proposed Changes:
1. Adds a check if the retrieved user ID is empty (if a user is not logged in, it will be `0`), and returns false if it is.
2. Adds a unit test for same.

Note: I commented out the early return and ran the new test locally and it failed (just wanted to check).