### PR TITLE
Improved hourly graphs in reporting for custom daterange

### DIFF
--- a/includes/admin/reporting/reports-callbacks.php
+++ b/includes/admin/reporting/reports-callbacks.php
@@ -47,12 +47,12 @@ function edd_overview_sales_earnings_chart() {
 	$sql_clauses['orderby'] = 'MONTH(date_created)';
 
 	// Now drill down to the smallest unit.
-	if ( $day_by_day ) {
-		$sql_clauses['groupby'] = Reports\get_groupby_date_string( 'DATE', 'date_created' );
-		$sql_clauses['orderby'] = 'DATE(date_created)';
-	} elseif ( $hour_by_hour ) {
+	if ( $hour_by_hour ) {
 		$sql_clauses['groupby'] = Reports\get_groupby_date_string( 'HOUR', 'date_created' );
 		$sql_clauses['orderby'] = 'HOUR(date_created)';
+	} elseif ( $day_by_day ) {
+		$sql_clauses['groupby'] = Reports\get_groupby_date_string( 'DATE', 'date_created' );
+		$sql_clauses['orderby'] = 'DATE(date_created)';
 	}
 
 	if ( ! empty( $currency ) && array_key_exists( strtoupper( $currency ), edd_get_currencies() ) ) {
@@ -219,12 +219,12 @@ function edd_overview_refunds_chart() {
 	$sql_clauses['orderby'] = 'MONTH(date_created)';
 
 	// Now drill down to the smallest unit.
-	if ( $day_by_day ) {
-		$sql_clauses['groupby'] = Reports\get_groupby_date_string( 'DATE', 'date_created' );
-		$sql_clauses['orderby'] = 'DATE(date_created)';
-	} elseif ( $hour_by_hour ) {
+	if ( $hour_by_hour ) {
 		$sql_clauses['groupby'] = Reports\get_groupby_date_string( 'HOUR', 'date_created' );
 		$sql_clauses['orderby'] = 'HOUR(date_created)';
+	} elseif ( $day_by_day ) {
+		$sql_clauses['groupby'] = Reports\get_groupby_date_string( 'DATE', 'date_created' );
+		$sql_clauses['orderby'] = 'DATE(date_created)';
 	}
 
 	if ( empty( $currency ) || 'convert' === $currency ) {

--- a/includes/admin/reporting/reports.php
+++ b/includes/admin/reporting/reports.php
@@ -701,17 +701,17 @@ function edd_register_downloads_report( $reports ) {
 							'orderby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created)',
 						);
 
-						if ( ! $day_by_day ) {
-							$sql_clauses = array(
-								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month',
-								'groupby' => 'YEAR(date_created), MONTH(date_created)',
-								'orderby' => 'YEAR(date_created), MONTH(date_created)',
-							);
-						} elseif ( $hour_by_hour ) {
+						if ( $hour_by_hour ) {
 							$sql_clauses = array(
 								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month, DAY(date_created) AS day, HOUR(date_created) AS hour',
 								'groupby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created), HOUR(date_created)',
 								'orderby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created), HOUR(date_created)',
+							);
+						} elseif ( ! $day_by_day ) {
+							$sql_clauses = array(
+								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month',
+								'groupby' => 'YEAR(date_created), MONTH(date_created)',
+								'orderby' => 'YEAR(date_created), MONTH(date_created)',
 							);
 						}
 
@@ -1355,17 +1355,17 @@ function edd_register_payment_gateways_report( $reports ) {
 							'orderby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created)',
 						);
 
-						if ( ! $day_by_day ) {
-							$sql_clauses = array(
-								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month',
-								'groupby' => 'YEAR(date_created), MONTH(date_created)',
-								'orderby' => 'YEAR(date_created), MONTH(date_created)',
-							);
-						} elseif ( $hour_by_hour ) {
+						if ( $hour_by_hour ) {
 							$sql_clauses = array(
 								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month, DAY(date_created) AS day, HOUR(date_created) AS hour',
 								'groupby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created), HOUR(date_created)',
 								'orderby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created), HOUR(date_created)',
+							);
+						} elseif ( ! $day_by_day ) {
+							$sql_clauses = array(
+								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month',
+								'groupby' => 'YEAR(date_created), MONTH(date_created)',
+								'orderby' => 'YEAR(date_created), MONTH(date_created)',
 							);
 						}
 
@@ -1818,12 +1818,12 @@ function edd_register_file_downloads_report( $reports ) {
 						$sql_clauses['orderby'] = 'MONTH(date_created)';
 
 						// Now drill down to the smallest unit.
-						if ( $day_by_day ) {
-							$sql_clauses['groupby'] = 'DATE(date_created)';
-							$sql_clauses['orderby'] = 'DATE(date_created)';
-						} elseif ( $hour_by_hour ) {
+						if ( $hour_by_hour ) {
 							$sql_clauses['groupby'] = 'HOUR(date_created)';
 							$sql_clauses['orderby'] = 'HOUR(date_created)';
+						} elseif ( $day_by_day ) {
+							$sql_clauses['groupby'] = 'DATE(date_created)';
+							$sql_clauses['orderby'] = 'DATE(date_created)';
 						}
 
 						$product_id = '';
@@ -2371,17 +2371,17 @@ function edd_register_customer_report( $reports ) {
 							'orderby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created)',
 						);
 
-						if ( ! $day_by_day ) {
-							$sql_clauses = array(
-								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month',
-								'groupby' => 'YEAR(date_created), MONTH(date_created)',
-								'orderby' => 'YEAR(date_created), MONTH(date_created)',
-							);
-						} elseif ( $hour_by_hour ) {
+						if ( $hour_by_hour ) {
 							$sql_clauses = array(
 								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month, DAY(date_created) AS day, HOUR(date_created) AS hour',
 								'groupby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created), HOUR(date_created)',
 								'orderby' => 'YEAR(date_created), MONTH(date_created), DAY(date_created), HOUR(date_created)',
+							);
+						} elseif ( ! $day_by_day ) {
+							$sql_clauses = array(
+								'select'  => 'YEAR(date_created) AS year, MONTH(date_created) AS month',
+								'groupby' => 'YEAR(date_created), MONTH(date_created)',
+								'orderby' => 'YEAR(date_created), MONTH(date_created)',
 							);
 						}
 

--- a/includes/reports/data/charts/v2/class-manifest.php
+++ b/includes/reports/data/charts/v2/class-manifest.php
@@ -356,10 +356,10 @@ class Manifest implements Error_Logger {
 
 		$time_format = 'MMM YYYY';
 
-		if ( $day_by_day ) {
-			$time_format = 'MMM D';
-		} else if ( $hour_by_hour ) {
+		if ( $hour_by_hour ) {
 			$time_format = 'hA';
+		} else if ( $day_by_day ) {
+			$time_format = 'MMM D';
 		}
 
 		$config->type         = $this->get_type();
@@ -433,12 +433,12 @@ class Manifest implements Error_Logger {
 			$time_unit = 'month';
 			$time_format = 'MMM YYYY';
 
-			if ( $day_by_day ) {
-				$time_unit   = 'day';
-				$time_format = 'MMM D';
-			} else if ( $hour_by_hour ) {
+			if ( $hour_by_hour ) {
 				$time_unit   = 'hour';
 				$time_format = 'hA';
+			} else if ( $day_by_day ) {
+				$time_unit   = 'day';
+				$time_format = 'MMM D';
 			}
 
 			$defaults = array(

--- a/includes/reports/reports-functions.php
+++ b/includes/reports/reports-functions.php
@@ -739,6 +739,12 @@ function get_dates_filter_hour_by_hour() {
 		case 'yesterday':
 			$hour_by_hour = true;
 			break;
+		case 'other':
+			$difference = ( $dates['end']->getTimestamp() - $dates['start']->getTimestamp() );
+			if ( $difference <= ( DAY_IN_SECONDS * 2 ) ) {
+				$hour_by_hour = true;
+			}
+			break;
 		default:
 			$hour_by_hour = false;
 			break;


### PR DESCRIPTION
Fixes #9263

For custom date range mode in reporting, if the request date range is not more than two days, we should switch to hourly graphs.

Proposed Changes:
- Added custom date range logic inside `get_dates_filter_hour_by_hour()` method to calculate if the requested date range is not more than two days
- Improved graph rendering logic, since it was reversed -`hour by hour` check should always be first, followed by `day by day` check 