### PR TITLE
Added support for bundle products in history downloads shortcode

### DIFF
--- a/includes/orders/classes/class-order.php
+++ b/includes/orders/classes/class-order.php
@@ -363,7 +363,7 @@ class Order extends Rows\Order {
 	 *
 	 * @return Order_Item[] Order items.
 	 */
-	public function get_deliverable_items() {
+	public function get_items_with_bundles() {
 		$items = $this->get_items();
 		foreach ( $items as $index => $item ) {
 			if ( edd_is_bundled_product( $item->product_id ) ) {

--- a/templates/history-downloads.php
+++ b/templates/history-downloads.php
@@ -49,7 +49,7 @@ if ( $orders ) :
 		</thead>
 		<?php
 		foreach ( $orders as $order ) :
-			foreach ( $order->get_deliverable_items() as $key => $item ) :
+			foreach ( $order->get_items_with_bundles() as $key => $item ) :
 				?>
 
 				<tr class="edd_download_history_row">


### PR DESCRIPTION
Fixes #9288

Proposed Changes:
-  Introduced new method to `class-order.php` to retrieve bundled products as ordinary order items, so that we can correctly show bundled downloads inside `[download_history]` shortcode without breaking the layout or removing old actions.
